### PR TITLE
[core] do not shutdown executors provided externally

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/dagger/LoadingModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/dagger/LoadingModule.java
@@ -62,6 +62,8 @@ import lombok.RequiredArgsConstructor;
 @Module
 public class LoadingModule {
     private final ExecutorService executor;
+    /* {@code true} if this instance manages its own executor and is responsible for stopping it */
+    private final boolean managedExecutor;
     private final HeroicConfiguration options;
     private final ExtraParameters parameters;
 
@@ -174,10 +176,12 @@ public class LoadingModule {
                 return null;
             }, ForkJoinPool.commonPool()));
 
-            registry.scoped("loading executor").stop(() -> async.call(() -> {
-                shutdown(executor);
-                return null;
-            }, ForkJoinPool.commonPool()));
+            if (managedExecutor) {
+                registry.scoped("loading executor").stop(() -> async.call(() -> {
+                    shutdown(executor);
+                    return null;
+                }, ForkJoinPool.commonPool()));
+            }
         };
     }
 


### PR DESCRIPTION
Executors provided through configuration should not be stopped by `HeroicCore`.

This _hopefully_ fixes the issue that arises here:
https://travis-ci.org/spotify/heroic/builds/166443596#L2305

Note the `java.util.concurrent.RejectedExecutionException`.

Because we use a shared thread pool for some of the tests here:
https://github.com/spotify/heroic/blob/master/heroic-dist/src/test/java/com/spotify/heroic/AbstractLocalClusterIT.java#L30
This is where it is being provided:
https://github.com/spotify/heroic/blob/master/heroic-dist/src/test/java/com/spotify/heroic/AbstractLocalClusterIT.java#L168

Really hard to know if this works or not since it is timing-related (failsafe plugin runs things in parallel).