### PR TITLE
rename Client-Id header to make it more generic

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/http/query/CoreQueryRequestMetadataFactory.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/query/CoreQueryRequestMetadataFactory.java
@@ -28,7 +28,7 @@ public class CoreQueryRequestMetadataFactory {
 
     public static QueryRequestMetadata create(HttpServletRequest httpServletRequest) {
         String userAgent = httpServletRequest.getHeader("User-Agent");
-        String clientId = httpServletRequest.getHeader("X-Alient-Client-Id");
+        String clientId = httpServletRequest.getHeader("X-Client-Id");
         return new QueryRequestMetadata(httpServletRequest.getRemoteAddr(),
                                         httpServletRequest.getRemoteHost(),
                                         httpServletRequest.getRemotePort(),


### PR DESCRIPTION
The current Client-Id header has a typo and points to a specfic client
implementation. It would be more useful to keep it generic.