### PR TITLE
Bumped Bigtable client library to 0.9.4

### DIFF
--- a/metric/bigtable/pom.xml
+++ b/metric/bigtable/pom.xml
@@ -22,7 +22,7 @@
   </description>
 
   <properties>
-    <bigtable.version>0.9.3</bigtable.version>
+    <bigtable.version>0.9.4</bigtable.version>
   </properties>
 
   <dependencies>

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/Table.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/Table.java
@@ -68,7 +68,7 @@ public class Table {
         final ImmutableMap.Builder<String, ColumnFamily> columnFamilies = ImmutableMap.builder();
 
         for (final Entry<String, com.google.bigtable.admin.v2.ColumnFamily> e : table
-            .getColumnFamiliesMap()
+            .getColumnFamilies()
             .entrySet()) {
             final ColumnFamily columnFamily = new ColumnFamily(cluster, tableId, e.getKey());
             columnFamilies.put(columnFamily.getName(), columnFamily);

--- a/repackaged/bigtable/pom.xml
+++ b/repackaged/bigtable/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <bigtable.version>0.9.3</bigtable.version>
+    <bigtable.version>0.9.4</bigtable.version>
     <tcnative.classifier>linux-x86_64</tcnative.classifier>
   </properties>
 
   <groupId>com.spotify.heroic.repackaged</groupId>
   <artifactId>bigtable-client-core</artifactId>
   <packaging>jar</packaging>
-  <version>0.9.3</version>
+  <version>0.9.4</version>
 
   <name>Heroic: Re-Packaging of Bigtable Client Utilities</name>
 


### PR DESCRIPTION
Bigtable client library 0.9.4 downgraded protobuf as well, which is why getColumnFamiliesMap() change to getColumnFamilies()