### PR TITLE
use shaded version of heroic jar

### DIFF
--- a/source/_pages/docs/getting_started/compile.ngt
+++ b/source/_pages/docs/getting_started/compile.ngt
@@ -37,5 +37,5 @@ $ mvn clean package
 </p>
 
 <pre><code language="bash">
-$ java -cp heroic-dist/target/heroic-dist-0.0.1-SNAPSHOT.jar com.spotify.heroic.HeroicService &lt;config&gt;
+$ java -cp heroic-dist/target/heroic-dist-0.0.1-SNAPSHOT-shaded.jar com.spotify.heroic.HeroicService &lt;config&gt;
 </code></pre>


### PR DESCRIPTION
only shaded version of jar could be executed without additional classpath locations