### PR TITLE
[component,core] enable shift_range by default and allow disabling of features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - tools/install-repackaged
 
 script:
-  - mvn -nsu -T 1.5C -D environment=test -P '!findbugs' verify
+  - mvn -nsu -T 2 -D environment=test -P '!findbugs,codecov' verify
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/heroic-component/src/main/java/com/spotify/heroic/Query.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/Query.java
@@ -22,7 +22,7 @@
 package com.spotify.heroic;
 
 import com.spotify.heroic.aggregation.Aggregation;
-import com.spotify.heroic.common.Features;
+import com.spotify.heroic.common.FeatureSet;
 import com.spotify.heroic.filter.Filter;
 import com.spotify.heroic.metric.MetricType;
 import lombok.Data;
@@ -37,5 +37,5 @@ public class Query {
     private final Optional<Filter> filter;
     private final Optional<QueryOptions> options;
     /* set of experimental features to enable */
-    private final Optional<Features> features;
+    private final Optional<FeatureSet> features;
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/QueryBuilder.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/QueryBuilder.java
@@ -23,7 +23,7 @@ package com.spotify.heroic;
 
 import com.spotify.heroic.aggregation.Aggregation;
 import com.spotify.heroic.aggregation.Group;
-import com.spotify.heroic.common.Features;
+import com.spotify.heroic.common.FeatureSet;
 import com.spotify.heroic.filter.AndFilter;
 import com.spotify.heroic.filter.Filter;
 import com.spotify.heroic.filter.MatchKeyFilter;
@@ -49,7 +49,7 @@ public class QueryBuilder {
     private Optional<QueryDateRange> range = Optional.empty();
     private Optional<Aggregation> aggregation = Optional.empty();
     private Optional<QueryOptions> options = Optional.empty();
-    private Optional<Features> features = Optional.empty();
+    private Optional<FeatureSet> features = Optional.empty();
 
     /**
      * Specify a set of tags that has to match.
@@ -141,9 +141,9 @@ public class QueryBuilder {
         return this;
     }
 
-    public QueryBuilder features(final Features features) {
+    public QueryBuilder features(final Optional<FeatureSet> features) {
         checkNotNull(features, "features");
-        this.features = Optional.of(features);
+        this.features = features;
         return this;
     }
 

--- a/heroic-component/src/main/java/com/spotify/heroic/common/Feature.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/Feature.java
@@ -26,6 +26,10 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Features that can be enabled in configuration, or per-query.
+ *
+ * Features should be formulated so that they are enabled when they are present, not the other way
+ * around which would be something like {@code DISABLE_SHIFT_RANGE}.
+ * Supporting such duality for every feature would cause more code and add to confusion.
  */
 public enum Feature {
     /**

--- a/heroic-component/src/main/java/com/spotify/heroic/common/FeatureSet.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/FeatureSet.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableSet;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A set of enabled and disabled features.
+ */
+@Data
+public class FeatureSet {
+    private final Set<Feature> enabled;
+    private final Set<Feature> disabled;
+
+    @JsonCreator
+    public static FeatureSet create(final Set<String> features) {
+        final ImmutableSet.Builder<Feature> enabled = ImmutableSet.builder();
+        final ImmutableSet.Builder<Feature> disabled = ImmutableSet.builder();
+
+        for (final String feature : features) {
+            if (feature.startsWith("-")) {
+                disabled.add(Feature.create(feature.substring(1)));
+            } else {
+                enabled.add(Feature.create(feature));
+            }
+        }
+
+        return new FeatureSet(enabled.build(), disabled.build());
+    }
+
+    @JsonValue
+    public List<String> value() {
+        final List<String> features = new ArrayList<>();
+
+        for (final Feature feature : enabled) {
+            features.add(feature.id());
+        }
+
+        for (final Feature feature : disabled) {
+            features.add("-" + feature.id());
+        }
+
+        return features;
+    }
+
+    /**
+     * Combine this feature set with another.
+     *
+     * @param other Other set to combine with.
+     * @return a new feature set.
+     */
+    public FeatureSet combine(final FeatureSet other) {
+        final Set<Feature> enabled = new HashSet<>(this.enabled);
+        enabled.addAll(other.enabled);
+
+        final Set<Feature> disabled = new HashSet<>(this.disabled);
+        disabled.addAll(other.disabled);
+
+        return new FeatureSet(enabled, disabled);
+    }
+
+    /**
+     * Create an empty feature set.
+     *
+     * @return a new feature set.
+     */
+    public static FeatureSet empty() {
+        return new FeatureSet(ImmutableSet.of(), ImmutableSet.of());
+    }
+
+    /**
+     * Create a new feature set with the given features enabled.
+     *
+     * @param features Features to enable in the new set.
+     * @return a new feature set.
+     */
+    public static FeatureSet of(final Feature... features) {
+        return new FeatureSet(ImmutableSet.copyOf(features), ImmutableSet.of());
+    }
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/common/Features.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/Features.java
@@ -26,20 +26,39 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableSet;
 import lombok.Data;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Supplier;
 
+/**
+ * A container for a set of features that provides convenience methods for accessing them.
+ */
 @Data
 public class Features {
+    /**
+     * Default set of features.
+     */
+    public static final Features DEFAULT = Features.create(ImmutableSet.<Feature>builder()
+        .add(Feature.SHIFT_RANGE)
+        .build());
+
     private final Set<Feature> features;
 
     public boolean hasFeature(final Feature feature) {
         return features.contains(feature);
     }
 
-    public Features combine(final Features other) {
-        return new Features(
-            ImmutableSet.<Feature>builder().addAll(features).addAll(other.features).build());
+    /**
+     * Apply the given feature set.
+     *
+     * @param featureSet Feature set to apply.
+     * @return A new Feature with the given set applied.
+     */
+    public Features applySet(final FeatureSet featureSet) {
+        final Set<Feature> features = new HashSet<>(this.features);
+        features.addAll(featureSet.getEnabled());
+        features.removeAll(featureSet.getDisabled());
+        return new Features(features);
     }
 
     @JsonCreator
@@ -50,14 +69,6 @@ public class Features {
     @JsonValue
     public Set<Feature> value() {
         return features;
-    }
-
-    public static Features of(final Feature... features) {
-        return new Features(ImmutableSet.copyOf(features));
-    }
-
-    public static Features empty() {
-        return new Features(ImmutableSet.of());
     }
 
     /**
@@ -73,5 +84,18 @@ public class Features {
         final Feature feature, final Supplier<T> isSet, final Supplier<T> isNotSet
     ) {
         return hasFeature(feature) ? isSet.get() : isNotSet.get();
+    }
+
+    /**
+     * Create an empty set of enabled features.
+     *
+     * @return A new feature set.
+     */
+    public static Features empty() {
+        return new Features(ImmutableSet.of());
+    }
+
+    public static Features of(final Feature... features) {
+        return new Features(ImmutableSet.copyOf(features));
     }
 }

--- a/heroic-component/src/test/java/com/spotify/heroic/common/FeatureSetTest.java
+++ b/heroic-component/src/test/java/com/spotify/heroic/common/FeatureSetTest.java
@@ -1,0 +1,51 @@
+package com.spotify.heroic.common;
+
+import com.google.common.collect.ImmutableSet;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FeatureSetTest {
+    private final ObjectMapper m = new ObjectMapper();
+
+    @Test
+    public void of() {
+        assertEquals(
+            new FeatureSet(ImmutableSet.of(Feature.DISTRIBUTED_AGGREGATIONS), ImmutableSet.of()),
+            FeatureSet.of(Feature.DISTRIBUTED_AGGREGATIONS));
+    }
+
+    @Test
+    public void empty() {
+        assertEquals(new FeatureSet(ImmutableSet.of(), ImmutableSet.of()), FeatureSet.empty());
+    }
+
+    @Test
+    public void applySetTest() {
+        final FeatureSet s1 =
+            new FeatureSet(ImmutableSet.of(Feature.DISTRIBUTED_AGGREGATIONS), ImmutableSet.of());
+
+        final FeatureSet s2 = new FeatureSet(ImmutableSet.of(Feature.SHIFT_RANGE),
+            ImmutableSet.of(Feature.DISTRIBUTED_AGGREGATIONS));
+
+        assertEquals(Features.of(Feature.DISTRIBUTED_AGGREGATIONS), Features.empty().applySet(s1));
+        assertEquals(Features.of(Feature.SHIFT_RANGE), Features.empty().applySet(s1).applySet(s2));
+        assertEquals(
+            new FeatureSet(ImmutableSet.of(Feature.SHIFT_RANGE, Feature.DISTRIBUTED_AGGREGATIONS),
+                ImmutableSet.of(Feature.DISTRIBUTED_AGGREGATIONS)), s1.combine(s2));
+    }
+
+    @Test
+    public void serializationTest() throws Exception {
+        final FeatureSet f = new FeatureSet(ImmutableSet.of(Feature.DISTRIBUTED_AGGREGATIONS),
+            ImmutableSet.of(Feature.SHIFT_RANGE));
+        final String ref = "[" + "\"com.spotify.heroic.distributed_aggregations\"," +
+            "\"-com.spotify.heroic.shift_range\"" + "]";
+
+        assertEquals(ref, m.writeValueAsString(f));
+        assertEquals(f, m.readValue(ref, FeatureSet.class));
+    }
+}

--- a/heroic-component/src/test/java/com/spotify/heroic/common/FeaturesTest.java
+++ b/heroic-component/src/test/java/com/spotify/heroic/common/FeaturesTest.java
@@ -1,25 +1,19 @@
 package com.spotify.heroic.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class FeaturesTest {
     private final ObjectMapper m = new ObjectMapper();
 
     @Test
-    public void basicTest() throws Exception {
-        final Features f1 = Features.of(Feature.DISTRIBUTED_AGGREGATIONS);
-        final Features f2 = Features.of(Feature.DISTRIBUTED_AGGREGATIONS);
-        assertEquals(f1, f1.combine(f2));
-        assertTrue(f1.hasFeature(Feature.DISTRIBUTED_AGGREGATIONS));
-    }
-
-    @Test
     public void serializationTest() throws Exception {
-        final Features f1 = Features.of(Feature.DISTRIBUTED_AGGREGATIONS);
+        final Features f1 = new Features(ImmutableSet.of(Feature.DISTRIBUTED_AGGREGATIONS));
         final String ref = "[\"com.spotify.heroic.distributed_aggregations\"]";
 
         assertEquals(ref, m.writeValueAsString(f1));

--- a/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
@@ -36,6 +36,7 @@ import com.spotify.heroic.cluster.ClusterShard;
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Duration;
 import com.spotify.heroic.common.Feature;
+import com.spotify.heroic.common.FeatureSet;
 import com.spotify.heroic.common.Features;
 import com.spotify.heroic.common.OptionalLimit;
 import com.spotify.heroic.filter.Filter;
@@ -193,10 +194,8 @@ public class CoreQueryManager implements QueryManager {
 
             final AggregationInstance aggregationInstance;
 
-            final Features features = q
-                .getFeatures()
-                .map(CoreQueryManager.this.features::combine)
-                .orElse(CoreQueryManager.this.features);
+            final Features features = CoreQueryManager.this.features
+                .applySet(q.getFeatures().orElseGet(FeatureSet::empty));
 
             boolean isDistributed = features.hasFeature(Feature.DISTRIBUTED_AGGREGATIONS);
 

--- a/heroic-core/src/main/java/com/spotify/heroic/HeroicConfig.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/HeroicConfig.java
@@ -33,7 +33,7 @@ import com.spotify.heroic.cache.CacheModule;
 import com.spotify.heroic.cache.noop.NoopCacheModule;
 import com.spotify.heroic.cluster.ClusterManagerModule;
 import com.spotify.heroic.common.Duration;
-import com.spotify.heroic.common.Features;
+import com.spotify.heroic.common.FeatureSet;
 import com.spotify.heroic.consumer.ConsumerModule;
 import com.spotify.heroic.generator.CoreGeneratorModule;
 import com.spotify.heroic.ingestion.IngestionModule;
@@ -100,7 +100,7 @@ public class HeroicConfig {
     private final Optional<Boolean> disableMetrics;
     private final boolean enableCors;
     private final Optional<String> corsAllowOrigin;
-    private final Features features;
+    private final FeatureSet features;
     private final ClusterManagerModule cluster;
     private final MetricManagerModule metric;
     private final MetadataManagerModule metadata;
@@ -179,7 +179,7 @@ public class HeroicConfig {
         private Optional<Boolean> disableMetrics = empty();
         private Optional<Boolean> enableCors = empty();
         private Optional<String> corsAllowOrigin = empty();
-        private Optional<Features> features = empty();
+        private Optional<FeatureSet> features = empty();
         private Optional<ClusterManagerModule.Builder> cluster = empty();
         private Optional<MetricManagerModule.Builder> metrics = empty();
         private Optional<MetadataManagerModule.Builder> metadata = empty();
@@ -225,7 +225,7 @@ public class HeroicConfig {
             return this;
         }
 
-        public Builder features(Features features) {
+        public Builder features(FeatureSet features) {
             this.features = of(features);
             return this;
         }
@@ -293,7 +293,7 @@ public class HeroicConfig {
                 pickOptional(disableMetrics, o.disableMetrics),
                 pickOptional(enableCors, o.enableCors),
                 pickOptional(corsAllowOrigin, o.corsAllowOrigin),
-                mergeOptional(features, o.features, Features::combine),
+                mergeOptional(features, o.features, FeatureSet::combine),
                 mergeOptional(cluster, o.cluster, ClusterManagerModule.Builder::merge),
                 mergeOptional(metrics, o.metrics, MetricManagerModule.Builder::merge),
                 mergeOptional(metadata, o.metadata, MetadataManagerModule.Builder::merge),
@@ -331,7 +331,7 @@ public class HeroicConfig {
                 disableMetrics,
                 enableCors.orElse(DEFAULT_ENABLE_CORS),
                 corsAllowOrigin,
-                features.orElseGet(Features::empty),
+                features.orElseGet(FeatureSet::empty),
                 cluster.orElseGet(ClusterManagerModule::builder).build(),
                 metrics.orElseGet(MetricManagerModule::builder).build(),
                 metadata.orElseGet(MetadataManagerModule::builder).build(),

--- a/heroic-core/src/main/java/com/spotify/heroic/dagger/PrimaryModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/dagger/PrimaryModule.java
@@ -32,6 +32,7 @@ import com.spotify.heroic.HeroicMappers;
 import com.spotify.heroic.QueryManager;
 import com.spotify.heroic.ShellTasks;
 import com.spotify.heroic.aggregation.AggregationRegistry;
+import com.spotify.heroic.common.FeatureSet;
 import com.spotify.heroic.common.Features;
 import com.spotify.heroic.grammar.CoreQueryParser;
 import com.spotify.heroic.grammar.QueryParser;
@@ -55,7 +56,7 @@ import java.util.TreeMap;
 @Module
 public class PrimaryModule {
     private final HeroicCoreInstance instance;
-    private final Features features;
+    private final FeatureSet features;
     private final HeroicReporter reporter;
 
     @Provides
@@ -92,7 +93,7 @@ public class PrimaryModule {
     @Named("features")
     @PrimaryScope
     Features features() {
-        return features;
+        return Features.DEFAULT.applySet(features);
     }
 
     @Provides

--- a/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryMetrics.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryMetrics.java
@@ -28,7 +28,7 @@ import com.spotify.heroic.QueryDateRange;
 import com.spotify.heroic.QueryOptions;
 import com.spotify.heroic.aggregation.Aggregation;
 import com.spotify.heroic.aggregation.Chain;
-import com.spotify.heroic.common.Features;
+import com.spotify.heroic.common.FeatureSet;
 import com.spotify.heroic.filter.Filter;
 import com.spotify.heroic.metric.MetricType;
 import lombok.Data;
@@ -54,7 +54,7 @@ public class QueryMetrics {
     private final Optional<String> key;
     private final Optional<Map<String, String>> tags;
     private final Optional<List<String>> groupBy;
-    private final Features features;
+    private final Optional<FeatureSet> features;
 
     public QueryMetrics(
         Optional<String> query, Optional<Aggregation> aggregation, Optional<MetricType> source,
@@ -70,7 +70,7 @@ public class QueryMetrics {
         this.key = Optional.empty();
         this.tags = Optional.empty();
         this.groupBy = Optional.empty();
-        this.features = Features.empty();
+        this.features = Optional.empty();
     }
 
     @JsonCreator
@@ -84,7 +84,7 @@ public class QueryMetrics {
         @JsonProperty("tags") Optional<Map<String, String>> tags,
         @JsonProperty("groupBy") Optional<List<String>> groupBy,
         @JsonProperty("options") Optional<QueryOptions> options,
-        @JsonProperty("features") Optional<Features> features,
+        @JsonProperty("features") Optional<FeatureSet> features,
         /* ignored */ @JsonProperty("noCache") Boolean noCache
     ) {
         this.query = query;
@@ -98,7 +98,7 @@ public class QueryMetrics {
         this.key = key;
         this.tags = tags;
         this.groupBy = groupBy;
-        this.features = features.orElseGet(Features::empty);
+        this.features = features;
     }
 
     public QueryBuilder toQueryBuilder(final Function<String, QueryBuilder> stringToQuery) {

--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
@@ -3,8 +3,9 @@ package com.spotify.heroic;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+
 import com.spotify.heroic.common.Feature;
-import com.spotify.heroic.common.Features;
+import com.spotify.heroic.common.FeatureSet;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.dagger.CoreComponent;
 import com.spotify.heroic.ingestion.Ingestion;
@@ -14,7 +15,9 @@ import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.MetricType;
 import com.spotify.heroic.metric.QueryResult;
 import com.spotify.heroic.metric.ShardedResultGroup;
+
 import eu.toolchain.async.AsyncFuture;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -72,7 +75,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
     public QueryResult query(final String queryString) throws Exception {
         final Query q = query
             .newQueryFromString(queryString)
-            .features(Features.of(Feature.DISTRIBUTED_AGGREGATIONS))
+            .features(Optional.of(FeatureSet.of(Feature.DISTRIBUTED_AGGREGATIONS)))
             .source(Optional.of(MetricType.POINT))
             .rangeIfAbsent(Optional.of(new QueryDateRange.Absolute(10, 40)))
             .build();

--- a/pom.xml
+++ b/pom.xml
@@ -73,13 +73,6 @@
     <profile>
       <id>codecov</id>
 
-      <activation>
-        <property>
-          <name>environment</name>
-          <value>test</value>
-        </property>
-      </activation>
-
       <modules>
         <module>reporting</module>
       </modules>


### PR DESCRIPTION
Enable `shift_range` by default.

Add a `disabled` field to query and configuration which will cause the specified feature to be disabled for that query.

Clarify that features should be named to be enabled (not disabled) to avoid future complexity.

This could also be implemented so that the set of features is specified using operators as prefix, like:

Features are applied in the following order:

`(((default_features + configuration_features) - configuration_disabled) + query_features) - query_disabled`

`+` being joining two sets and `-` means subtracting the right hand side set from the left hand side.

#### Query

```javascript
{
  /* query */,
  "features": [
    "com.spotify.heroic.bar"
  ],
  "disabled": [
    "com.spotify.heroic.baz"
  ]
}
```

#### Configuration

```yaml
features:
  - com.spotify.heroic.bar

disabled:
  - com.spotify.heroic.baz
```