### PR TITLE
[core,dist] implement integration tests for tasks

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/ParseQuery.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/ParseQuery.java
@@ -37,7 +37,6 @@ import com.spotify.heroic.shell.TaskUsage;
 import dagger.Component;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.ToString;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.Option;
 
@@ -88,12 +87,11 @@ public class ParseQuery implements ShellTask {
         return async.resolved();
     }
 
-    @ToString
     private static class Parameters extends AbstractShellTaskParams {
         @Option(name = "--no-indent", usage = "Do not indent output")
         private boolean noIndent = false;
 
-        @Option(name = "-e", aliases = {"--eval"}, usage = "Evaluate output")
+        @Option(name = "-e", aliases = "--eval", usage = "Evaluate output")
         private boolean eval = false;
 
         @Argument(usage = "Query to parse")
@@ -105,7 +103,7 @@ public class ParseQuery implements ShellTask {
     }
 
     @Component(dependencies = CoreComponent.class)
-    static interface C {
+    interface C {
         ParseQuery task();
     }
 }

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/Pause.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/Pause.java
@@ -33,8 +33,6 @@ import com.spotify.heroic.shell.TaskUsage;
 import dagger.Component;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.Getter;
-import lombok.ToString;
 import org.kohsuke.args4j.Option;
 
 import javax.inject.Inject;
@@ -74,10 +72,8 @@ public class Pause implements ShellTask {
         return async.collectAndDiscard(futures.build());
     }
 
-    @ToString
     private static class Parameters extends AbstractShellTaskParams {
         @Option(name = "--skip-consumers", usage = "Do not pause consumers")
-        @Getter
         private boolean skipConsumers = false;
     }
 
@@ -86,7 +82,7 @@ public class Pause implements ShellTask {
     }
 
     @Component(dependencies = CoreComponent.class)
-    static interface C {
+    interface C {
         Pause task();
     }
 }

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/TestPrint.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/TestPrint.java
@@ -31,8 +31,6 @@ import com.spotify.heroic.shell.TaskUsage;
 import dagger.Component;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.Getter;
-import lombok.ToString;
 import org.kohsuke.args4j.Option;
 
 import javax.inject.Inject;
@@ -63,10 +61,8 @@ public class TestPrint implements ShellTask {
         return async.resolved();
     }
 
-    @ToString
     private static class Parameters extends AbstractShellTaskParams {
         @Option(name = "--count", usage = "Number of lines to print")
-        @Getter
         private long count = 10000;
     }
 

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/TestReadFile.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/TestReadFile.java
@@ -32,8 +32,6 @@ import com.spotify.heroic.shell.TaskUsage;
 import dagger.Component;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.Getter;
-import lombok.ToString;
 import org.kohsuke.args4j.Option;
 
 import javax.inject.Inject;
@@ -82,10 +80,8 @@ public class TestReadFile implements ShellTask {
         return async.resolved();
     }
 
-    @ToString
     private static class Parameters extends AbstractShellTaskParams {
         @Option(name = "-i", usage = "File to read from")
-        @Getter
         private Path in = Paths.get("in.txt");
     }
 

--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractLocalClusterIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractLocalClusterIT.java
@@ -1,17 +1,10 @@
 package com.spotify.heroic;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.spotify.heroic.cluster.ClusterManagerModule;
 import com.spotify.heroic.cluster.discovery.simple.StaticListDiscoveryModule;
-import com.spotify.heroic.common.Feature;
-import com.spotify.heroic.common.Features;
-import com.spotify.heroic.common.Series;
-import com.spotify.heroic.ingestion.Ingestion;
-import com.spotify.heroic.ingestion.IngestionComponent;
-import com.spotify.heroic.ingestion.IngestionManager;
-import com.spotify.heroic.metric.MetricType;
-import com.spotify.heroic.metric.QueryResult;
 import com.spotify.heroic.profile.MemoryProfile;
 import com.spotify.heroic.rpc.jvm.JvmRpcContext;
 import com.spotify.heroic.rpc.jvm.JvmRpcProtocolModule;
@@ -22,7 +15,6 @@ import org.junit.Before;
 
 import java.net.URI;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -31,22 +23,38 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 
 public abstract class AbstractLocalClusterIT {
-    protected final Series s1 = Series.of("key1", ImmutableMap.of("shared", "a", "diff", "a"));
-    protected final Series s2 = Series.of("key1", ImmutableMap.of("shared", "a", "diff", "b"));
-
     protected final ExecutorService executor = Executors.newSingleThreadExecutor();
-
     protected final TinyAsync async = TinyAsync.builder().executor(executor).build();
 
     protected List<HeroicCoreInstance> instances;
 
-    protected QueryManager query;
+    /**
+     * Override to configure more than one instance.
+     * <p>
+     * These will be available in the {@link #instances} field.
+     *
+     * @return a list of URIs.
+     */
+    protected List<URI> instanceUris() {
+        return ImmutableList.of(URI.create("jvm://a"), URI.create("jvm://b"));
+    }
+
+    /**
+     * Prepare the environment before the test.
+     * <p>
+     * {@link #instances} have been configured before this is called and can be safely used.
+     *
+     * @return a future that indicates that the environment is ready.
+     */
+    protected AsyncFuture<Void> prepareEnvironment() {
+        return async.resolved(null);
+    }
 
     @Before
     public final void abstractSetup() throws Exception {
         final JvmRpcContext context = new JvmRpcContext();
 
-        final List<URI> uris = ImmutableList.of(URI.create("jvm://a"), URI.create("jvm://b"));
+        final List<URI> uris = instanceUris();
         final List<Integer> expectedNumberOfNodes =
             uris.stream().map(u -> uris.size()).collect(Collectors.toList());
 
@@ -63,7 +71,7 @@ public abstract class AbstractLocalClusterIT {
                 .map(c -> c.inject(inj -> inj.clusterManager().refresh()))
                 .collect(Collectors.toList())));
 
-        final AsyncFuture<Void> verify = refresh.lazyTransform(v -> {
+        refresh.lazyTransform(v -> {
             // verify that the correct number of nodes are visible from all instances.
             final List<Integer> actualNumberOfNodes = instances
                 .stream()
@@ -71,25 +79,9 @@ public abstract class AbstractLocalClusterIT {
                 .collect(Collectors.toList());
 
             assertEquals(expectedNumberOfNodes, actualNumberOfNodes);
-
-            final List<IngestionManager> ingestion = instances
-                .stream()
-                .map(i -> i.inject(IngestionComponent::ingestionManager))
-                .collect(Collectors.toList());
-
-            final List<AsyncFuture<Ingestion>> writes = setupWrites(ingestion);
-
-            return async.collectAndDiscard(writes);
-        });
-
-        query = verify
-            .directTransform(v -> instances.get(0).inject(QueryComponent::queryManager))
-            .get(10, TimeUnit.SECONDS);
+            return prepareEnvironment();
+        }).get(10, TimeUnit.SECONDS);
     }
-
-    protected abstract List<AsyncFuture<Ingestion>> setupWrites(
-        final List<IngestionManager> ingestion
-    );
 
     @After
     public final void abstractTeardown() throws Exception {
@@ -99,43 +91,38 @@ public abstract class AbstractLocalClusterIT {
             .get(10, TimeUnit.SECONDS);
     }
 
-    public QueryResult query(final String queryString) throws Exception {
-        final Query q = query
-            .newQueryFromString(queryString)
-            .features(Features.of(Feature.DISTRIBUTED_AGGREGATIONS))
-            .source(Optional.of(MetricType.POINT))
-            .rangeIfAbsent(Optional.of(new QueryDateRange.Absolute(10, 40)))
-            .build();
-
-        return query.useDefaultGroup().query(q).get();
-    }
-
     private HeroicCoreInstance setupCore(
         final URI uri, final List<URI> uris, final JvmRpcContext context
     ) {
         try {
-            final JvmRpcProtocolModule protocol =
-                JvmRpcProtocolModule.builder().context(context).bindName(uri.getHost()).build();
-
-            return HeroicCore
-                .builder()
-                .setupShellServer(false)
-                .setupService(false)
-                .oneshot(true)
-                .executor(executor)
-                .configFragment(HeroicConfig
-                    .builder()
-                    .cluster(ClusterManagerModule
-                        .builder()
-                        .tags(ImmutableMap.of("shard", uri.getHost()))
-                        .protocols(ImmutableList.of(protocol))
-                        .discovery(new StaticListDiscoveryModule(uris))))
-                .profile(new MemoryProfile())
-                .modules(HeroicModules.ALL_MODULES)
-                .build()
-                .newInstance();
+            return setupCoreThrowing(uri, uris, context);
         } catch (Exception e) {
-            throw new RuntimeException("Could not build new instance");
+            throw Throwables.propagate(e);
         }
+    }
+
+    private HeroicCoreInstance setupCoreThrowing(
+        final URI uri, final List<URI> uris, final JvmRpcContext context
+    ) throws Exception {
+        final JvmRpcProtocolModule protocol =
+            JvmRpcProtocolModule.builder().context(context).bindName(uri.getHost()).build();
+
+        return HeroicCore
+            .builder()
+            .setupShellServer(false)
+            .setupService(false)
+            .oneshot(true)
+            .executor(executor)
+            .configFragment(HeroicConfig
+                .builder()
+                .cluster(ClusterManagerModule
+                    .builder()
+                    .tags(ImmutableMap.of("shard", uri.getHost()))
+                    .protocols(ImmutableList.of(protocol))
+                    .discovery(new StaticListDiscoveryModule(uris))))
+            .profile(new MemoryProfile())
+            .modules(HeroicModules.ALL_MODULES)
+            .build()
+            .newInstance();
     }
 }

--- a/heroic-dist/src/test/java/com/spotify/heroic/TaskIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/TaskIT.java
@@ -1,0 +1,178 @@
+package com.spotify.heroic;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.spotify.heroic.common.Series;
+import com.spotify.heroic.dagger.CoreComponent;
+import com.spotify.heroic.ingestion.Ingestion;
+import com.spotify.heroic.ingestion.IngestionComponent;
+import com.spotify.heroic.ingestion.IngestionManager;
+import com.spotify.heroic.shell.ShellIO;
+import eu.toolchain.async.AsyncFuture;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.mockito.InOrder;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.spotify.heroic.test.Data.points;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+public class TaskIT extends AbstractLocalClusterIT {
+    private final Series s1 = Series.of("key1", ImmutableMap.of("shared", "a", "diff", "a"));
+    private final Series s2 = Series.of("key1", ImmutableMap.of("shared", "a", "diff", "b"));
+
+    private ShellTasks tasks;
+
+    private PrintWriter out;
+    private ShellIO io;
+
+    @Rule
+    public Timeout timeout = Timeout.millis(10000);
+
+    @Override
+    protected List<URI> instanceUris() {
+        return ImmutableList.of(URI.create("jvm://a"));
+    }
+
+    @Before
+    public void setup() {
+        tasks = instances.get(0).inject(CoreComponent::tasks);
+
+        io = mock(ShellIO.class);
+        out = mock(PrintWriter.class);
+        doReturn(out).when(io).out();
+    }
+
+    @Override
+    protected AsyncFuture<Void> prepareEnvironment() {
+        final List<IngestionManager> ingestion = instances
+            .stream()
+            .map(i -> i.inject(IngestionComponent::ingestionManager))
+            .collect(Collectors.toList());
+
+        final List<AsyncFuture<Ingestion>> writes = new ArrayList<>();
+
+        final IngestionManager m1 = ingestion.get(0);
+
+        writes.add(m1
+            .useDefaultGroup()
+            .write(new Ingestion.Request(s1, points().p(10, 1D).p(30, 2D).build())));
+
+        return async.collectAndDiscard(writes);
+    }
+
+    @Test
+    public void readFile() throws Exception {
+        final InputStream in = new ByteArrayInputStream("foo\nbar\n".getBytes(Charsets.UTF_8));
+
+        doReturn(in).when(io).newInputStream(any(Path.class), eq(StandardOpenOption.READ));
+
+        run("test-read-file");
+
+        final InOrder order = inOrder(out);
+
+        order.verify(out).println("Read: 0");
+        order.verify(out).println("Read: 1");
+        order.verify(out, never()).println(any(String.class));
+    }
+
+    @Test
+    public void print() {
+        run("test-print", "--count", "2");
+
+        final InOrder order = inOrder(out);
+
+        order.verify(out).println("Count: 00000000");
+        order.verify(out).println("Count: 00000001");
+        order.verify(out, never()).println(any(String.class));
+    }
+
+    @Test
+    public void pause() {
+        run("pause");
+
+        final InOrder order = inOrder(out);
+
+        order.verify(out).println("Pausing Consumers");
+        order.verify(out, never()).println(any(String.class));
+    }
+
+    @Test
+    public void resume() {
+        run("resume");
+
+        final InOrder order = inOrder(out);
+
+        order.verify(out).println("Resuming Consumers");
+        order.verify(out, never()).println(any(String.class));
+    }
+
+    @Test
+    public void parseQuery() {
+        run("parse-query", "*");
+
+        final InOrder order = inOrder(out);
+
+        order.verify(out).println(any(String.class));
+        order.verify(out, never()).println(any(String.class));
+    }
+
+    @Test
+    public void parseQueryEval() {
+        run("parse-query", "--eval", "*");
+
+        final InOrder order = inOrder(out);
+
+        order.verify(out).println(any(String.class));
+        order.verify(out, never()).println(any(String.class));
+    }
+
+    @Test
+    public void ingestionFilter() {
+        run("ingestion-filter");
+        run("ingestion-filter", "role=lol");
+        run("ingestion-filter");
+
+        final InOrder order = inOrder(out);
+
+        order.verify(out).println("Current ingestion filter: [true]");
+        order.verify(out).println("Updating ingestion filter to: [=, role, lol]");
+        order.verify(out).println("Current ingestion filter: [=, role, lol]");
+        order.verify(out, never()).println(any(String.class));
+    }
+
+    @Test
+    public void refresh() {
+        run("refresh");
+
+        final InOrder order = inOrder(out);
+
+        order.verify(out, never()).println(any(String.class));
+    }
+
+    private void run(final String... command) {
+        try {
+            tasks.evaluate(ImmutableList.copyOf(command), io).get();
+        } catch (final Exception e) {
+            throw Throwables.propagate(e);
+        }
+    }
+}


### PR DESCRIPTION
`AbstractLocalClusterIT` has been modified to bee less opinionated and is now used to setup integration tests for a few basic tasks.