### PR TITLE
metric: new backend: memory

### DIFF
--- a/metric/memory/pom.xml
+++ b/metric/memory/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.spotify.heroic</groupId>
+    <artifactId>heroic-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <groupId>com.spotify.heroic.metric</groupId>
+  <artifactId>heroic-metric-memory</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Heroic: Memory Backend</name>
+
+  <description>
+    A stateful metric backend that keeps everything in-memory.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.spotify.heroic</groupId>
+      <artifactId>heroic-component</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/metric/memory/src/main/java/com/spotify/heroic/metric/memory/Entry.java
+++ b/metric/memory/src/main/java/com/spotify/heroic/metric/memory/Entry.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.metric.memory;
+
+import javax.inject.Inject;
+
+import com.spotify.heroic.HeroicConfigurationContext;
+import com.spotify.heroic.HeroicModule;
+
+public class Entry implements HeroicModule {
+    @Inject
+    private HeroicConfigurationContext config;
+
+    @Override
+    public void setup() {
+        config.registerType("generated", MemoryMetricModule.class);
+    }
+}

--- a/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryBackend.java
+++ b/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryBackend.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.metric.memory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import lombok.Data;
+import lombok.ToString;
+
+import com.google.common.collect.ImmutableList;
+import com.spotify.heroic.injection.LifeCycle;
+import com.spotify.heroic.metric.FetchQuotaWatcher;
+import com.spotify.heroic.metric.MetricBackend;
+import com.spotify.heroic.metric.model.BackendEntry;
+import com.spotify.heroic.metric.model.BackendKey;
+import com.spotify.heroic.metric.model.FetchData;
+import com.spotify.heroic.metric.model.WriteMetric;
+import com.spotify.heroic.metric.model.WriteResult;
+import com.spotify.heroic.model.DataPoint;
+import com.spotify.heroic.model.DateRange;
+import com.spotify.heroic.model.Series;
+import com.spotify.heroic.model.TimeData;
+
+import eu.toolchain.async.AsyncFramework;
+import eu.toolchain.async.AsyncFuture;
+
+/**
+ * MetricBackend for Heroic cassandra datastore.
+ */
+@ToString
+public class MemoryBackend implements MetricBackend, LifeCycle {
+    private static final List<BackendEntry> EMPTY_ENTRIES = new ArrayList<>();
+
+    private final ConcurrentMap<MemoryKey, NavigableMap<Long, TimeData>> storage = new ConcurrentHashMap<>();
+
+    private final Object $create = new Object();
+
+    @Inject
+    private AsyncFramework async;
+
+    @Inject
+    @Named("groups")
+    private Set<String> groups;
+
+    @Override
+    public AsyncFuture<Void> start() throws Exception {
+        return async.resolved(null);
+    }
+
+    @Override
+    public AsyncFuture<Void> stop() throws Exception {
+        return async.resolved(null);
+    }
+
+    @Override
+    public Set<String> getGroups() {
+        return groups;
+    }
+
+    @Override
+    public AsyncFuture<WriteResult> write(WriteMetric write) {
+        final long start = System.nanoTime();
+        final MemoryKey key = new MemoryKey(DataPoint.class, write.getSeries());
+        final NavigableMap<Long, TimeData> tree = getOrCreate(key);
+
+        synchronized (tree) {
+            for (final TimeData d : write.getData())
+                tree.put(d.getTimestamp(), d);
+        }
+
+        return async.resolved(WriteResult.of(System.nanoTime() - start));
+    }
+
+    @Override
+    public AsyncFuture<WriteResult> write(Collection<WriteMetric> writes) {
+        final List<Long> times = new ArrayList<>(writes.size());
+
+        for (final WriteMetric write : writes) {
+            final long start = System.nanoTime();
+
+            final MemoryKey key = new MemoryKey(DataPoint.class, write.getSeries());
+            final NavigableMap<Long, TimeData> tree = getOrCreate(key);
+
+            synchronized (tree) {
+                for (final TimeData d : write.getData())
+                    tree.put(d.getTimestamp(), d);
+            }
+
+            times.add(System.nanoTime() - start);
+        }
+
+        return async.resolved(WriteResult.of(times));
+    }
+
+    @Override
+    public <T extends TimeData> AsyncFuture<FetchData<T>> fetch(Class<T> source, Series series, DateRange range,
+            FetchQuotaWatcher watcher) {
+        final long start = System.nanoTime();
+
+        final MemoryKey key = new MemoryKey(source, series);
+
+        final NavigableMap<Long, ? extends TimeData> tree = storage.get(key);
+
+        if (tree == null)
+            return async.resolved(new FetchData<T>(series, ImmutableList.<T> of(), ImmutableList.<Long> of()));
+
+        synchronized (tree) {
+            final List<? extends TimeData> data = new ArrayList<>(tree.tailMap(range.getStart())
+                    .headMap(range.getEnd()).values());
+            return async.resolved(new FetchData<T>(series, (List<T>) data, ImmutableList.<Long> of(System.nanoTime()
+                    - start)));
+        }
+    }
+
+    @Override
+    public AsyncFuture<List<BackendKey>> keys(BackendKey start, BackendKey end, int limit) {
+        return async.resolved((List<BackendKey>) new ArrayList<BackendKey>());
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public Iterable<BackendEntry> listEntries() {
+        return EMPTY_ENTRIES;
+    }
+
+    @Data
+    public static final class MemoryKey {
+        private final Class<? extends TimeData> source;
+        private final Series series;
+    }
+
+    /**
+     * Get or create a new navigable map to store time data.
+     *
+     * @param key The key to create the map under.
+     * @return An existing, or a newly created navigable map for the given key.
+     */
+    private NavigableMap<Long, TimeData> getOrCreate(final MemoryKey key) {
+        final NavigableMap<Long, TimeData> tree = storage.get(key);
+
+        if (tree != null)
+            return tree;
+
+        synchronized ($create) {
+            final NavigableMap<Long, TimeData> checked = storage.get(key);
+
+            if (checked != null)
+                return checked;
+
+            final NavigableMap<Long, TimeData> created = new TreeMap<>();
+            storage.put(key, created);
+            return created;
+        }
+    }
+}

--- a/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryMetricModule.java
+++ b/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryMetricModule.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.metric.memory;
+
+import java.util.Set;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import lombok.Data;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.inject.Key;
+import com.google.inject.PrivateModule;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.spotify.heroic.metric.MetricBackend;
+import com.spotify.heroic.metric.MetricModule;
+import com.spotify.heroic.statistics.LocalMetricManagerReporter;
+import com.spotify.heroic.statistics.MetricBackendReporter;
+import com.spotify.heroic.utils.GroupedUtils;
+
+@Data
+public final class MemoryMetricModule implements MetricModule {
+    public static final String DEFAULT_GROUP = "memory";
+
+    private final String id;
+    private final Set<String> groups;
+
+    @JsonCreator
+    public MemoryMetricModule(@JsonProperty("id") String id, @JsonProperty("group") String group,
+            @JsonProperty("groups") Set<String> groups) {
+        this.id = id;
+        this.groups = GroupedUtils.groups(group, groups, DEFAULT_GROUP);
+    }
+
+    @Override
+    public PrivateModule module(final Key<MetricBackend> key, final String id) {
+        return new PrivateModule() {
+            @Provides
+            @Singleton
+            public MetricBackendReporter reporter(LocalMetricManagerReporter reporter) {
+                return reporter.newBackend(id);
+            }
+
+            @Provides
+            @Singleton
+            @Named("groups")
+            public Set<String> groups() {
+                return groups;
+            }
+
+            @Override
+            protected void configure() {
+                bind(key).to(MemoryBackend.class).in(Scopes.SINGLETON);
+                expose(key);
+            }
+        };
+    }
+
+    @Override
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public String buildId(int i) {
+        return String.format("memory#%d", i);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String id;
+        private String group;
+        private Set<String> groups;
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder group(String group) {
+            this.group = group;
+            return this;
+        }
+
+        public Builder groups(Set<String> groups) {
+            this.groups = groups;
+            return this;
+        }
+
+        public MemoryMetricModule build() {
+            return new MemoryMetricModule(id, group, groups);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <module>metric/astyanax</module>
     <module>metric/datastax</module>
     <module>metric/generated</module>
+    <module>metric/memory</module>
     <module>metadata/elasticsearch</module>
     <module>suggest/elasticsearch</module>
     <module>discovery/simple</module>
@@ -103,6 +104,11 @@
       <dependency>
         <groupId>com.spotify.heroic.metric</groupId>
         <artifactId>heroic-metric-generated</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.spotify.heroic.metric</groupId>
+        <artifactId>heroic-metric-memory</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
A metric backend that keeps all metrics in-memory.

Each time-series is backed by a TreeMap, since it is convenient to access a range of keys (in our case; timespans).
