### PR TITLE
Delta aggregation

### DIFF
--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Delta.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Delta.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.spotify.heroic.aggregation.Aggregation;
+import com.spotify.heroic.aggregation.AggregationContext;
+import com.spotify.heroic.aggregation.AggregationInstance;
+import lombok.Data;
+
+@Data
+public class Delta implements Aggregation {
+    public static final String NAME = "delta";
+
+    @JsonCreator
+    public Delta() { }
+
+    @Override
+    public AggregationInstance apply(
+        final AggregationContext aggregationContext
+    ) {
+        return new DeltaInstance();
+    }
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/DeltaInstance.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/DeltaInstance.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+import com.spotify.heroic.aggregation.AggregationInstance;
+import com.spotify.heroic.aggregation.AggregationResult;
+import com.spotify.heroic.aggregation.AggregationSession;
+import com.spotify.heroic.aggregation.AggregationOutput;
+import com.spotify.heroic.aggregation.EmptyInstance;
+import com.spotify.heroic.common.DateRange;
+import com.spotify.heroic.common.Series;
+import com.spotify.heroic.metric.MetricCollection;
+import com.spotify.heroic.metric.MetricGroup;
+import com.spotify.heroic.metric.Event;
+import com.spotify.heroic.metric.Payload;
+import com.spotify.heroic.metric.MetricType;
+import com.spotify.heroic.metric.Point;
+import com.spotify.heroic.metric.Spread;
+import lombok.Data;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Iterator;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Data
+public class DeltaInstance implements AggregationInstance {
+    private final EmptyInstance inner = new EmptyInstance();
+
+    @Override
+    public long estimate(DateRange range) {
+        return -1;
+    }
+
+    @Override
+    public long cadence() {
+        return -1;
+    }
+
+    @Override
+    public AggregationInstance distributed() {
+        return this;
+    }
+
+    @Override
+    public boolean distributable() {
+        return false;
+    }
+
+    public List<Point> computeDiff(List<Point> points) {
+        final Iterator<Point> it = points.iterator();
+        final ArrayList<Point> result = new ArrayList<Point>();
+
+        if (!it.hasNext()) {
+            return Collections.emptyList();
+        }
+
+        Point previous = it.next();
+
+        while (it.hasNext()) {
+            final Point current = it.next();
+            double diff = current.getValue() - previous.getValue();
+            result.add(new Point(current.getTimestamp(), diff));
+            previous = current;
+        }
+
+        return result;
+    }
+
+
+    @Override
+    public AggregationSession session(DateRange range) {
+        return new Session(inner.session(range));
+    }
+
+    private class Session implements AggregationSession {
+        private final AggregationSession childSession;
+
+        public Session(AggregationSession childSession) {
+            this.childSession = childSession;
+        }
+
+        @Override
+        public void updatePoints(
+            final Map<String, String> key, final Set<Series> series, final List<Point> values
+        ) {
+            this.childSession.updatePoints(key, series, values);
+        }
+
+        @Override
+        public void updateEvents(
+            final Map<String, String> key, final Set<Series> series, final List<Event> values
+        ) { }
+
+        @Override
+        public void updatePayload(
+            final Map<String, String> key, final Set<Series> series, final List<Payload> values
+        ) { }
+
+        @Override
+        public void updateGroup(
+            final Map<String, String> key, final Set<Series> series, final List<MetricGroup> values
+        ) { }
+
+        @Override
+        public void updateSpreads(
+            final Map<String, String> key, final Set<Series> series, final List<Spread> values
+        ) { }
+
+        @Override
+        public AggregationResult result() {
+            AggregationResult aggregationResult = this.childSession.result();
+            List<AggregationOutput> outputs = aggregationResult
+                .getResult()
+                .stream()
+                .map(aggregationOutput -> new AggregationOutput(
+                    aggregationOutput.getKey(),
+                    aggregationOutput.getSeries(),
+                    MetricCollection.build(
+                        MetricType.POINT,
+                        computeDiff(aggregationOutput.getMetrics().getDataAs(Point.class))
+                    )
+                ))
+                .collect(Collectors.toList());
+            return new AggregationResult(outputs, aggregationResult.getStatistics());
+        }
+    }
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Module.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Module.java
@@ -109,6 +109,8 @@ public class Module implements HeroicModule {
                     }
                 });
 
