### PR TITLE
[all] remove cadence hint in Aggregation

### DIFF
--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/AboveK.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/AboveK.java
@@ -27,8 +27,6 @@ import com.spotify.heroic.aggregation.Aggregation;
 import com.spotify.heroic.aggregation.AggregationContext;
 import lombok.Data;
 
-import java.util.Optional;
-
 @Data
 public class AboveK implements Aggregation {
     public static final String NAME = "abovek";
@@ -38,16 +36,6 @@ public class AboveK implements Aggregation {
     @JsonCreator
     public AboveK(@JsonProperty("k") double k) {
         this.k = k;
-    }
-
-    @Override
-    public Optional<Long> size() {
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<Long> extent() {
-        return Optional.empty();
     }
 
     @Override

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/BelowK.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/BelowK.java
@@ -27,8 +27,6 @@ import com.spotify.heroic.aggregation.Aggregation;
 import com.spotify.heroic.aggregation.AggregationContext;
 import lombok.Data;
 
-import java.util.Optional;
-
 @Data
 public class BelowK implements Aggregation {
     public static final String NAME = "belowk";
@@ -38,16 +36,6 @@ public class BelowK implements Aggregation {
     @JsonCreator
     public BelowK(@JsonProperty("k") double k) {
         this.k = k;
-    }
-
-    @Override
-    public Optional<Long> size() {
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<Long> extent() {
-        return Optional.empty();
     }
 
     @Override

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/BottomK.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/BottomK.java
@@ -27,8 +27,6 @@ import com.spotify.heroic.aggregation.Aggregation;
 import com.spotify.heroic.aggregation.AggregationContext;
 import lombok.Data;
 
-import java.util.Optional;
-
 @Data
 public class BottomK implements Aggregation {
     public static final String NAME = "bottomk";
@@ -38,16 +36,6 @@ public class BottomK implements Aggregation {
     @JsonCreator
     public BottomK(@JsonProperty("k") long k) {
         this.k = k;
-    }
-
-    @Override
-    public Optional<Long> size() {
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<Long> extent() {
-        return Optional.empty();
     }
 
     @Override

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/TopK.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/TopK.java
@@ -27,8 +27,6 @@ import com.spotify.heroic.aggregation.Aggregation;
 import com.spotify.heroic.aggregation.AggregationContext;
 import lombok.Data;
 
-import java.util.Optional;
-
 @Data
 public class TopK implements Aggregation {
     public static final String NAME = "topk";
@@ -38,16 +36,6 @@ public class TopK implements Aggregation {
     @JsonCreator
     public TopK(@JsonProperty("k") long k) {
         this.k = k;
-    }
-
-    @Override
-    public Optional<Long> size() {
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<Long> extent() {
-        return Optional.empty();
     }
 
     @Override

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/Aggregation.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/Aggregation.java
@@ -21,7 +21,6 @@
 
 package com.spotify.heroic.aggregation;
 
-import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -38,21 +37,4 @@ import java.util.function.Function;
  * @see AggregationInstance
  */
 public interface Aggregation extends Function<AggregationContext, AggregationInstance> {
-    /**
-     * Get the size of the aggregation.
-     * <p>
-     * The size is the space of time between subsequent samples.
-     *
-     * @return The size if available, otherwise an empty result.
-     */
-    Optional<Long> size();
-
-    /**
-     * Get the extent of the aggregation.
-     * <p>
-     * The extent is the space of time in milliseconds that an aggregation takes samples.
-     *
-     * @return The extent if available, otherwise an empty result.
-     */
-    Optional<Long> extent();
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/Chain.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/Chain.java
@@ -53,19 +53,6 @@ public class Chain implements Aggregation {
     }
 
     @Override
-    public Optional<Long> size() {
-        return chain.get(chain.size() - 1).size();
-    }
-
-    /**
-     * The first aggregation in the chain determines the extent.
-     */
-    @Override
-    public Optional<Long> extent() {
-        return chain.iterator().next().extent();
-    }
-
-    @Override
     public AggregationInstance apply(final AggregationContext context) {
         ListIterator<Aggregation> it = chain.listIterator(chain.size());
 

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/Collapse.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/Collapse.java
@@ -47,16 +47,6 @@ public class Collapse implements Aggregation {
     }
 
     @Override
-    public Optional<Long> size() {
-        return each.flatMap(Aggregation::size);
-    }
-
-    @Override
-    public Optional<Long> extent() {
-        return each.flatMap(Aggregation::extent);
-    }
-
-    @Override
     public CollapseInstance apply(final AggregationContext context) {
         final AggregationInstance instance = each.orElse(Empty.INSTANCE).apply(context);
 

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/Empty.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/Empty.java
@@ -24,8 +24,6 @@ package com.spotify.heroic.aggregation;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Data;
 
-import java.util.Optional;
-
 @Data
 public class Empty implements Aggregation {
     public static final String NAME = "empty";
@@ -34,16 +32,6 @@ public class Empty implements Aggregation {
 
     @JsonCreator
     public Empty() {
-    }
-
-    @Override
-    public Optional<Long> size() {
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<Long> extent() {
-        return Optional.empty();
     }
 
     @Override

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/Group.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/Group.java
@@ -54,16 +54,6 @@ public class Group implements Aggregation {
     }
 
     @Override
-    public Optional<Long> size() {
-        return each.flatMap(Aggregation::size);
-    }
-
-    @Override
-    public Optional<Long> extent() {
-        return each.flatMap(Aggregation::extent);
-    }
-
-    @Override
     public GroupInstance apply(final AggregationContext context) {
         final AggregationInstance instance = each.orElse(Empty.INSTANCE).apply(context);
 

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/Options.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/Options.java
@@ -23,13 +23,10 @@ package com.spotify.heroic.aggregation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.spotify.heroic.common.Duration;
 import lombok.Data;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-
-import static com.spotify.heroic.common.Optionals.firstPresent;
 
 @Data
 public class Options implements Aggregation {
@@ -47,18 +44,6 @@ public class Options implements Aggregation {
     ) {
         this.sampling = sampling;
         this.aggregation = aggregation;
-    }
-
-    @Override
-    public Optional<Long> size() {
-        return firstPresent(aggregation.flatMap(Aggregation::size),
-            sampling.flatMap(SamplingQuery::getSize).map(Duration::toMilliseconds));
-    }
-
-    @Override
-    public Optional<Long> extent() {
-        return firstPresent(aggregation.flatMap(Aggregation::extent),
-            sampling.flatMap(SamplingQuery::getExtent).map(Duration::toMilliseconds));
     }
 
     @Override

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/SamplingAggregation.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/SamplingAggregation.java
@@ -44,16 +44,6 @@ public abstract class SamplingAggregation implements Aggregation {
         return apply(context, s.convert(TimeUnit.MILLISECONDS), e.convert(TimeUnit.MILLISECONDS));
     }
 
-    @Override
-    public Optional<Long> size() {
-        return size.map(Duration::toMilliseconds);
-    }
-
-    @Override
-    public Optional<Long> extent() {
-        return extent.map(Duration::toMilliseconds);
-    }
-
     protected abstract AggregationInstance apply(
         AggregationContext context, long size, long extent
     );


### PR DESCRIPTION
This simplifies the Aggregation interface by removing the initial cadence hint.

This hint is not necessary since the final cadence can be extracted from the
`AggregationInstance` which takes the initial range-based cadence into account
as a hint.

This does slightly change the behavior of queries which specifies no resolution in part of their aggregations, 

This does slightly change the behaviour of queries like: `sum(10m) | average`, after this change average will use the resolution derived from the range, rather than the previous aggregation. I believe this behaviour is more expected.