### PR TITLE
[pom] introduce reporting module to do aggregate reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,12 +81,16 @@
         </property>
       </activation>
 
+      <modules>
+        <module>reporting</module>
+      </modules>
+
       <build>
         <plugins>
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.7.6.201602180812</version>
+            <version>0.7.7.201606060606</version>
             <configuration>
               <excludes>
                 <exclude>**/Dagger*.class</exclude>
@@ -96,18 +100,23 @@
             </configuration>
             <executions>
               <execution>
+                <id>codecov-test</id>
                 <goals>
                   <goal>prepare-agent</goal>
                 </goals>
+                <configuration>
+                  <propertyName>surefireArgLine</propertyName>
+                </configuration>
               </execution>
+
               <execution>
-                <id>report-coverage</id>
-
-                <phase>verify</phase>
-
+                <id>codecov-integration-test</id>
                 <goals>
-                  <goal>report</goal>
+                  <goal>prepare-agent-integration</goal>
                 </goals>
+                <configuration>
+                  <propertyName>failsafeArgLine</propertyName>
+                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -132,6 +141,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>2.19.1</version>
             <configuration>
+              <argLine>${failsafeArgLine}</argLine>
               <parallel>classesAndMethods</parallel>
               <threadCount>2</threadCount>
               <perCoreThreadCount>true</perCoreThreadCount>
@@ -758,6 +768,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.19.1</version>
         <configuration>
+          <argLine>${surefireArgLine}</argLine>
           <parallel>classesAndMethods</parallel>
           <threadCount>2</threadCount>
           <perCoreThreadCount>true</perCoreThreadCount>
@@ -767,6 +778,11 @@
 
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.7.7.201606060606</version>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>

--- a/reporting/README.md
+++ b/reporting/README.md
@@ -1,0 +1,4 @@
+# Heroic Reporting
+
+This component depends on all other individual components in order to aggregate
+coverage reports across all of them.

--- a/reporting/pom.xml
+++ b/reporting/pom.xml
@@ -1,0 +1,145 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.spotify.heroic</groupId>
+    <artifactId>heroic-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>heroic-reporting</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Heroic: Reporting Component</name>
+
+  <description>
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.spotify.heroic</groupId>
+      <artifactId>heroic-component</artifactId>
+    </dependency>
+
+    <!-- core -->
+    <dependency>
+      <groupId>com.spotify.heroic</groupId>
+      <artifactId>heroic-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.spotify.heroic</groupId>
+      <artifactId>heroic-shell</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.spotify.heroic</groupId>
+      <artifactId>heroic-dist</artifactId>
+    </dependency>
+
+    <!-- metric backends -->
+    <dependency>
+      <groupId>com.spotify.heroic.metric</groupId>
+      <artifactId>heroic-metric-datastax</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.spotify.heroic.metric</groupId>
+      <artifactId>heroic-metric-bigtable</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.spotify.heroic.metric</groupId>
+      <artifactId>heroic-metric-memory</artifactId>
+    </dependency>
+
+    <!-- metadata backends -->
+    <dependency>
+      <groupId>com.spotify.heroic.metadata</groupId>
+      <artifactId>heroic-metadata-elasticsearch</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.spotify.heroic.metadata</groupId>
+      <artifactId>heroic-metadata-memory</artifactId>
+    </dependency>
+
+    <!-- suggest backends -->
+    <dependency>
+      <groupId>com.spotify.heroic.suggest</groupId>
+      <artifactId>heroic-suggest-elasticsearch</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.spotify.heroic.suggest</groupId>
+      <artifactId>heroic-suggest-memory</artifactId>
+    </dependency>
+
+    <!-- discovery implementations -->
+    <dependency>
+      <groupId>com.spotify.heroic.discovery</groupId>
+      <artifactId>heroic-discovery-simple</artifactId>
+    </dependency>
+
+    <!-- aggregation methods -->
+    <dependency>
+      <groupId>com.spotify.heroic.aggregation</groupId>
+      <artifactId>heroic-aggregation-simple</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.spotify.heroic.aggregation</groupId>
+      <artifactId>heroic-aggregation-cardinality</artifactId>
+    </dependency>
+
+    <!-- consumer implementations -->
+    <dependency>
+      <groupId>com.spotify.heroic.consumer</groupId>
+      <artifactId>heroic-consumer-kafka</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.spotify.heroic.consumer</groupId>
+      <artifactId>heroic-consumer-collectd</artifactId>
+    </dependency>
+
+    <!-- rpc implementations -->
+    <dependency>
+      <groupId>com.spotify.heroic.rpc</groupId>
+      <artifactId>heroic-rpc-nativerpc</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.spotify.heroic.rpc</groupId>
+      <artifactId>heroic-rpc-grpc</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.spotify.heroic.rpc</groupId>
+      <artifactId>heroic-rpc-jvm</artifactId>
+    </dependency>
+
+    <!-- statistics -->
+    <dependency>
+      <groupId>com.spotify.heroic.statistics</groupId>
+      <artifactId>heroic-statistics-semantic</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>codecov-report</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
codecov only looks at `jacoco.xml` files generated by reports when determining total coverage. These only contain coverage as reported per-module and ignores if one module tests aspects of another.

This is solved by introducing a `reporting` module that depends immediately on everything that should be included in the coverage and using the `report-aggregate` goal of jacoco which specifically merges all immediate dependencies into a single report.