### PR TITLE
[aggregation/simple,dist] fix test so that non-distributed filtering aggregations work

### DIFF
--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/AboveKInstance.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/AboveKInstance.java
@@ -21,16 +21,19 @@
 
 package com.spotify.heroic.aggregation.simple;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
-import java.beans.ConstructorProperties;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class AboveKInstance extends FilterAggregation {
-    @ConstructorProperties({"k"})
-    public AboveKInstance(final double k) {
+    private final double k;
+
+    @JsonCreator
+    public AboveKInstance(@JsonProperty("k") final double k) {
         super(new FilterKThresholdStrategy(FilterKThresholdType.ABOVE, k));
+        this.k = k;
     }
 }

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/BelowKInstance.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/BelowKInstance.java
@@ -21,16 +21,19 @@
 
 package com.spotify.heroic.aggregation.simple;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
-import java.beans.ConstructorProperties;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class BelowKInstance extends FilterAggregation {
-    @ConstructorProperties({"k"})
-    public BelowKInstance(final double k) {
+    private final double k;
+
+    @JsonCreator
+    public BelowKInstance(@JsonProperty("k") final double k) {
         super(new FilterKThresholdStrategy(FilterKThresholdType.BELOW, k));
+        this.k = k;
     }
 }

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/BottomKInstance.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/BottomKInstance.java
@@ -21,16 +21,19 @@
 
 package com.spotify.heroic.aggregation.simple;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
-import java.beans.ConstructorProperties;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class BottomKInstance extends FilterAggregation {
-    @ConstructorProperties({"k"})
-    public BottomKInstance(final long k) {
+    private final long k;
+
+    @JsonCreator
+    public BottomKInstance(@JsonProperty("k") final long k) {
         super(new FilterKAreaStrategy(FilterKAreaType.BOTTOM, k));
+        this.k = k;
     }
 }

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/FilterAggregation.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/FilterAggregation.java
@@ -21,6 +21,7 @@
 
 package com.spotify.heroic.aggregation.simple;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.spotify.heroic.aggregation.AggregationInstance;
 import com.spotify.heroic.aggregation.AggregationOutput;
 import com.spotify.heroic.aggregation.AggregationResult;
@@ -44,6 +45,7 @@ import java.util.stream.Collectors;
 @Data
 public abstract class FilterAggregation implements AggregationInstance {
     @NonNull
+    @JsonIgnore
     private final FilterStrategy filterStrategy;
 
     @Override

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/TopKInstance.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/TopKInstance.java
@@ -21,16 +21,19 @@
 
 package com.spotify.heroic.aggregation.simple;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
-import java.beans.ConstructorProperties;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class TopKInstance extends FilterAggregation {
-    @ConstructorProperties({"k"})
-    public TopKInstance(long k) {
+    private final long k;
+
+    @JsonCreator
+    public TopKInstance(@JsonProperty("k") final long k) {
         super(new FilterKAreaStrategy(FilterKAreaType.TOP, k));
+        this.k = k;
     }
 }

--- a/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/FilterAggregationTest.java
+++ b/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/FilterAggregationTest.java
@@ -1,27 +1,66 @@
 package com.spotify.heroic.aggregation.simple;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.spotify.heroic.aggregation.AggregationInstance;
+import org.junit.Before;
 import org.junit.Test;
 
-import static com.spotify.heroic.test.LombokDataTest.verifyClassBuilder;
+import static org.junit.Assert.assertEquals;
 
 public class FilterAggregationTest {
-    @Test
-    public void testAboveKInstance() {
-        verifyClassBuilder(AboveKInstance.class).checkGetters(false).verify();
+    private ObjectMapper mapper;
+
+    @Before
+    public void setup() {
+        mapper = new ObjectMapper();
+        mapper.addMixIn(AggregationInstance.class, TypeNameMixin.class);
+        mapper.registerSubtypes(new NamedType(AboveKInstance.class, AboveK.NAME));
+        mapper.registerSubtypes(new NamedType(BelowKInstance.class, BelowK.NAME));
+        mapper.registerSubtypes(new NamedType(BottomKInstance.class, BottomK.NAME));
+        mapper.registerSubtypes(new NamedType(TopKInstance.class, TopK.NAME));
     }
 
     @Test
-    public void testBelowKInstance() {
-        verifyClassBuilder(BelowKInstance.class).checkGetters(false).verify();
+    public void testAboveKInstance() throws Exception {
+        // TODO: support @JsonCreator
+        // verifyClassBuilder(AboveKInstance.class).checkGetters(false).verify();
+        verifyRoundtrip("{\"type\":\"abovek\",\"k\":0.0}", new AboveKInstance(0),
+            AboveKInstance.class);
     }
 
     @Test
-    public void testBottomKInstance() {
-        verifyClassBuilder(BottomKInstance.class).checkGetters(false).verify();
+    public void testBelowKInstance() throws Exception {
+        // TODO: support @JsonCreator
+        // verifyClassBuilder(BelowKInstance.class).checkGetters(false).verify();
+        verifyRoundtrip("{\"type\":\"belowk\",\"k\":0.0}", new BelowKInstance(0),
+            BelowKInstance.class);
     }
 
     @Test
-    public void testTopKInstance() {
-        verifyClassBuilder(TopKInstance.class).checkGetters(false).verify();
+    public void testBottomKInstance() throws Exception {
+        // TODO: support @JsonCreator
+        // verifyClassBuilder(BottomKInstance.class).checkGetters(false).verify();
+        verifyRoundtrip("{\"type\":\"bottomk\",\"k\":0}", new BottomKInstance(0),
+            BottomKInstance.class);
+    }
+
+    @Test
+    public void testTopKInstance() throws Exception {
+        // TODO: support @JsonCreator
+        // verifyClassBuilder(TopKInstance.class).checkGetters(false).verify();
+        verifyRoundtrip("{\"type\":\"topk\",\"k\":0}", new TopKInstance(0), TopKInstance.class);
+    }
+
+    private <T> void verifyRoundtrip(
+        final String json, final T reference, final Class<T> cls
+    ) throws Exception {
+        assertEquals(reference, mapper.readValue(json, cls));
+        assertEquals(json, mapper.writeValueAsString(reference));
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+    public interface TypeNameMixin {
     }
 }


### PR DESCRIPTION
Also add tests that performs a non-distributed filtering aggregation, and checks that serialization works as expected.

There are some duplicated infrastructure in the test that should be moved into `heroic-test-base`, specifically we want to be able to load serializers using a `LoadingComponent` to avoid repeating that piece of initialization all the time. `HeroicMappers` also needs a new home in that case.