### PR TITLE
[dist] skip shading when environment=test

### DIFF
--- a/heroic-dist/pom.xml
+++ b/heroic-dist/pom.xml
@@ -70,14 +70,29 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-      </plugin>
-    </plugins>
+  <profiles>
+    <profile>
+      <id>shade</id>
 
+      <activation>
+        <property>
+          <name>environment</name>
+          <value>!test</value>
+        </property>
+      </activation>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+  <build>
     <resources>
       <resource>
         <directory>src/main/resources</directory>


### PR DESCRIPTION
This will disable shading for `dist` when `environment=test` is specified which is specifically designed for running all available test suites, and shading should be an unnecessary step.

This will not affect regular packaging builds (`mvn clean package`).

This build should give an indication how how faster testing will be without this step.