### PR TITLE
Trim white space around shell input

### DIFF
--- a/heroic-shell/src/main/java/com/spotify/heroic/shell/QuoteParser.java
+++ b/heroic-shell/src/main/java/com/spotify/heroic/shell/QuoteParser.java
@@ -59,6 +59,8 @@ public class QuoteParser {
 
         int pos = 0;
 
+        input = input.trim();
+        
         for (final char c : input.toCharArray()) {
             ++pos;
 

--- a/heroic-shell/src/main/java/com/spotify/heroic/shell/QuoteParser.java
+++ b/heroic-shell/src/main/java/com/spotify/heroic/shell/QuoteParser.java
@@ -60,7 +60,7 @@ public class QuoteParser {
         int pos = 0;
 
         input = input.trim();
-        
+
         for (final char c : input.toCharArray()) {
             ++pos;
 


### PR DESCRIPTION
These have leading spaces
<img width="547" alt="screen shot 2016-01-11 at 12 04 17 pm" src="https://cloud.githubusercontent.com/assets/3356993/12240512/d6ecd444-b85b-11e5-9da8-fbcc30c7f7ab.png">

I was going to add a test case, but I wasn't positive on how the syntax of QuoteParserTest works.

Would this work?

```
test(Case.of("  trimming_spaces  ", "trimming_spaces"));
```
