### PR TITLE
[docs] update /query/metrics example

### DIFF
--- a/source/_pages/docs/api.ngt
+++ b/source/_pages/docs/api.ngt
@@ -80,7 +80,7 @@
     Query and aggregate metrics.
   </p>
 
-  <api-accept curl-data='{"range": {"type": "relative"}, "filter": ["and", ["key", "foo"], ["=", "foo", "bar"], ["+", "role"]], "groupBy": ["site"], "aggregation": []}'>
+  <api-accept curl-data='{"range": {"type": "relative", "unit": "HOURS", "value": 2}, "filter": ["and", ["key", "foo"], ["=", "foo", "bar"], ["+", "role"]], "groupBy": ["site"]}'>
     <api-type>
       <api-field required="true" name="range" type-href="QueryDateRange">
         The range in time for which to query
@@ -119,10 +119,9 @@
 
     <codeblock language="json">
     {
-      "range": {"type": "relative"},
+      "range": {"type": "relative", "unit": "HOURS", "value": 2},
       "filter": ["and", ["key", "foo"], ["=", "foo", "bar"], ["+", "role"]],
-      "groupBy": ["site"],
-      "aggregators": []
+      "groupBy": ["site"]
     }
     </codeblock>
   </api-accept>
@@ -183,7 +182,10 @@
           "values": [[1300000000000, 42.0]]
         }
       ],
-      "range": {},
+      "range": {
+        "end": 1469816790000,
+        "start": 1469809590000
+      },
       "statistics": {}
     }
     </codeblock>


### PR DESCRIPTION
[docs] update /query/metrics example
Make the example request to /query/metrics have an explicit unit and value.

The value needs to be set in the example query, I'll update the error
message to be more specific than just returning "value" for the failure.

```
curl -H "Content-Type: application/json" http://localhost:8080/query/metrics -d '
{"range": {"type":"relative"}, "filter": ["and", ["key", "foo"], ["=", "foo", "bar"], ["+", "role"]], "groupBy": ["site"]}'

{
    "type": "json-error"
    "path":"range",
    "status":400,
    "reason":"Bad Request",
    "message":"Instantiation of [simple type, class com.spotify.heroic.QueryDateRange$Relative] value failed: value",
}
```

Also having an empty aggregator being applied to an empty result set
causes an error. I chose to remove this query option instead.

```
curl -H "Content-Type: application/json" http://localhost:8080/query/metrics -d '
{"range": {"type": "relative", "value": 1}, "filter": ["and", ["key", "foo"], ["=", "foo", "bar"], ["+", "role"]], "groupBy": ["site"], "aggregation": []}'

{
    "type": "json-error",
    "path": "aggregation",
    "status": 400,
    "reason": "Bad Request",
    "message": "Unexpected token (END_ARRAY), expected VALUE_STRING: need JSON String that contains type id (for subtype of com.spotify.heroic.aggregation.Aggregation)"
}
```