### PR TITLE
[statistics/semantic] fix forwarding of method calls in decorated type

### DIFF
--- a/statistics/semantic/pom.xml
+++ b/statistics/semantic/pom.xml
@@ -42,5 +42,17 @@
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporter.java
@@ -32,6 +32,8 @@ import com.spotify.heroic.metadata.Entries;
 import com.spotify.heroic.metadata.FindKeys;
 import com.spotify.heroic.metadata.FindSeries;
 import com.spotify.heroic.metadata.FindSeriesIds;
+import com.spotify.heroic.metadata.FindSeriesIdsStream;
+import com.spotify.heroic.metadata.FindSeriesStream;
 import com.spotify.heroic.metadata.FindTags;
 import com.spotify.heroic.metadata.MetadataBackend;
 import com.spotify.heroic.metadata.WriteMetadata;
@@ -149,10 +151,24 @@ public class SemanticMetadataBackendReporter implements MetadataBackendReporter 
         }
 
         @Override
+        public AsyncObservable<FindSeriesStream> findSeriesStream(
+            final FindSeries.Request request
+        ) {
+            return delegate.findSeriesStream(request);
+        }
+
+        @Override
         public AsyncFuture<FindSeriesIds> findSeriesIds(
             final FindSeriesIds.Request request
         ) {
             return delegate.findSeriesIds(request).onDone(findSeriesIds.setup());
+        }
+
+        @Override
+        public AsyncObservable<FindSeriesIdsStream> findSeriesIdsStream(
+            final FindSeriesIds.Request request
+        ) {
+            return delegate.findSeriesIdsStream(request);
         }
 
         @Override

--- a/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporterTest.java
+++ b/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporterTest.java
@@ -1,0 +1,53 @@
+package com.spotify.heroic.statistics.semantic;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.spotify.heroic.async.AsyncObservable;
+import com.spotify.heroic.common.Statistics;
+import com.spotify.heroic.metadata.FindSeries;
+import com.spotify.heroic.metadata.FindSeriesIds;
+import com.spotify.heroic.metadata.FindSeriesIdsStream;
+import com.spotify.heroic.metadata.FindSeriesStream;
+import com.spotify.heroic.metadata.MetadataBackend;
+import com.spotify.metrics.core.SemanticMetricRegistry;
+import org.junit.Test;
+
+public class SemanticMetadataBackendReporterTest {
+    @Test
+    public void testDecorated() {
+        final SemanticMetricRegistry registry = mock(SemanticMetricRegistry.class);
+        final SemanticMetadataBackendReporter reporter =
+            new SemanticMetadataBackendReporter(registry);
+
+        final MetadataBackend backend = mock(MetadataBackend.class);
+        final MetadataBackend decorated = reporter.decorate(backend);
+
+        // TODO: Currently covers the methods which have defender methods, but should cover all.
+
+        {
+            final AsyncObservable<FindSeriesIdsStream> response = mock(AsyncObservable.class);
+            final FindSeriesIds.Request request = mock(FindSeriesIds.Request.class);
+            doReturn(response).when(backend).findSeriesIdsStream(request);
+            assertEquals(response, decorated.findSeriesIdsStream(request));
+            verify(backend).findSeriesIdsStream(request);
+        }
+
+        {
+            final AsyncObservable<FindSeriesStream> response = mock(AsyncObservable.class);
+            final FindSeries.Request request = mock(FindSeries.Request.class);
+            doReturn(response).when(backend).findSeriesStream(request);
+            assertEquals(response, decorated.findSeriesStream(request));
+            verify(backend).findSeriesStream(request);
+        }
+
+        {
+            final Statistics statistics = mock(Statistics.class);
+            doReturn(statistics).when(backend).getStatistics();
+            assertEquals(statistics, decorated.getStatistics());
+            verify(backend).getStatistics();
+        }
+    }
+}


### PR DESCRIPTION
Currently if a statistics module is configured the `metadata-find-series` and `metadata-find-series-ids` tasks will return empty results.
These tasks use these methods, which were currently not implemented in the decorating class.

I've added the forwarding, and test-cases to make sure that all defender methods have the correct implementation.