### PR TITLE
Set Bigtable batchSize as a parameter

### DIFF
--- a/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsModule.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsModule.java
@@ -49,6 +49,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 
+
 @ToString
 @RequiredArgsConstructor
 @Module
@@ -93,7 +94,7 @@ public class BigtableAnalyticsModule implements AnalyticsModule {
                 return async.call(
                     new BigtableConnectionBuilder(project, cluster, credentials, async,
                         executorService, DEFAULT_DISABLE_BULK_MUTATIONS,
-                        DEFAULT_FLUSH_INTERVAL_SECONDS));
+                        DEFAULT_FLUSH_INTERVAL_SECONDS, Optional.empty()));
             }
 
             @Override

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableMetricModule.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableMetricModule.java
@@ -72,6 +72,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
     private final boolean configure;
     private final boolean disableBulkMutations;
     private final int flushIntervalSeconds;
+    private final Optional<Integer> batchSize;
 
     @JsonCreator
     public BigtableMetricModule(
@@ -82,7 +83,8 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         @JsonProperty("credentials") Optional<CredentialsBuilder> credentials,
         @JsonProperty("configure") Optional<Boolean> configure,
         @JsonProperty("disableBulkMutations") Optional<Boolean> disableBulkMutations,
-        @JsonProperty("flushIntervalSeconds") Optional<Integer> flushIntervalSeconds
+        @JsonProperty("flushIntervalSeconds") Optional<Integer> flushIntervalSeconds,
+        @JsonProperty("batchSize") Optional<Integer> batchSize
     ) {
         this.id = id;
         this.groups = groups.orElseGet(Groups::empty).or(DEFAULT_GROUP);
@@ -93,6 +95,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         this.configure = configure.orElse(DEFAULT_CONFIGURE);
         this.disableBulkMutations = disableBulkMutations.orElse(DEFAULT_DISABLE_BULK_MUTATIONS);
         this.flushIntervalSeconds = flushIntervalSeconds.orElse(DEFAULT_FLUSH_INTERVAL_SECONDS);
+        this.batchSize = batchSize;
     }
 
     @Override
@@ -127,7 +130,8 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
                 public AsyncFuture<BigtableConnection> construct() throws Exception {
                     return async.call(
                         new BigtableConnectionBuilder(project, instance, credentials, async,
-                            executorService, disableBulkMutations, flushIntervalSeconds));
+                            executorService, disableBulkMutations, flushIntervalSeconds,
+                            batchSize));
                 }
 
                 @Override
@@ -193,6 +197,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         private Optional<Boolean> configure = empty();
         private Optional<Boolean> disableBulkMutations = empty();
         private Optional<Integer> flushIntervalSeconds = empty();
+        private Optional<Integer> batchSize = empty();
 
         public Builder id(String id) {
             this.id = of(id);
@@ -235,6 +240,11 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
             return this;
         }
 
+        public Builder batchSize(int batchSize) {
+            this.batchSize = of(batchSize);
+            return this;
+        }
+
         public Builder table(final String table) {
             this.table = of(table);
             return this;
@@ -242,7 +252,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
 
         public BigtableMetricModule build() {
             return new BigtableMetricModule(id, groups, project, instance, table, credentials,
-                configure, disableBulkMutations, flushIntervalSeconds);
+                configure, disableBulkMutations, flushIntervalSeconds, batchSize);
         }
     }
 }


### PR DESCRIPTION
Allow a new setting for bigtable metric backend: batchSize.
This will set the size of BulkMutations when initializing BigTable.