### PR TITLE
fix links to idea/eclipse directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ $ env DH_VERBOSE=1 dpkg-buildpackage -uc -us
 ## Hacking
 
 * [A Guide to Dagger 2](docs/guide-to-dagger2.md)
-* [Using IDEA](idea)
-* [Using Eclipse](eclipse)
+* [Using IDEA](idea/README.md)
+* [Using Eclipse](eclipse/README.md)
 
 #### Module Orientation
 


### PR DESCRIPTION
When viewing https://github.com/spotify/heroic, Github renders the links
to `idea` and `eclipse` as links to `https://github.com/spotify/idea`
etc. Fix this by linking to the README instead.