### PR TITLE
[statistics/semantic] add pending counter

### DIFF
--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/Units.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/Units.java
@@ -33,4 +33,5 @@ final class Units {
     public static final String BYTE = "B";
     public static final String MILLISECOND = "ms";
     public static final String DROP = "drop";
+    public static final String COUNT = "count";
 }


### PR DESCRIPTION
This adds pending counters to instrumented futures.

The pending counter is incremented when the future is created, and decremented when it finishes. This gives an indication of how many pending operations there are for a given type of future.