### PR TITLE
[core,component] add empty query results to response

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryResult.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryResult.java
@@ -83,10 +83,6 @@ public class QueryResult {
                 traces.add(part.getTrace());
                 queryTraces.add(part.getQueryTrace());
 
-                if (part.isEmpty()) {
-                    continue;
-                }
-
                 all.add(part.getGroups());
             }
 

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -525,11 +525,6 @@ public class LocalMetricManager implements MetricManager {
             final List<ResultGroup> groups = new ArrayList<>();
 
             for (final AggregationData group : result.getResult()) {
-                /* skip empty groups (no valid values) */
-                if (group.isEmpty()) {
-                    continue;
-                }
-
                 final Set<Series> s = lookup.get(group.getGroup());
 
                 if (s == null) {


### PR DESCRIPTION
Our alerting system relies on heroic returning time-series with
empty values for its "data is missing" capabilities.