### PR TITLE
[bigtable] make serialization backwards compatible

### DIFF
--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableMetricModule.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableMetricModule.java
@@ -27,7 +27,6 @@ import com.spotify.heroic.ExtraParameters;
 import com.spotify.heroic.common.DynamicModuleId;
 import com.spotify.heroic.common.Groups;
 import com.spotify.heroic.common.ModuleId;
-import com.spotify.heroic.common.Series;
 import com.spotify.heroic.dagger.PrimaryComponent;
 import com.spotify.heroic.lifecycle.LifeCycle;
 import com.spotify.heroic.lifecycle.LifeCycleManager;
@@ -41,7 +40,6 @@ import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.Managed;
 import eu.toolchain.async.ManagedSetup;
 import eu.toolchain.serializer.Serializer;
-import eu.toolchain.serializer.SerializerFramework;
 import lombok.Data;
 
 import javax.inject.Named;
@@ -154,10 +152,8 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
 
         @Provides
         @BigtableScope
-        public Serializer<RowKey> rowKeySerializer(
-            Serializer<Series> series, @Named("common") SerializerFramework s
-        ) {
-            return new RowKey_Serializer(s);
+        public Serializer<RowKey> rowKeySerializer() {
+           return new MetricsRowKeySerializer();
         }
 
         @Provides

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/CustomStringSerializer.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/CustomStringSerializer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.metric.bigtable;
+
+import eu.toolchain.serializer.SerialReader;
+import eu.toolchain.serializer.SerialWriter;
+import eu.toolchain.serializer.Serializer;
+import lombok.RequiredArgsConstructor;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+
+/**
+ * Custom string serializer to be backwards compatible with our previous serialization.
+ */
+@RequiredArgsConstructor
+public class CustomStringSerializer implements Serializer<String> {
+    private final Serializer<Integer> size;
+
+    private static final Charset UTF_8 = Charset.forName("utf8");
+
+    @Override
+    public void serialize(SerialWriter buffer, String value) throws IOException {
+        final CharsetEncoder encoder = UTF_8.newEncoder();
+        /* allocate a worst-case buffer */
+        final int worst = (int) (value.length() * encoder.maxBytesPerChar());
+        final ByteBuffer bytes = buffer.pool().allocate(worst);
+
+        try {
+            encoder.encode(CharBuffer.wrap(value), bytes, true);
+            bytes.flip();
+
+            this.size.serialize(buffer, bytes.remaining());
+            this.size.serialize(buffer, value.length());
+
+            buffer.write(bytes);
+        } finally {
+            buffer.pool().release(worst);
+        }
+    }
+
+    @Override
+    public String deserialize(SerialReader buffer) throws IOException {
+        final CharsetDecoder decoder = UTF_8.newDecoder();
+
+        final int length = this.size.deserialize(buffer);
+        final int size = this.size.deserialize(buffer);
+
+        final ByteBuffer bytes = buffer.pool().allocate(length);
+
+        try {
+            buffer.read(bytes);
+            bytes.flip();
+
+            final char[] chars = new char[size];
+            decoder.decode(bytes, CharBuffer.wrap(chars), true);
+            return new String(chars);
+        } finally {
+            buffer.pool().release(length);
+        }
+    }
+}

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/MetricsRowKeySerializer.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/MetricsRowKeySerializer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.metric.bigtable;
+
+import eu.toolchain.serializer.SerialReader;
+import eu.toolchain.serializer.SerialWriter;
+import eu.toolchain.serializer.Serializer;
+import eu.toolchain.serializer.SerializerFramework;
+import eu.toolchain.serializer.TinySerializer;
+
+import java.io.IOException;
+
+public class MetricsRowKeySerializer implements Serializer<RowKey> {
+    final SerializerFramework serializerFramework = TinySerializer
+        .builder()
+        .string(CustomStringSerializer::new)
+        .build();
+
+    final RowKey_Serializer serializer = new RowKey_Serializer(serializerFramework);
+
+    @Override
+    public void serialize(SerialWriter serialWriter, RowKey rowKey) throws IOException {
+        serializer.serialize(serialWriter, rowKey);
+    }
+
+    @Override
+    public RowKey deserialize(SerialReader serialReader) throws IOException {
+        return serializer.deserialize(serialReader);
+    }
+}

--- a/metric/bigtable/src/test/java/com/spotify/heroic/metric/bigtable/MetricsRowKeySerializerTest.java
+++ b/metric/bigtable/src/test/java/com/spotify/heroic/metric/bigtable/MetricsRowKeySerializerTest.java
@@ -1,0 +1,44 @@
+package com.spotify.heroic.metric.bigtable;
+
+import com.google.common.collect.ImmutableMap;
+import com.spotify.heroic.common.Series;
+import eu.toolchain.serializer.BytesSerialWriter;
+import eu.toolchain.serializer.SerialReader;
+import eu.toolchain.serializer.Serializer;
+import eu.toolchain.serializer.SerializerFramework;
+import eu.toolchain.serializer.TinySerializer;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+
+public class MetricsRowKeySerializerTest extends TestCase {
+    private Series series = Series.of("key", ImmutableMap.of("from", "123", "to", "4567"));
+
+    private static final String EXPECTED_SERIALIZATION =
+        "\u0003\u0003key" +
+        "\u0002\u0004\u0004from\u0003\u0003123" +
+        "\u0002\u0002to\u0004\u00044567" +
+        "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001";
+
+
+    private final SerializerFramework serializerFramework = TinySerializer.builder().build();
+    private final Serializer<RowKey> serializer = new MetricsRowKeySerializer();
+
+    public void testSerializationIsBackwardsCompatible() throws Exception {
+        final RowKey rowKey = new RowKey(series, 1);
+
+        final BytesSerialWriter serializedBytes = serializerFramework.writeBytes();
+        serializer.serialize(serializedBytes, rowKey);
+
+        Assert.assertArrayEquals(EXPECTED_SERIALIZATION.getBytes(), serializedBytes.toByteArray());
+    }
+
+    public void testDeserializationIsBackwardsCompatible() throws Exception {
+        final SerialReader serialReader =
+            serializerFramework.readByteArray(EXPECTED_SERIALIZATION.getBytes());
+
+        final RowKey rowKey = serializer.deserialize(serialReader);
+
+        assertEquals(rowKey, new RowKey(series, 1));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <semantic-metrics.version>0.2.3</semantic-metrics.version>
     <netty.version>4.1.0.CR3</netty.version>
     <tiny-async.version>1.8.0</tiny-async.version>
-    <tiny-serializer.version>1.4.4</tiny-serializer.version>
+    <tiny-serializer.version>1.4.5</tiny-serializer.version>
     <antlr.version>4.5</antlr.version>
     <log4j.version>2.2</log4j.version>
     <elasticsearch.version>1.7.5</elasticsearch.version>


### PR DESCRIPTION
- Upgrade tiny-serializer to 1.4.5 to configure string serialization
- Add custom string serializer to honour prevous serialization