### PR TITLE
Query log - configurable logging of big queries

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/QueryBuilder.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/QueryBuilder.java
@@ -50,6 +50,7 @@ public class QueryBuilder {
     private Optional<Aggregation> aggregation = Optional.empty();
     private Optional<QueryOptions> options = Optional.empty();
     private Optional<FeatureSet> features = Optional.empty();
+    private Optional<QueryOriginContext> originContext = Optional.empty();
 
     /**
      * Specify a set of tags that has to match.
@@ -147,8 +148,15 @@ public class QueryBuilder {
         return this;
     }
 
+    public QueryBuilder originContext(final Optional<QueryOriginContext> m) {
+        checkNotNull(m, "originContext");
+        this.originContext = m;
+        return this;
+    }
+
     public Query build() {
-        return new Query(legacyAggregation(), source, range, legacyFilter(), options, features);
+        return new Query(legacyAggregation(), source, range, legacyFilter(), options, features,
+            originContext);
     }
 
     /**

--- a/heroic-component/src/main/java/com/spotify/heroic/QueryLogger.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/QueryLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Spotify AB.
+ * Copyright (c) 2016 Spotify AB.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,22 +21,12 @@
 
 package com.spotify.heroic;
 
-import com.spotify.heroic.aggregation.Aggregation;
-import com.spotify.heroic.common.FeatureSet;
-import com.spotify.heroic.filter.Filter;
-import com.spotify.heroic.metric.MetricType;
-import lombok.Data;
+import com.spotify.heroic.metric.QueryResult;
 
-import java.util.Optional;
+public interface QueryLogger {
 
-@Data
-public class Query {
-    private final Optional<Aggregation> aggregation;
-    private final Optional<MetricType> source;
-    private final Optional<QueryDateRange> range;
-    private final Optional<Filter> filter;
-    private final Optional<QueryOptions> options;
-    /* set of experimental features to enable */
-    private final Optional<FeatureSet> features;
-    private final Optional<QueryOriginContext> originContext;
+    void logQueryAccess(Query query);
+    void logQueryFailed(Query query, Throwable t);
+    void logQueryResolved(Query query, QueryResult queryResult);
+    void logQueryCancelled(Query query);
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/QueryOriginContext.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/QueryOriginContext.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class QueryOriginContext {
+    private final String remoteAddr;
+    private final String remoteHost;
+    private final int    remotePort;
+    private final String remoteUserAgent;
+    private final String remoteClientId;
+    private final UUID   queryId;
+    private final String queryString;
+
+    public static QueryOriginContext empty() {
+        return new QueryOriginContext("", "", 0, "", "", UUID.randomUUID(), "");
+    }
+
+    public static QueryOriginContext of(final String  remoteAddr,
+                                        final String  remoteHost,
+                                        final int     remotePort,
+                                        final String  remoteUserAgent,
+                                        final String  remoteClientId,
+                                        final String  queryString) {
+        return new QueryOriginContext(remoteAddr, remoteHost, remotePort, remoteUserAgent,
+                                      remoteClientId, UUID.randomUUID(), queryString);
+    }
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/common/Feature.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/Feature.java
@@ -46,7 +46,15 @@ public enum Feature {
      * This will assert that there are data outside of the range queried for, which is a useful
      * feature when using a dashboarding system.
      */
-    SHIFT_RANGE("com.spotify.heroic.shift_range");
+    SHIFT_RANGE("com.spotify.heroic.shift_range"),
+
+    /**
+     * Enable feature to log queries 1) as they arrive & 2) when they're complete
+     * <p>
+     * This will write to two logs, query.access.log and query.done.log with log level TRACE. Please
+     * make sure to handle this in log4j config.
+     */
+    LOG_QUERIES("com.spotify.heroic.log_queries");
 
     private final String id;
 

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryTrace.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryTrace.java
@@ -25,17 +25,30 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+@AllArgsConstructor
 @Data
 public class QueryTrace {
     private final Identifier what;
     private final long elapsed;
     private final List<QueryTrace> children;
+
+    private long preAggregationSampleSize;
+    private long numSeries;
+
+    public QueryTrace(final Identifier what, final long elapsed, final List<QueryTrace> children) {
+        this(what, elapsed, children, 0, 0);
+        for (QueryTrace child : children) {
+            preAggregationSampleSize += child.getPreAggregationSampleSize();
+            numSeries += child.getNumSeries();
+        }
+    }
 
     public static QueryTrace of(final Identifier what) {
         return new QueryTrace(what, 0L, ImmutableList.of());
@@ -49,6 +62,15 @@ public class QueryTrace {
         final Identifier what, final long elapsed, final List<QueryTrace> children
     ) {
         return new QueryTrace(what, elapsed, children);
+    }
+
+    public static QueryTrace of(
+        final Identifier what, final long elapsed, final List<QueryTrace> children,
+        final long preAggregationSampleSize, final long numSeries
+    ) {
+        QueryTrace qt = new QueryTrace(what, elapsed, children, preAggregationSampleSize,
+                                       numSeries);
+        return qt;
     }
 
     public void formatTrace(PrintWriter out) {

--- a/heroic-core/src/main/java/com/spotify/heroic/CoreQueryLogger.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/CoreQueryLogger.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.heroic.common.OptionalLimit;
+import com.spotify.heroic.metric.QueryResult;
+import com.spotify.heroic.metric.QueryTrace;
+import com.spotify.heroic.metric.ShardedResultGroup;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.TimeZone;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.core.MediaType;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Slf4j
+@Data
+public class CoreQueryLogger implements QueryLogger {
+    private static Logger queryAccessLog = LoggerFactory.getLogger("query.access.log");
+    private static Logger queryDoneLog = LoggerFactory.getLogger("query.done.log");
+
+    private OptionalLimit logQueriesThresholdDataPoints;
+    private ObjectMapper objectMapper;
+
+    private static LongAdder totalQueriesProcessed = new LongAdder();
+
+    // Use AtomicLong since every time we do this we'll also read the value, so LongAdder is no use
+    private static AtomicLong queriesAboveThreshold = new AtomicLong();
+
+    @Inject
+    public CoreQueryLogger(@Named ("logQueriesThresholdDataPoints") final OptionalLimit
+        logQueriesThresholdDataPoints,
+        @Named(MediaType.APPLICATION_JSON) final ObjectMapper objectMapper) {
+        this.logQueriesThresholdDataPoints = logQueriesThresholdDataPoints;
+        this.objectMapper = objectMapper;
+    }
+
+    public void logQueryAccess(Query query) {
+        String idString;
+        QueryOriginContext originContext;
+        if (query != null && query.getOriginContext().isPresent()) {
+            originContext = query.getOriginContext().get();
+            idString = originContext.getQueryId().toString();
+        } else {
+            originContext = QueryOriginContext.empty();
+            idString = "";
+        }
+
+        // Format timestamp nicely
+        TimeZone tz = TimeZone.getTimeZone("UTC");
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+        dateFormat.setTimeZone(tz);
+        String currentTimeAsISO = dateFormat.format(new Date());
+
+        boolean isIPv6 = originContext.getRemoteAddr().indexOf(':') != -1;
+
+        QueryAccessDataMessage message = new QueryAccessDataMessage(
+            originContext.getQueryId(),
+            (isIPv6 ? "[" : "") + originContext.getRemoteAddr() + (isIPv6 ? "]" : "") +
+                ":" + originContext.getRemotePort(),
+            originContext.getRemoteHost(),
+            originContext.getRemoteUserAgent(),
+            originContext.getRemoteClientId(),
+            originContext.getQueryString());
+
+        QueryAccessData queryAccessData = new QueryAccessData(currentTimeAsISO, message);
+
+        String json;
+        try {
+            json = objectMapper.writeValueAsString(queryAccessData);
+        } catch (JsonProcessingException e) {
+            log.info("Failed to generate JSON for logging of query");
+            return;
+        }
+
+        queryAccessLog.trace(json);
+    }
+
+
+    public void logQueryFailed(Query query, Throwable t) {
+        logQueryDone(query, null, "failed", t);
+    }
+    public void logQueryResolved(Query query, QueryResult queryResult) {
+        logQueryDone(query, queryResult, "resolved", null);
+    }
+    public void logQueryCancelled(Query query) {
+        logQueryDone(query, null, "cancelled", null);
+    }
+
+    public void logQueryDone(Query query, QueryResult result, String status, Throwable throwable) {
+        final QueryTrace trace = result.getTrace();
+        final List<ShardedResultGroup> groups = result.getGroups();
+        final QueryOriginContext originContext = query.getOriginContext()
+            .orElse(QueryOriginContext.empty());
+
+        log.info("QueryResult:logQueryDone entering");
+
+        totalQueriesProcessed.increment();
+
+        int postAggregationDataPoints = 0;
+        for (ShardedResultGroup g : groups) {
+            postAggregationDataPoints += g.getMetrics().getData().size();
+        }
+
+        if (!logQueriesThresholdDataPoints.isGreaterOrEqual(postAggregationDataPoints)) {
+            log.info("QueryResult:logQueryDone Won't log because of threshold");
+            return;
+        }
+
+        long currQueriesAboveThreshold = queriesAboveThreshold.incrementAndGet();
+
+        // Format timestamp nicely
+        TimeZone tz = TimeZone.getTimeZone("UTC");
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+        dateFormat.setTimeZone(tz);
+        String currentTimeAsISO = dateFormat.format(new Date());
+
+        boolean isIPv6 = originContext.getRemoteAddr().indexOf(':') != -1;
+
+        long postAggregationDataPointsPerS = 0;
+        if (trace.getElapsed() != 0) {
+            postAggregationDataPointsPerS =
+                (1000000 * postAggregationDataPoints) / trace.getElapsed();
+        }
+
+        QueryDoneMessageData message = new QueryDoneMessageData(
+            status,
+            (throwable == null ? null : throwable.toString()),
+            originContext.getQueryId(),
+            totalQueriesProcessed.longValue(),
+            currQueriesAboveThreshold,
+            postAggregationDataPoints,
+            trace.getElapsed(),
+            postAggregationDataPointsPerS,
+            trace.getPreAggregationSampleSize(),
+            trace.getNumSeries(),
+            (isIPv6 ? "[" : "") + originContext.getRemoteAddr() + (isIPv6 ? "]" : "") +
+                ":" + originContext.getRemotePort(),
+            originContext.getRemoteHost(),
+            originContext.getRemoteUserAgent(),
+            originContext.getRemoteClientId(),
+            originContext.getQueryString(),
+            createQueryDoneChildList(trace.getChildren()));
+
+        QueryDoneData queryDoneData = new QueryDoneData(currentTimeAsISO, message);
+
+        String json;
+        try {
+            json = objectMapper.writeValueAsString(queryDoneData);
+        } catch (JsonProcessingException e) {
+            log.info("Failed to generate JSON for logging of query");
+            return;
+        }
+
+        queryDoneLog.trace(json);
+    }
+
+
+    @AllArgsConstructor
+    @Data
+    class QueryAccessData {
+        @JsonProperty("@timestamp")
+        private String timestamp;
+        @JsonProperty("@message")
+        private QueryAccessDataMessage message;
+    }
+    @AllArgsConstructor
+    @Data
+    class QueryAccessDataMessage {
+        private UUID uuid;
+        private String fromIP;
+        private String fromHost;
+        private String userAgent;
+        private String clientId;
+        // The query String already contains the original JSON, so tell Jackson to not escape it
+        @JsonRawValue
+        private String query;
+    }
+
+
+    @AllArgsConstructor
+    @Data
+    class QueryDoneData {
+        @JsonProperty("@timestamp")
+        String timestamp;
+        @JsonProperty("@message")
+        QueryDoneMessageData message;
+    }
+
+    @AllArgsConstructor
+    @Data
+    class QueryDoneMessageData {
+        String status;
+        String error;
+        UUID uuid;
+        long totalQueries;
+        long numQueriesAboveThreshold;
+        long postAggregationDataPoints;
+        long elapsed;
+        long postAggregationDataPointsPerS;
+        long preAggregationDataPoints;
+        long preAggregationSeries;
+        String fromIP;
+        String fromHost;
+        private String userAgent;
+        private String clientId;
+        // The query String already contains the original JSON, so tell Jackson to not escape it
+        @JsonRawValue
+        private String query;
+        List<QueryDoneChildData> queryTraceChildren;
+    }
+
+    @AllArgsConstructor
+    @Data
+    class QueryDoneChildData {
+        private String traceLevel;
+        private long elapsed;
+        private long preAggregationDataPoints;
+        private long preAggregationSeries;
+        List<QueryDoneChildData> queryTraceChildren;
+    }
+
+    private List<QueryDoneChildData> createQueryDoneChildList(List<QueryTrace> queryTraces) {
+        List<QueryDoneChildData> list = new ArrayList<>();
+        Iterator<QueryTrace> iterator = queryTraces.iterator();
+
+        while (iterator.hasNext()) {
+            QueryTrace queryTrace = iterator.next();
+            list.add(createQueryDoneChild(queryTrace));
+        }
+        return list;
+    }
+
+    private QueryDoneChildData createQueryDoneChild(QueryTrace queryTrace) {
+        List<QueryDoneChildData> children = createQueryDoneChildList(queryTrace.getChildren());
+
+        QueryDoneChildData child = new QueryDoneChildData(queryTrace.getWhat().toString(),
+            queryTrace.getElapsed(), queryTrace.getPreAggregationSampleSize(),
+            queryTrace.getNumSeries(), children);
+
+        return child;
+    }
+
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/HeroicCore.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/HeroicCore.java
@@ -476,7 +476,8 @@ public class HeroicCore implements HeroicConfiguration {
 
         final QueryComponent query = DaggerCoreQueryComponent
             .builder()
-            .queryModule(new QueryModule(config.getMetric().getGroupLimit()))
+            .queryModule(new QueryModule(config.getMetric().getGroupLimit(),
+                config.getMetric().logQueriesThresholdDataPoints()))
             .corePrimaryComponent(primary)
             .clusterComponent(cluster)
             .cacheComponent(cache)

--- a/heroic-core/src/main/java/com/spotify/heroic/QueryModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/QueryModule.java
@@ -32,6 +32,7 @@ import javax.inject.Named;
 @Data
 public class QueryModule {
     private final OptionalLimit groupLimit;
+    private final OptionalLimit logQueriesThresholdDataPoints;
 
     @Provides
     @QueryScope
@@ -39,4 +40,12 @@ public class QueryModule {
     public OptionalLimit groupLimit() {
         return groupLimit;
     }
+
+    @Provides
+    @QueryScope
+    @Named("logQueriesThresholdDataPoints")
+    public OptionalLimit logQueriesThresholdDataPoints() {
+        return logQueriesThresholdDataPoints;
+    }
+
 }

--- a/heroic-core/src/main/java/com/spotify/heroic/http/query/CoreQueryOriginContextFactory.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/query/CoreQueryOriginContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Spotify AB.
+ * Copyright (c) 2016 Spotify AB.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,24 +19,22 @@
  * under the License.
  */
 
-package com.spotify.heroic;
+package com.spotify.heroic.http.query;
 
-import com.spotify.heroic.aggregation.Aggregation;
-import com.spotify.heroic.common.FeatureSet;
-import com.spotify.heroic.filter.Filter;
-import com.spotify.heroic.metric.MetricType;
-import lombok.Data;
+import com.spotify.heroic.QueryOriginContext;
+import javax.servlet.http.HttpServletRequest;
 
-import java.util.Optional;
+public class CoreQueryOriginContextFactory {
 
-@Data
-public class Query {
-    private final Optional<Aggregation> aggregation;
-    private final Optional<MetricType> source;
-    private final Optional<QueryDateRange> range;
-    private final Optional<Filter> filter;
-    private final Optional<QueryOptions> options;
-    /* set of experimental features to enable */
-    private final Optional<FeatureSet> features;
-    private final Optional<QueryOriginContext> originContext;
+    public static QueryOriginContext create(HttpServletRequest httpServletRequest, String query) {
+        String userAgent = httpServletRequest.getHeader("User-Agent");
+        String clientId = httpServletRequest.getHeader("X-Client-Id");
+        return QueryOriginContext.of(httpServletRequest.getRemoteAddr(),
+            httpServletRequest.getRemoteHost(),
+            httpServletRequest.getRemotePort(),
+            userAgent == null ? "" : userAgent,
+            clientId == null ? "" : clientId,
+            query);
+    }
+
 }

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/MetricManagerModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/MetricManagerModule.java
@@ -54,6 +54,7 @@ import static java.util.Optional.of;
 public class MetricManagerModule {
     public static final int DEFAULT_FETCH_PARALLELISM = 100;
     public static final boolean DEFAULT_FAIL_ON_LIMITS = false;
+    public static final long DEFAULT_LOG_QUERIES_THRESHOLD = 1000000;
 
     private final List<MetricModule> backends;
     private final Optional<List<String>> defaultBackends;
@@ -87,6 +88,11 @@ public class MetricManagerModule {
      * If {@code true}, will cause any limits applied to be reported as a failure.
      */
     private final boolean failOnLimits;
+
+    /**
+     * Limit which queries that are logged
+     */
+    private final OptionalLimit logQueriesThresholdDataPoints;
 
     @Provides
     @MetricScope
@@ -184,6 +190,13 @@ public class MetricManagerModule {
         return failOnLimits;
     }
 
+    @Provides
+    @MetricScope
+    @Named("logQueriesThresholdDataPoints")
+    public OptionalLimit logQueriesThresholdDataPoints() {
+        return logQueriesThresholdDataPoints;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -199,6 +212,7 @@ public class MetricManagerModule {
         private OptionalLimit dataLimit = OptionalLimit.empty();
         private Optional<Integer> fetchParallelism = empty();
         private Optional<Boolean> failOnLimits = empty();
+        private OptionalLimit logQueriesThresholdDataPoints = OptionalLimit.empty();
 
         public Builder backends(List<MetricModule> backends) {
             this.backends = of(backends);
@@ -240,6 +254,11 @@ public class MetricManagerModule {
             return this;
         }
 
+        public Builder logQueriesThresholdDataPoints(long logQueriesThresholdDataPoints) {
+            this.logQueriesThresholdDataPoints = OptionalLimit.of(logQueriesThresholdDataPoints);
+            return this;
+        }
+
         public Builder merge(final Builder o) {
             // @formatter:off
             return new Builder(
@@ -250,7 +269,8 @@ public class MetricManagerModule {
                 aggregationLimit.orElse(o.aggregationLimit),
                 dataLimit.orElse(o.dataLimit),
                 pickOptional(fetchParallelism, o.fetchParallelism),
-                pickOptional(failOnLimits, o.failOnLimits)
+                pickOptional(failOnLimits, o.failOnLimits),
+                logQueriesThresholdDataPoints.orElse(o.logQueriesThresholdDataPoints)
             );
             // @formatter:on
         }
@@ -265,7 +285,9 @@ public class MetricManagerModule {
                 aggregationLimit,
                 dataLimit,
                 fetchParallelism.orElse(DEFAULT_FETCH_PARALLELISM),
-                failOnLimits.orElse(DEFAULT_FAIL_ON_LIMITS)
+                failOnLimits.orElse(DEFAULT_FAIL_ON_LIMITS),
+                logQueriesThresholdDataPoints.orElse(
+                    OptionalLimit.of(DEFAULT_LOG_QUERIES_THRESHOLD))
             );
             // @formatter:on
         }

--- a/heroic-core/src/test/java/com/spotify/heroic/CoreQueryManagerTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/CoreQueryManagerTest.java
@@ -1,5 +1,6 @@
 package com.spotify.heroic;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spotify.heroic.aggregation.AggregationFactory;
 import com.spotify.heroic.cache.QueryCache;
 import com.spotify.heroic.cluster.ClusterManager;
@@ -39,7 +40,8 @@ public class CoreQueryManagerTest {
     public void setup() {
         manager =
             new CoreQueryManager(Features.empty(), async, cluster, parser, queryCache, aggregations,
-                OptionalLimit.empty());
+                OptionalLimit.empty(), new CoreQueryLogger(OptionalLimit.of(0),
+                new ObjectMapper()));
     }
 
     @Test


### PR DESCRIPTION
This adds the possibility to log queries, including information such as ip:port, elapsed time, number of resulting data points, full request.
Define a new Logger called "query.log" to get the output to a separate file. Log level for the query logging is "debug".
Query logging is disabled by default. Use logQueries in the metrics section to enable it.
Logging can be filtered on the amount of data points being returned by the query. Use logQueriesThresholdDataPoints in the metrics section to define lower threshold. Default threshold is 1000000. Sample configuration:

```
metrics:
  logQueries: true
  logQueriesThresholdDataPoints: 1000000
```