### PR TITLE
[shell,dist] break out module dependencies to new component heroic-all

### DIFF
--- a/heroic-all/pom.xml
+++ b/heroic-all/pom.xml
@@ -1,0 +1,87 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.spotify.heroic</groupId>
+    <artifactId>heroic-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <artifactId>heroic-all</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Heroic: Dependencies to All Components</name>
+
+  <description>
+  </description>
+
+  <dependencies>
+    <!-- core -->
+    <dependency>
+      <groupId>com.spotify.heroic</groupId>
+      <artifactId>heroic-core</artifactId>
+    </dependency>
+
+    <!-- metric backends -->
+    <dependency>
+      <groupId>com.spotify.heroic.metric</groupId>
+      <artifactId>heroic-metric-astyanax</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.spotify.heroic.metric</groupId>
+      <artifactId>heroic-metric-datastax</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.spotify.heroic.metric</groupId>
+      <artifactId>heroic-metric-generated</artifactId>
+    </dependency>
+
+    <!-- metadata backends -->
+    <dependency>
+      <groupId>com.spotify.heroic.metadata</groupId>
+      <artifactId>heroic-metadata-elasticsearch</artifactId>
+    </dependency>
+
+    <!-- suggest backends -->
+    <dependency>
+      <groupId>com.spotify.heroic.suggest</groupId>
+      <artifactId>heroic-suggest-elasticsearch</artifactId>
+    </dependency>
+
+    <!-- discovery implementations -->
+    <dependency>
+      <groupId>com.spotify.heroic.discovery</groupId>
+      <artifactId>heroic-discovery-simple</artifactId>
+    </dependency>
+
+    <!-- aggregation methods -->
+    <dependency>
+      <groupId>com.spotify.heroic.aggregation</groupId>
+      <artifactId>heroic-aggregation-simple</artifactId>
+    </dependency>
+
+    <!-- consumer implementations -->
+    <dependency>
+      <groupId>com.spotify.heroic.consumer</groupId>
+      <artifactId>heroic-consumer-kafka</artifactId>
+    </dependency>
+
+    <!-- aggregation caching -->
+    <dependency>
+      <groupId>com.spotify.heroic.aggregationcache</groupId>
+      <artifactId>heroic-aggregationcache-cassandra2</artifactId>
+    </dependency>
+
+    <!-- rpc implementations -->
+    <dependency>
+      <groupId>com.spotify.heroic.rpc</groupId>
+      <artifactId>heroic-rpc-httprpc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.spotify.heroic.rpc</groupId>
+      <artifactId>heroic-rpc-nativerpc</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/heroic-all/src/main/java/com/spotify/heroic/HeroicModules.java
+++ b/heroic-all/src/main/java/com/spotify/heroic/HeroicModules.java
@@ -1,0 +1,30 @@
+package com.spotify.heroic;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+public class HeroicModules {
+    // @formatter:off
+    public static final List<Class<?>> ALL_MODULES = ImmutableList.<Class<?>>of(
+        com.spotify.heroic.metric.astyanax.Entry.class,
+        com.spotify.heroic.metric.datastax.Entry.class,
+        com.spotify.heroic.metric.generated.Entry.class,
+
+        com.spotify.heroic.metadata.elasticsearch.Entry.class,
+        com.spotify.heroic.suggest.elasticsearch.Entry.class,
+        // com.spotify.heroic.suggest.lucene.Entry.class,
+
+        com.spotify.heroic.cluster.discovery.simple.Entry.class,
+
+        com.spotify.heroic.aggregation.simple.Entry.class,
+
+        com.spotify.heroic.consumer.kafka.Entry.class,
+
+        com.spotify.heroic.aggregationcache.cassandra2.Entry.class,
+
+        com.spotify.heroic.rpc.httprpc.Entry.class,
+        com.spotify.heroic.rpc.nativerpc.Entry.class
+    );
+    // @formatter:on
+}

