### PR TITLE
Add support for FilterK aggregations

### DIFF
--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/BottomK.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/BottomK.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.spotify.heroic.aggregation.Aggregation;
+import com.spotify.heroic.aggregation.AggregationContext;
+import lombok.Data;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@Data
+public class BottomK implements Aggregation {
+    public static final String NAME = "bottomk";
+
+    private final long k;
+    private final Aggregation of;
+
+    @JsonCreator
+    public BottomK(@JsonProperty("k") long k, @JsonProperty("of") Aggregation of) {
+        this.k = k;
+        this.of = checkNotNull(of, "of");
+    }
+
+    @Override
+    public Optional<Long> size() {
+        return of.size();
+    }
+
+    @Override
+    public Optional<Long> extent() {
+        return of.extent();
+    }
+
+    @Override
+    public BottomKInstance apply(final AggregationContext context) {
+        return new BottomKInstance(k, of.apply(context));
+    }
+
+    @Override
+    public String toDSL() {
+        return String.format("%s(%d, %s)", NAME, k, of.toDSL());
+    }
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/BottomKInstance.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/BottomKInstance.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+
+import com.spotify.heroic.aggregation.AggregationInstance;
+import com.spotify.heroic.aggregation.AggregationState;
+import com.spotify.heroic.aggregation.AggregationTraversal;
+import com.spotify.heroic.aggregation.ReducerSession;
+import com.spotify.heroic.common.DateRange;
+
+import java.util.List;
+
+public class BottomKInstance implements FilterKInstance {
+    private final FilterKInstanceImpl filterK;
+
+    public BottomKInstance(long k, AggregationInstance of) {
+        filterK = new FilterKInstanceImpl(k, FilterKInstanceImpl.FilterType.BOTTOM, of);
+    }
+
+    @Override
+    public long estimate(DateRange range) {
+        return filterK.estimate(range);
+    }
+
+    @Override
+    public long cadence() {
+        return filterK.cadence();
+    }
+
+    @Override
+    public AggregationTraversal session(List<AggregationState> states, DateRange range) {
+        return filterK.session(states, range);
+    }
+
+    @Override
+    public ReducerSession reducer(DateRange range) {
+        return filterK.reducer(range);
+    }
+
+    @Override
+    public long getK() {
+        return filterK.getK();
+    }
+
+    @Override
+    public AggregationInstance getOf() {
+        return filterK.getOf();
+    }
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/FilterKAggregationBuilder.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/FilterKAggregationBuilder.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+
+
+import com.spotify.heroic.aggregation.AbstractAggregationDSL;
+import com.spotify.heroic.aggregation.Aggregation;
+import com.spotify.heroic.aggregation.AggregationArguments;
+import com.spotify.heroic.aggregation.AggregationFactory;
+import com.spotify.heroic.grammar.AggregationValue;
+
+public abstract class FilterKAggregationBuilder<T extends Aggregation>
+    extends AbstractAggregationDSL {
+
+    public FilterKAggregationBuilder(AggregationFactory factory) {
+        super(factory);
+    }
+
+    @Override
+    public Aggregation build(AggregationArguments args) {
+        final int k = args.positional(Long.class)
+            .orElseThrow(() -> new IllegalArgumentException(
+                "missing required argument 'k'")).intValue();
+
+        final AggregationValue of = args.positional(AggregationValue.class)
+            .orElseThrow(() -> new IllegalArgumentException(
+                "missing required child aggregation 'of'"));
+
+        return buildAggregation(k, asAggregation(of));
+    }
+
+    protected abstract T buildAggregation(long k, Aggregation of);
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/FilterKInstance.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/FilterKInstance.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+
+import com.spotify.heroic.aggregation.AggregationInstance;
+
+public interface FilterKInstance extends AggregationInstance {
+    long getK();
+
+    AggregationInstance getOf();
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/FilterKInstanceImpl.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/FilterKInstanceImpl.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+
+import com.spotify.heroic.aggregation.AggregationCombiner;
+import com.spotify.heroic.aggregation.AggregationData;
+import com.spotify.heroic.aggregation.AggregationInstance;
+import com.spotify.heroic.aggregation.AggregationResult;
+import com.spotify.heroic.aggregation.AggregationSession;
+import com.spotify.heroic.aggregation.AggregationState;
+import com.spotify.heroic.aggregation.AggregationTraversal;
+import com.spotify.heroic.aggregation.ReducerResult;
+import com.spotify.heroic.aggregation.ReducerSession;
+import com.spotify.heroic.common.DateRange;
+import com.spotify.heroic.common.Series;
+import com.spotify.heroic.metric.Event;
+import com.spotify.heroic.metric.MetricCollection;
+import com.spotify.heroic.metric.MetricGroup;
+import com.spotify.heroic.metric.Point;
+import com.spotify.heroic.metric.ShardedResultGroup;
+import com.spotify.heroic.metric.Spread;
+import lombok.Data;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class FilterKInstanceImpl implements FilterKInstance {
+    private final AggregationInstance of;
+
+    public enum FilterType {
+        TOP,
+        BOTTOM
+    }
+    private final long k;
+
+    private final FilterType filterType;
+    public FilterKInstanceImpl(long k, FilterType filterType, final AggregationInstance of) {
+        this.k = k;
+        this.filterType = checkNotNull(filterType, "filterType");
+        this.of = checkNotNull(of, "of");
+    }
+
+    @Override
+    public long getK() {
+        return k;
+    }
+
+    @Override
+    public AggregationInstance getOf() {
+        return of;
+    }
+
+    @Override
+    public long estimate(DateRange range) {
+        return 0;
+    }
+
+    @Override
+    public long cadence() {
+        return of.cadence();
+    }
+
+    @Override
+    public AggregationTraversal session(List<AggregationState> states, DateRange range) {
+        final AggregationSession child = of.session(states, range).getSession();
+        return new AggregationTraversal(states, new Session(k, filterType, child));
+    }
+
+    @Override
+    public ReducerSession reducer(DateRange range) {
+        return new FilterKReducerSession(of.reducer(range), k, filterType);
+    }
+
+    @Override
+    public AggregationCombiner combiner(DateRange range) {
+        return all -> {
+            final List<FilterableKMetrics<ShardedResultGroup>> filterableMetrics =
+                of.combiner(range)
+                    .combine(all)
+                    .stream()
+                    .map(s -> new FilterableKMetrics<>(s, s::getGroup))
+                    .collect(Collectors.toList());
+
+            return FilterK.filter(filterableMetrics, filterType, k);
+        };
+    }
+
+    private static class Session implements AggregationSession {
+        private final long k;
+        private final FilterType filterType;
+        private final AggregationSession childSession;
+
+        public Session(long k,
+                       FilterType filterType,
+                       AggregationSession childSession) {
+            this.k = k;
+            this.filterType = filterType;
+            this.childSession = childSession;
+        }
+
+        @Override
+        public void updatePoints(Map<String, String> group, Set<Series> series,
+                                 List<Point> values) {
+            childSession.updatePoints(group, series, values);
+        }
+
+        @Override
+        public void updateEvents(Map<String, String> group, Set<Series> series,
+                                 List<Event> values) {
+            childSession.updateEvents(group, series, values);
+        }
+
+        @Override
+        public void updateSpreads(Map<String, String> group, Set<Series> series,
+                                  List<Spread> values) {
+            childSession.updateSpreads(group, series, values);
+        }
+
+        @Override
+        public void updateGroup(Map<String, String> group, Set<Series> series,
+                                List<MetricGroup> values) {
+            childSession.updateGroup(group, series, values);
+        }
+
+        @Override
+        public AggregationResult result() {
+            final List<AggregationData> result = FilterK.filter(getFilterableAggregationData(),
+                filterType, k);
+
+            return new AggregationResult(result, childSession.result().getStatistics());
+        }
+
+        private List<FilterableKMetrics<AggregationData>> getFilterableAggregationData() {
+            return childSession.result().getResult()
+                .stream()
+                .map(a -> new AggregationData(a.getGroup(), a.getSeries(), a.getMetrics()))
+                .map(a -> new FilterableKMetrics<>(a, a::getMetrics))
+                .collect(Collectors.toList());
+        }
+    }
+
+    private static class FilterKReducerSession implements ReducerSession {
+        private final ReducerSession childReducer;
+        private final long k;
+        private final FilterType filterType;
+
+        public FilterKReducerSession(ReducerSession reducer, long k, FilterType filterType) {
+            this.childReducer = reducer;
+            this.k = k;
+            this.filterType = filterType;
+        }
+
+        @Override
+        public void updatePoints(Map<String, String> group, List<Point> values) {
+            childReducer.updatePoints(group, values);
+        }
+
+        @Override
+        public void updateEvents(Map<String, String> group, List<Event> values) {
+            childReducer.updateEvents(group, values);
+        }
+
+        @Override
+        public void updateSpreads(Map<String, String> group, List<Spread> values) {
+            childReducer.updateSpreads(group, values);
+        }
+
+        @Override
+        public void updateGroup(Map<String, String> group, List<MetricGroup> values) {
+            childReducer.updateGroup(group, values);
+        }
+
+        @Override
+        public ReducerResult result() {
+            final List<FilterableKMetrics<MetricCollection>> filterableKMetrics =
+                childReducer.result()
+                    .getResult()
+                    .stream()
+                    .map(m -> new FilterableKMetrics<>(m, () -> m))
+                    .collect(Collectors.toList());
+
+            return new ReducerResult(FilterK.filter(filterableKMetrics, filterType, k),
+                childReducer.result().getStatistics());
+        }
+    }
+
+    @Data
+    private static class FilterableKMetrics<T> {
+        private final T data;
+        private final Supplier<MetricCollection> metricSupplier;
+    }
+
+    private static class FilterK<T> {
+        private final List<FilterableKMetrics<T>> metrics;
+        private final FilterType filterType;
+        private final long k;
+
+        public static <T> List<T> filter(List<FilterableKMetrics<T>> metrics,
+                                         FilterType filterType, long k) {
+            return new FilterK<>(metrics, filterType, k).apply();
+        }
+
+        private FilterK(List<FilterableKMetrics<T>> metrics, FilterType filterType, long k) {
+            this.metrics = metrics;
+            this.filterType = filterType;
+            this.k = k;
+        }
+
+        private List<T> apply() {
+            return metrics.stream()
+                .map(Area::new)
+                .sorted(buildCompare(filterType))
+                .limit(k)
+                .map(Area::getFilterableKMetrics)
+                .map(FilterableKMetrics::getData)
+                .collect(Collectors.toList());
+        }
+
+        private Comparator<Area> buildCompare(FilterType filterType) {
+            return (Area a, Area b) -> {
+                final Comparator<Double> comparator = Double::compare;
+
+                if (filterType == FilterType.TOP) {
+                    return comparator.reversed().compare(a.getValue(), b.getValue());
+                } else {
+                    return comparator.compare(a.getValue(), b.getValue());
+                }
+            };
+        }
+
+        @Data
+        private class Area {
+            private final FilterableKMetrics<T> filterableKMetrics;
+            private final double value;
+
+            public Area(FilterableKMetrics<T> filterableKMetrics) {
+                this.filterableKMetrics = filterableKMetrics;
+                this.value = computeArea(filterableKMetrics.getMetricSupplier().get());
+            }
+
+            private Double computeArea(MetricCollection metrics) {
+                return metrics.getDataAs(Point.class)
+                    .stream()
+                    .map(Point::getValue)
+                    .reduce(0D, (a, b) -> a + b);
+            }
+        }
+    }
+
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/FilterKSerializer.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/FilterKSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+
+import com.spotify.heroic.aggregation.AggregationInstance;
+import com.spotify.heroic.aggregation.AggregationSerializer;
+import eu.toolchain.serializer.SerialReader;
+import eu.toolchain.serializer.SerialWriter;
+import eu.toolchain.serializer.Serializer;
+import eu.toolchain.serializer.SerializerFramework;
+
+import java.io.IOException;
+
+public abstract class  FilterKSerializer<T extends FilterKInstance> implements Serializer<T> {
+    private final Serializer<Long> fixedLong;
+    private final AggregationSerializer serializer;
+
+    public FilterKSerializer(SerializerFramework framework, AggregationSerializer serializer) {
+        this.fixedLong = framework.fixedLong();
+        this.serializer = serializer;
+    }
+
+    @Override
+    public void serialize(SerialWriter buffer, T t) throws IOException {
+        fixedLong.serialize(buffer, t.getK());
+        serializer.serialize(buffer, t.getOf());
+    }
+
+    @Override
+    public T deserialize(SerialReader serialReader) throws IOException {
+        final long k = fixedLong.deserialize(serialReader);
+        final AggregationInstance of = serializer.deserialize(serialReader);
+        return build(k, of);
+    }
+
+    protected abstract T build(long k, AggregationInstance of);
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/TopK.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/TopK.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.spotify.heroic.aggregation.Aggregation;
+import com.spotify.heroic.aggregation.AggregationContext;
+import lombok.Data;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@Data
+public class TopK implements Aggregation {
+    public static final String NAME = "topk";
+
+    private final long k;
+    private final Aggregation of;
+
+    @JsonCreator
+    public TopK(@JsonProperty("k") long k, @JsonProperty("of") Aggregation of) {
+        this.k = k;
+        this.of = checkNotNull(of, "of");
+    }
+
+    @Override
+    public Optional<Long> size() {
+        return of.size();
+    }
+
+    @Override
+    public Optional<Long> extent() {
+        return of.extent();
+    }
+
+    @Override
+    public TopKInstance apply(final AggregationContext context) {
+        return new TopKInstance(k, of.apply(context));
+    }
+
+    @Override
+    public String toDSL() {
+        return String.format("%s(%d, %s)", NAME, k, of.toDSL());
+    }
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/TopKInstance.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/TopKInstance.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+
+import com.spotify.heroic.aggregation.AggregationInstance;
+import com.spotify.heroic.aggregation.AggregationState;
+import com.spotify.heroic.aggregation.AggregationTraversal;
+import com.spotify.heroic.aggregation.ReducerSession;
+import com.spotify.heroic.common.DateRange;
+
+import java.util.List;
+
+public class TopKInstance implements FilterKInstance {
+    private final FilterKInstanceImpl filterK;
+
+    public TopKInstance(long k, AggregationInstance of) {
+        filterK = new FilterKInstanceImpl(k, FilterKInstanceImpl.FilterType.TOP, of);
+    }
+
+    @Override
+    public long estimate(DateRange range) {
+        return filterK.estimate(range);
+    }
+
+    @Override
+    public long cadence() {
+        return filterK.cadence();
+    }
+
+    @Override
+    public AggregationTraversal session(List<AggregationState> states, DateRange range) {
+        return filterK.session(states, range);
+    }
+
+    @Override
+    public ReducerSession reducer(DateRange range) {
+        return filterK.reducer(range);
+    }
+
+    @Override
+    public long getK() {
+        return filterK.getK();
+    }
+
+    @Override
+    public AggregationInstance getOf() {
+        return filterK.getOf();
+    }
+}

--- a/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/FilterKAggregationTest.java
+++ b/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/FilterKAggregationTest.java
@@ -1,0 +1,86 @@
+package com.spotify.heroic.aggregation.simple;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.spotify.heroic.aggregation.AggregationData;
+import com.spotify.heroic.aggregation.AggregationSession;
+import com.spotify.heroic.aggregation.AggregationState;
+import com.spotify.heroic.aggregation.ChainInstance;
+import com.spotify.heroic.aggregation.EmptyInstance;
+import com.spotify.heroic.aggregation.GroupInstance;
+import com.spotify.heroic.aggregation.GroupingAggregation;
+import com.spotify.heroic.common.DateRange;
+import com.spotify.heroic.common.Series;
+import com.spotify.heroic.metric.Point;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FilterKAggregationTest {
+
+    @Test
+    public void testFilterKSession() {
+        final GroupingAggregation g1 = new GroupInstance(
+            Optional.of(ImmutableList.of("site", "host")), EmptyInstance.INSTANCE);
+        final GroupingAggregation g2 =
+            new GroupInstance(Optional.of(ImmutableList.of("site")), EmptyInstance.INSTANCE);
+        final ChainInstance chain = new ChainInstance(
+            Optional.of(ImmutableList.of(g1, g2)));
+
+        final TopKInstance t1 = new TopKInstance(2, chain);
+        final BottomKInstance b1 = new BottomKInstance(1, t1);
+
+        final List<AggregationState> states = new ArrayList<>();
+
+        final Series s1 = Series.of("foo", ImmutableMap.of("site", "sto", "host", "a"));
+        final Series s2 = Series.of("foo", ImmutableMap.of("site", "sto", "host", "b"));
+        final Series s3 = Series.of("foo", ImmutableMap.of("site", "lon", "host", "b"));
+        final Series s4 = Series.of("foo", ImmutableMap.of("host", "c"));
+
+        states.add(AggregationState.forSeries(s1));
+        states.add(AggregationState.forSeries(s2));
+        states.add(AggregationState.forSeries(s3));
+        states.add(AggregationState.forSeries(s4));
+
+        final AggregationSession session =
+            b1.session(states, new DateRange(0, 10000)).getSession();
+
+        session.updatePoints(s4.getTags(), ImmutableSet.of(s4),
+            ImmutableList.of(new Point(1, 1.0)));
+        session.updatePoints(s3.getTags(), ImmutableSet.of(s3),
+            ImmutableList.of(new Point(2, 2.0)));
+        session.updatePoints(s2.getTags(), ImmutableSet.of(s2),
+            ImmutableList.of(new Point(3, 3.0)));
+        session.updatePoints(s1.getTags(), ImmutableSet.of(s1),
+            ImmutableList.of(new Point(4, 4.0)));
+
+        /* Before the time series reach the bottomk/topk aggregation, the aggregated areas should be
+           {empty: 1, lon: 2, sto: 7}. And we apply topk(2) | bottomk(1) so we expect lon to be
+            the only group at the end of the aggregation
+         */
+
+        final List<AggregationData> result = session.result().getResult();
+
+        assertEquals(1, result.size());
+
+        AggregationData first = result.get(0);
+
+        if (first.getGroup().equals(ImmutableMap.of("site", "lon"))) {
+            assertEquals(ImmutableList.of(new Point(2, 2.0)), first.getMetrics().getData());
+        } else {
+            Assert.fail("unexpected group: " + first.getGroup());
+        }
+    }
+}


### PR DESCRIPTION
This aggregation provides topk and bottomk filtering. Time-series are
sorted by computing the area under the curve.

It needs to be used along with a child aggregation.
e.g: "topk(3, avergage by host)"