### PR TITLE
[parser] relax SimpleString and fix precedence (fixes #76)

### DIFF
--- a/heroic-parser/src/main/antlr4/com/spotify/heroic/grammar/HeroicQuery.g4
+++ b/heroic-parser/src/main/antlr4/com/spotify/heroic/grammar/HeroicQuery.g4
@@ -188,11 +188,6 @@ QuotedString : '"' StringCharacters? '"' ;
 
 Identifier : [a-zA-Z] [a-zA-Z0-9]* ;
 
-// strings that do not have to be quoted
-SimpleString
-    : [a-zA-Z] [a-zA-Z0-9:/_\-\.]*
-    ;
-
 Duration
     : Minus? Integer Unit
     ;
@@ -204,6 +199,11 @@ Integer
 Float
     : Minus? Digits '.' Digits?
     | Minus? '.' Digits
+    ;
+
+// strings that do not have to be quoted
+SimpleString
+    : [a-zA-Z0-9:/_\-\.]+
     ;
 
 fragment

--- a/heroic-parser/src/test/java/com/spotify/heroic/grammar/QueryParserTest.java
+++ b/heroic-parser/src/test/java/com/spotify/heroic/grammar/QueryParserTest.java
@@ -51,6 +51,7 @@ public class QueryParserTest {
         assertEquals(string(cols(0, 2), "foo"), parseExpression("foo"));
         assertEquals(string(cols(0, 4), "foo"), parseExpression("\"foo\""));
         assertEquals(string(cols(0, 2), "\u4040"), parseExpression("\"\u4040\""));
+        assertEquals(string(cols(0, 1), "1a"), parseExpression("1a"));
 
         // test all possible escape sequences
         assertEquals(string(cols(0, 17), "\b\t\n\f\r\"\'\\"),


### PR DESCRIPTION
This changes the precedence of the `SimpleString` lexer rule to happen after
`Integer`, `Float`, and `Duration`.

It also allows `SimpleString` to start with a numeric component, but because of
the change in precedence the above will match before if applicable.

This allows the following expression to work (as referenced in #76):
```
$key = 4cf41d4b-a5d2-420e-b008-644f0b3d7832
```