### PR TITLE
[core] actually start the internal life cycles and test it

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/dagger/LoadingModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/dagger/LoadingModule.java
@@ -50,14 +50,13 @@ import eu.toolchain.async.TinyAsync;
 import eu.toolchain.serializer.Serializer;
 import eu.toolchain.serializer.SerializerFramework;
 import eu.toolchain.serializer.TinySerializer;
-import lombok.RequiredArgsConstructor;
-
-import javax.inject.Named;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import javax.inject.Named;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Module
@@ -170,12 +169,12 @@ public class LoadingModule {
         final ScheduledExecutorService scheduler, final ExecutorService executor
     ) {
         return () -> {
-            registry.start(() -> async.call(() -> {
+            registry.scoped("loading scheduler").stop(() -> async.call(() -> {
                 shutdown(scheduler);
                 return null;
             }, ForkJoinPool.commonPool()));
 
-            registry.start(() -> async.call(() -> {
+            registry.scoped("loading executor").stop(() -> async.call(() -> {
                 shutdown(executor);
                 return null;
             }, ForkJoinPool.commonPool()));

--- a/heroic-dist/src/test/java/com/spotify/heroic/HeroicConfigurationTest.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/HeroicConfigurationTest.java
@@ -2,6 +2,7 @@ package com.spotify.heroic;
 
 import com.google.common.collect.ImmutableList;
 import com.spotify.heroic.lifecycle.CoreLifeCycleRegistry;
+import com.spotify.heroic.lifecycle.LifeCycleNamedHook;
 import org.junit.Test;
 
 import java.io.InputStream;
@@ -42,20 +43,46 @@ public class HeroicConfigurationTest {
         );
         // @formatter:on
 
+        // @formatter:off
+        final List<String> referenceInternalStarters = ImmutableList.of(
+            "startup future"
+        );
+        // @formatter:on
+
+        // @formatter:off
+        final List<String> referenceInternalStoppers = ImmutableList.of(
+            "loading executor",
+            "loading scheduler"
+        );
+        // @formatter:on
+
         final HeroicCoreInstance instance = testConfiguration("heroic-all.yml");
 
         final List<String> starters = instance.inject(c -> {
             final CoreLifeCycleRegistry reg = (CoreLifeCycleRegistry) c.lifeCycleRegistry();
-            return reg.starters().stream().map(h -> h.id()).sorted().collect(Collectors.toList());
+            return reg.starters().stream().map(LifeCycleNamedHook::id).sorted().collect(Collectors.toList());
         });
 
         final List<String> stoppers = instance.inject(c -> {
             final CoreLifeCycleRegistry reg = (CoreLifeCycleRegistry) c.lifeCycleRegistry();
-            return reg.stoppers().stream().map(h -> h.id()).sorted().collect(Collectors.toList());
+            return reg.stoppers().stream().map(LifeCycleNamedHook::id).sorted().collect(Collectors.toList());
         });
 
         assertEquals(referenceStarters, starters);
         assertEquals(referenceStoppers, stoppers);
+
+        final List<String> internalStarters = instance.inject(c -> {
+            final CoreLifeCycleRegistry reg = (CoreLifeCycleRegistry) c.internalLifeCycleRegistry();
+            return reg.starters().stream().map(LifeCycleNamedHook::id).sorted().collect(Collectors.toList());
+        });
+
+        final List<String> internalStoppers = instance.inject(c -> {
+            final CoreLifeCycleRegistry reg = (CoreLifeCycleRegistry) c.internalLifeCycleRegistry();
+            return reg.stoppers().stream().map(LifeCycleNamedHook::id).sorted().collect(Collectors.toList());
+        });
+
+        assertEquals(internalStarters, referenceInternalStarters);
+        assertEquals(internalStoppers, referenceInternalStoppers);
     }
 
     private HeroicCoreInstance testConfiguration(final String name) throws Exception {


### PR DESCRIPTION
This fixes a startup regression introduced in 5094210.

The issue was caused by the internal started future never being resolved, which prevents the initial cluster refresh from being called as is done here:
https://github.com/spotify/heroic/blob/master/heroic-core/src/main/java/com/spotify/heroic/cluster/CoreClusterManager.java#L306