### PR TITLE
[core,dist] fix ShellServerModule configuration when host is empty

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/shell/ShellServerModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/ShellServerModule.java
@@ -21,8 +21,6 @@
 
 package com.spotify.heroic.shell;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.heroic.lifecycle.LifeCycle;
 import com.spotify.heroic.lifecycle.LifeCycleManager;
 import dagger.Module;
@@ -37,11 +35,11 @@ import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import javax.inject.Named;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import javax.inject.Named;
 
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
@@ -53,16 +51,8 @@ public class ShellServerModule {
     public static final String DEFAULT_HOST = "localhost";
     public static final int DEFAULT_PORT = 9190;
 
-    final String host;
-    final int port;
-
-    @JsonCreator
-    public ShellServerModule(
-        @JsonProperty("host") Optional<String> host, @JsonProperty("port") Optional<Integer> port
-    ) {
-        this.host = host.orElse(DEFAULT_HOST);
-        this.port = port.orElse(DEFAULT_PORT);
-    }
+    final Optional<String> host;
+    final Optional<Integer> port;
 
     @Provides
     @ShellServerScope
@@ -74,6 +64,9 @@ public class ShellServerModule {
     @Provides
     @ShellServerScope
     Managed<ShellServerState> state(final AsyncFramework async) {
+        final String host = this.host.orElse(DEFAULT_HOST);
+        final int port = this.port.orElse(DEFAULT_PORT);
+
         return async.managed(new ManagedSetup<ShellServerState>() {
             @Override
             public AsyncFuture<ShellServerState> construct() throws Exception {
@@ -122,7 +115,7 @@ public class ShellServerModule {
         }
 
         public ShellServerModule build() {
-            return new ShellServerModule(host.orElse(DEFAULT_HOST), port.orElse(DEFAULT_PORT));
+            return new ShellServerModule(host, port);
         }
     }
 }

--- a/heroic-dist/src/test/java/com/spotify/heroic/HeroicConfigurationTest.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/HeroicConfigurationTest.java
@@ -85,6 +85,13 @@ public class HeroicConfigurationTest {
         assertEquals(internalStoppers, referenceInternalStoppers);
     }
 
+    @Test
+    public void testNullShellHost() throws Exception {
+        // TODO: get this into the shell server module
+        final HeroicCoreInstance instance = testConfiguration("heroic-null-shell-host.yml");
+        instance.start().get();
+    }
+
     private HeroicCoreInstance testConfiguration(final String name) throws Exception {
         final HeroicCore.Builder builder = HeroicCore.builder();
         builder.modules(HeroicModules.ALL_MODULES);

--- a/heroic-dist/src/test/resources/heroic-null-shell-host.yml
+++ b/heroic-dist/src/test/resources/heroic-null-shell-host.yml
@@ -1,0 +1,2 @@
+shellServer:
+  port: 9192


### PR DESCRIPTION
An absent value in `shellServer.host` causes the following exception:
```
java.util.concurrent.ExecutionException: java.lang.IllegalArgumentException: hostname can't be null
```

This fixes that issue and adds a test to check for it.