+            c.register(Delta.NAME, Delta.class, DeltaInstance.class, args -> new Delta());
+
             c.register(TopK.NAME, TopK.class, TopKInstance.class,
                 args -> new TopK(fetchK(args, IntegerExpression.class).getValue(),
                     Optional.empty()));

--- a/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/DeltaTest.java
+++ b/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/DeltaTest.java
@@ -1,0 +1,47 @@
+package com.spotify.heroic.aggregation.simple;
+
+import com.spotify.heroic.aggregation.AggregationSession;
+import com.spotify.heroic.common.DateRange;
+import com.spotify.heroic.metric.Point;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+public class DeltaTest {
+
+    final private DeltaInstance deltaInstance = new DeltaInstance();
+    final private AggregationSession session = deltaInstance.session(new DateRange(0, 10000));
+
+    @Test
+    public void testComputePositiveDeltas() throws Exception {
+        // Test positive deltas
+        ArrayList<Point> points = new ArrayList<Point>();
+        points.add(new Point(1, 2));
+        points.add(new Point(2, 3));
+        points.add(new Point(3, 100));
+
+        ArrayList<Point> expected = new ArrayList<Point>();
+        expected.add(new Point(2, 1));
+        expected.add(new Point(3, 97));
+
+        assertEquals(expected, deltaInstance.computeDiff(points));
+    }
+
+    @Test
+    public void testComputeNegativeDelta() throws Exception {
+        // Test negative deltas
+        ArrayList<Point> points = new ArrayList<Point>();
+        points.add(new Point(1, 5));
+        points.add(new Point(2, 25));
+        points.add(new Point(3, 0));
+
+        ArrayList<Point> expected = new ArrayList<Point>();
+        expected.add(new Point(2, 20));
+        expected.add(new Point(3, -25));
+
+        assertEquals(expected, deltaInstance.computeDiff(points));
+    }
+
+}

--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
@@ -161,6 +161,31 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
     }
 
     @Test
+    public void deltaQueryTest() throws Exception {
+        final QueryResult result =
+            query("delta", builder -> {
+                builder.features(Optional.empty());
+            });
+
+        final Set<MetricCollection> m = getResults(result);
+        final List<Long> cadences = getCadences(result);
+
+        assertEquals(ImmutableList.of(-1L, -1L), cadences);
+        assertEquals(ImmutableSet.of(points().p(30, 1D).build(), points().p(20, 3D).build()), m);
+    }
+
+    @Test
+    public void distributedDeltaQueryTest() throws Exception {
+        final QueryResult result = query("max | delta");
+
+        final Set<MetricCollection> m = getResults(result);
+        final List<Long> cadences = getCadences(result);
+
+        assertEquals(ImmutableList.of(1L), cadences);
+        assertEquals(ImmutableSet.of(points().p(20, 3D).p(30, -2D).build()), m);
+    }
+
+    @Test
     public void filterLastQueryTest() throws Exception {
         final QueryResult result = query("average(10ms) by * | topk(2) | bottomk(1)");
 


### PR DESCRIPTION
Adds delta aggregation (i.e. "diff" in KairosDB or "rate" in OpenTSDB; open to alternative names). There are no arguments, leaving it up to the user to decide whether to chain it as an input to a `SamplingAggregation`, or to diff the output for any other `Aggregation`. Example:

```
{
  "range": {"type": "relative", "unit": "HOURS", "value": 2},
  "filter": ["and", ["key", "foo"], ["=", "foo", "bar"], ["+", "role"]],
  "aggregation": {"type": "delta"},
  "groupBy": ["site"]
}
```

The above would return the difference of each point from the last within the sample. ~~The first point in a difference is always 0.~~ (EDIT: The First point sampled is truncated and the first _returned_ point is the difference from the last point).

This is my first time writing Java, so please go easy! I understand it might not be the most idiomatic code, but I did my best to use patterns found in the other aggregators (stream, map, etc.). Thanks for looking.