### PR TITLE
HeroicShell should return exit code 1 in case of errors

### DIFF
--- a/heroic-shell/src/main/java/com/spotify/heroic/HeroicShell.java
+++ b/heroic-shell/src/main/java/com/spotify/heroic/HeroicShell.java
@@ -112,8 +112,12 @@ public class HeroicShell {
                 System.exit(1);
                 return;
             }
-
-            interactive(params, bridge);
+            try {
+                interactive(params, bridge);
+            } catch (Exception e) {
+                log.error("Error when running shell", e);
+                System.exit(1);
+            }
             System.exit(0);
             return;
         }
@@ -175,21 +179,28 @@ public class HeroicShell {
         });
     }
 
-    static void interactive(Parameters params, CoreInterface core) {
+    static void interactive(Parameters params, CoreInterface core) throws Exception {
         log.info("Setting up interactive shell...");
 
+        Exception e = null;
         try {
             runInteractiveShell(core);
-        } catch (Exception e) {
-            log.error("Error when running shell", e);
+        } catch (final Exception inner) {
+            e = inner;
         }
 
         log.info("Closing core bridge...");
 
         try {
             core.shutdown();
-        } catch (Exception e) {
-            log.error("Failed to close core bridge", e);
+        } catch (final Exception inner) {
+            if (e != null) {
+                inner.addSuppressed(e);
+            }
+            e = inner;
+        }
+        if (e != null) {
+            throw e;
         }
     }
 


### PR DESCRIPTION
This addresses the problem referenced in #70 .  Please let me know if you have any questions or suggestions.  

Note: I enclosed `core.shutdown()` within a `finally` block to ensure it always runs as it currently does.   That method is currently empty but I assume that its functionality will be implemented.  