--- a/heroic-dist/pom.xml
+++ b/heroic-dist/pom.xml
@@ -43,7 +43,7 @@
     <!-- core -->
     <dependency>
       <groupId>com.spotify.heroic</groupId>
-      <artifactId>heroic-core</artifactId>
+      <artifactId>heroic-all</artifactId>
     </dependency>
 
     <dependency>
@@ -51,77 +51,11 @@
       <artifactId>heroic-shell</artifactId>
     </dependency>
 
-    <!-- metric backends -->
-    <dependency>
-      <groupId>com.spotify.heroic.metric</groupId>
-      <artifactId>heroic-metric-astyanax</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.spotify.heroic.metric</groupId>
-      <artifactId>heroic-metric-datastax</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.spotify.heroic.metric</groupId>
-      <artifactId>heroic-metric-generated</artifactId>
-    </dependency>
-
-    <!-- metadata backends -->
-    <dependency>
-      <groupId>com.spotify.heroic.metadata</groupId>
-      <artifactId>heroic-metadata-elasticsearch</artifactId>
-    </dependency>
-
-    <!-- suggest backends -->
-    <dependency>
-      <groupId>com.spotify.heroic.suggest</groupId>
-      <artifactId>heroic-suggest-elasticsearch</artifactId>
-    </dependency>
-
-    <!-- discovery implementations -->
-    <dependency>
-      <groupId>com.spotify.heroic.discovery</groupId>
-      <artifactId>heroic-discovery-simple</artifactId>
-    </dependency>
-
-    <!-- aggregation methods -->
-    <dependency>
-      <groupId>com.spotify.heroic.aggregation</groupId>
-      <artifactId>heroic-aggregation-simple</artifactId>
-    </dependency>
-
-    <!-- consumer implementations -->
-    <dependency>
-      <groupId>com.spotify.heroic.consumer</groupId>
-      <artifactId>heroic-consumer-kafka</artifactId>
-    </dependency>
-
-    <!-- aggregation caching -->
-    <dependency>
-      <groupId>com.spotify.heroic.aggregationcache</groupId>
-      <artifactId>heroic-aggregationcache-cassandra2</artifactId>
-    </dependency>
-
-    <!-- rpc implementations -->
-    <dependency>
-      <groupId>com.spotify.heroic.rpc</groupId>
-      <artifactId>heroic-rpc-httprpc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.spotify.heroic.rpc</groupId>
-      <artifactId>heroic-rpc-nativerpc</artifactId>
-    </dependency>
-
-    <!-- shell -->
+    <!-- argument parsing -->
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
       <version>2.0.29</version>
-    </dependency>
-
-    <dependency>
-      <groupId>jline</groupId>
-      <artifactId>jline</artifactId>
-      <version>2.12</version>
     </dependency>
 
     <!-- testing -->

--- a/heroic-dist/src/main/java/com/spotify/heroic/HeroicService.java
+++ b/heroic-dist/src/main/java/com/spotify/heroic/HeroicService.java
@@ -39,7 +39,6 @@ import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
-import com.google.common.collect.ImmutableList;
 import com.spotify.heroic.HeroicCore.Builder;
 import com.spotify.heroic.profile.GeneratedProfile;
 import com.spotify.heroic.reflection.ResourceException;
