### PR TITLE
Report when a time series is filtered out during ingest

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/IngestionManagerReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/IngestionManagerReporter.java
@@ -24,6 +24,8 @@ package com.spotify.heroic.statistics;
 public interface IngestionManagerReporter {
     FutureReporter.Context reportMetadataWrite();
 
+    void reportDroppedByFilter();
+
     void incrementConcurrentWrites();
 
     void decrementConcurrentWrites();

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopIngestionManagerReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopIngestionManagerReporter.java
@@ -34,6 +34,10 @@ public class NoopIngestionManagerReporter implements IngestionManagerReporter {
     }
 
     @Override
+    public void reportDroppedByFilter() {
+    }
+
+    @Override
     public void incrementConcurrentWrites() {
 
     }

--- a/heroic-core/src/main/java/com/spotify/heroic/ingestion/CoreIngestionGroup.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/ingestion/CoreIngestionGroup.java
@@ -81,7 +81,7 @@ public class CoreIngestionGroup implements IngestionGroup {
 
     protected AsyncFuture<Ingestion> syncWrite(final Ingestion.Request request) {
         if (!filter.get().apply(request.getSeries())) {
-            // XXX: report dropped-by-filter
+            reporter.reportDroppedByFilter();
             return async.resolved(Ingestion.of(ImmutableList.of()));
         }
 

--- a/heroic-core/src/test/java/com/spotify/heroic/ingestion/CoreIngestionGroupTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/ingestion/CoreIngestionGroupTest.java
@@ -135,6 +135,7 @@ public class CoreIngestionGroupTest {
         verify(writePermits).release();
         verify(reporter).incrementConcurrentWrites();
         verify(reporter).decrementConcurrentWrites();
+        verify(reporter, never()).reportDroppedByFilter();
         verify(group).doWrite(request);
         verify(expected).onFinished(any(FutureFinished.class));
     }
@@ -161,6 +162,7 @@ public class CoreIngestionGroupTest {
         verify(writePermits, never()).release();
         verify(reporter, never()).incrementConcurrentWrites();
         verify(reporter, never()).decrementConcurrentWrites();
+        verify(reporter).reportDroppedByFilter();
         verify(group, never()).doWrite(request);
         verify(other, never()).onFinished(any(FutureFinished.class));
     }

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticIngestionManagerReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticIngestionManagerReporter.java
@@ -22,6 +22,7 @@
 package com.spotify.heroic.statistics.semantic;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
 import com.spotify.heroic.statistics.FutureReporter;
 import com.spotify.heroic.statistics.FutureReporter.Context;
 import com.spotify.heroic.statistics.IngestionManagerReporter;
@@ -36,6 +37,7 @@ public class SemanticIngestionManagerReporter implements IngestionManagerReporte
     private final FutureReporter metadataWrite;
 
     private final Counter concurrentWritesCounter;
+    private final Meter droppedByFilter;
 
     public SemanticIngestionManagerReporter(SemanticMetricRegistry registry) {
         final MetricId id = MetricId.build().tagged("component", COMPONENT);
@@ -43,12 +45,17 @@ public class SemanticIngestionManagerReporter implements IngestionManagerReporte
             id.tagged("what", "metadata-write", "unit", Units.FAILURE));
         this.concurrentWritesCounter =
             registry.counter(id.tagged("what", "concurrent-writes", "unit", Units.WRITE));
+        this.droppedByFilter =
+            registry.meter(id.tagged("what", "dropped-by-filter", "unit", Units.DROP));
     }
 
     @Override
     public Context reportMetadataWrite() {
         return metadataWrite.setup();
     }
+
+    @Override
+    public void reportDroppedByFilter() { droppedByFilter.mark(); }
 
     @Override
     public void incrementConcurrentWrites() {


### PR DESCRIPTION
Report dropped-by-filter when a filter drops a time series during ingest. This fixes a "XXX:" comment.
Also updated tests.

Is this the right way of doing this? Any comments?