@@ -66,29 +65,6 @@ public class HeroicService {
     static {
         PROFILES.put("generated", new GeneratedProfile());
     }
-
-    // @formatter:off
-    private static final List<Class<?>> MODULES = ImmutableList.<Class<?>>of(
-        com.spotify.heroic.metric.astyanax.Entry.class,
-        com.spotify.heroic.metric.datastax.Entry.class,
-        com.spotify.heroic.metric.generated.Entry.class,
-
-        com.spotify.heroic.metadata.elasticsearch.Entry.class,
-        com.spotify.heroic.suggest.elasticsearch.Entry.class,
-        // com.spotify.heroic.suggest.lucene.Entry.class,
-
-        com.spotify.heroic.cluster.discovery.simple.Entry.class,
-
-        com.spotify.heroic.aggregation.simple.Entry.class,
-
-        com.spotify.heroic.consumer.kafka.Entry.class,
-
-        com.spotify.heroic.aggregationcache.cassandra2.Entry.class,
-
-        com.spotify.heroic.rpc.httprpc.Entry.class,
-        com.spotify.heroic.rpc.nativerpc.Entry.class
-    );
-    // @formatter:on
 
     public static void main(final String[] args) throws Exception {
         main(args, null);
@@ -193,7 +169,7 @@ public class HeroicService {
         if (params.profile != null)
             builder.profile(setupProfile(params.profile));
 
-        builder.modules(MODULES);
+        builder.modules(HeroicModules.ALL_MODULES);
     }
 
     private static HeroicProfile setupProfile(final String profile) {

--- a/heroic-shell/pom.xml
+++ b/heroic-shell/pom.xml
@@ -39,10 +39,10 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- core -->
+    <!-- all -->
     <dependency>
       <groupId>com.spotify.heroic</groupId>
-      <artifactId>heroic-core</artifactId>
+      <artifactId>heroic-all</artifactId>
     </dependency>
 
     <dependency>

--- a/heroic-shell/src/main/java/com/spotify/heroic/shell/CoreBridge.java
+++ b/heroic-shell/src/main/java/com/spotify/heroic/shell/CoreBridge.java
@@ -39,9 +39,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 
-import com.google.common.collect.ImmutableList;
 import com.spotify.heroic.HeroicCore;
 import com.spotify.heroic.HeroicCore.Builder;
+import com.spotify.heroic.HeroicModules;
 
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.Borrowed;
@@ -52,28 +52,6 @@ import eu.toolchain.async.Managed;
 public class CoreBridge {
     public static final Path[] DEFAULT_CONFIGS = new Path[] { Paths.get("heroic.yml"),
             Paths.get("/etc/heroic/heroic.yml") };
-
-    // @formatter:off
-    private static final List<String> MODULES = ImmutableList.<String>of(
-        "com.spotify.heroic.metric.astyanax",
-        "com.spotify.heroic.metric.datastax",
-        "com.spotify.heroic.metric.generated",
-
-        "com.spotify.heroic.metadata.elasticsearch",
-        "com.spotify.heroic.suggest.elasticsearch",
-
-        "com.spotify.heroic.cluster.discovery.simple",
-
-        "com.spotify.heroic.aggregation.simple",
-
-        "com.spotify.heroic.consumer.kafka",
-
-        "com.spotify.heroic.aggregationcache.cassandra2",
-
-        "com.spotify.heroic.rpc.httprpc",
-        "com.spotify.heroic.rpc.nativerpc"
-    );
-    // @formatter:on
 
     private final Managed<State> state;
 
@@ -234,7 +212,8 @@ public class CoreBridge {
     }
 
     public static Builder setupBuilder(boolean server, String config) {
-        return HeroicCore.builder().server(server).configPath(CoreBridge.parseConfigPath(config)).modules(MODULES)
+        return HeroicCore.builder().server(server).configPath(CoreBridge.parseConfigPath(config))
+                .modules(HeroicModules.ALL_MODULES)
                 .oneshot(true);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <module>heroic-core</module>
     <module>heroic-shell</module>
     <module>heroic-parser</module>
+    <module>heroic-all</module>
     <module>metric/astyanax</module>
     <module>metric/datastax</module>
     <module>metric/generated</module>
@@ -68,6 +69,11 @@
       <dependency>
         <groupId>com.spotify.heroic</groupId>
         <artifactId>heroic-parser</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.spotify.heroic</groupId>
+        <artifactId>heroic-all</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
This makes it easier to run tasks from heroic-shell directly in your IDE.

The new module 'heroic-all' depends on all the common components that are
required to operate a heroic service.
