### PR TITLE
Log incoming query before processing it

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/QueryBuilder.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/QueryBuilder.java
@@ -50,6 +50,7 @@ public class QueryBuilder {
     private Optional<Aggregation> aggregation = Optional.empty();
     private Optional<QueryOptions> options = Optional.empty();
     private Optional<FeatureSet> features = Optional.empty();
+    private Optional<QueryOriginContext> originContext = Optional.empty();
 
     /**
      * Specify a set of tags that has to match.
@@ -147,8 +148,15 @@ public class QueryBuilder {
         return this;
     }
 
+    public QueryBuilder originContext(final Optional<QueryOriginContext> m) {
+        checkNotNull(m, "originContext");
+        this.originContext = m;
+        return this;
+    }
+
     public Query build() {
-        return new Query(legacyAggregation(), source, range, legacyFilter(), options, features);
+        return new Query(legacyAggregation(), source, range, legacyFilter(), options, features,
+            originContext);
     }
 
     /**

--- a/heroic-component/src/main/java/com/spotify/heroic/QueryLogger.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/QueryLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Spotify AB.
+ * Copyright (c) 2016 Spotify AB.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,22 +21,13 @@
 
 package com.spotify.heroic;
 
-import com.spotify.heroic.aggregation.Aggregation;
-import com.spotify.heroic.common.FeatureSet;
-import com.spotify.heroic.filter.Filter;
-import com.spotify.heroic.metric.MetricType;
-import lombok.Data;
+import com.spotify.heroic.Query;
+import com.spotify.heroic.metric.QueryResult;
 
-import java.util.Optional;
+public interface QueryLogger {
 
-@Data
-public class Query {
-    private final Optional<Aggregation> aggregation;
-    private final Optional<MetricType> source;
-    private final Optional<QueryDateRange> range;
-    private final Optional<Filter> filter;
-    private final Optional<QueryOptions> options;
-    /* set of experimental features to enable */
-    private final Optional<FeatureSet> features;
-    private final Optional<QueryOriginContext> originContext;
+    void logQueryAccess(Query query);
+    void logQueryFailed(Query query, Throwable t);
+    void logQueryResolved(Query query, QueryResult queryResult);
+    void logQueryCancelled(Query query);
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/QueryOriginContext.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/QueryOriginContext.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class QueryOriginContext {
+    private final String remoteAddr;
+    private final String remoteHost;
+    private final int    remotePort;
+    private final String remoteUserAgent;
+    private final String remoteClientId;
+    private final UUID   queryId;
+    private final String queryString;
+
+    public static QueryOriginContext of() {
+        return new QueryOriginContext("", "", 0, "", "", UUID.randomUUID(), "");
+    }
+
+    public static QueryOriginContext of(final String  remoteAddr,
+                                        final String  remoteHost,
+                                        final int     remotePort,
+                                        final String  remoteUserAgent,
+                                        final String  remoteClientId,
+                                        final String  queryString) {
+        return new QueryOriginContext(remoteAddr, remoteHost, remotePort, remoteUserAgent,
+                                      remoteClientId, UUID.randomUUID(), queryString);
+    }
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/common/Feature.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/Feature.java
@@ -46,7 +46,15 @@ public enum Feature {
      * This will assert that there are data outside of the range queried for, which is a useful
      * feature when using a dashboarding system.
      */
-    SHIFT_RANGE("com.spotify.heroic.shift_range");
+    SHIFT_RANGE("com.spotify.heroic.shift_range"),
+
+    /**
+     * Enable feature to log queries 1) as they arrive & 2) when they're complete
+     * <p>
+     * This will write to two logs, query.access.log and query.done.log with log level TRACE. Please
+     * make sure to handle this in log4j config.
+     */
+    LOG_QUERIES("com.spotify.heroic.log_queries");
 
     private final String id;
 

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryResult.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryResult.java
@@ -23,15 +23,27 @@ package com.spotify.heroic.metric;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.spotify.heroic.QueryOriginContext;
 import com.spotify.heroic.aggregation.AggregationCombiner;
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.OptionalLimit;
 import eu.toolchain.async.Collector;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.TimeZone;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 import lombok.Data;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+@Slf4j
 @Data
 public class QueryResult {
     /**
@@ -95,8 +107,8 @@ public class QueryResult {
                 limits.add(ResultLimit.GROUP);
             }
 
-            return new QueryResult(range, groupLimit.limitList(groups), errors, trace,
-                new ResultLimits(limits.build()));
+            return new QueryResult(range, groupLimit.limitList(groups), errors,
+                trace, new ResultLimits(limits.build()));
         };
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryTrace.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryTrace.java
@@ -25,17 +25,30 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+@AllArgsConstructor
 @Data
 public class QueryTrace {
     private final Identifier what;
     private final long elapsed;
     private final List<QueryTrace> children;
+
+    private long preAggregationSampleSize;
+    private long numSeries;
+
+    public QueryTrace(final Identifier what, final long elapsed, final List<QueryTrace> children) {
+        this(what, elapsed, children, 0, 0);
+        for (QueryTrace child : children) {
+            preAggregationSampleSize += child.getPreAggregationSampleSize();
+            numSeries += child.getNumSeries();
+        }
+    }
 
     public static QueryTrace of(final Identifier what) {
         return new QueryTrace(what, 0L, ImmutableList.of());
@@ -49,6 +62,15 @@ public class QueryTrace {
         final Identifier what, final long elapsed, final List<QueryTrace> children
     ) {
         return new QueryTrace(what, elapsed, children);
+    }
+
+    public static QueryTrace of(
+        final Identifier what, final long elapsed, final List<QueryTrace> children,
+        final long preAggregationSampleSize, final long numSeries
+    ) {
+        QueryTrace qt = new QueryTrace(what, elapsed, children, preAggregationSampleSize,
+                                       numSeries);
+        return qt;
     }
 
     public void formatTrace(PrintWriter out) {

--- a/heroic-core/src/main/java/com/spotify/heroic/CoreQueryLogger.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/CoreQueryLogger.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic;
+
+import com.spotify.heroic.Query;
+import com.spotify.heroic.QueryLogger;
+import com.spotify.heroic.QueryOriginContext;
+import com.spotify.heroic.common.OptionalLimit;
+import com.spotify.heroic.metric.QueryResult;
+import com.spotify.heroic.metric.QueryTrace;
+import com.spotify.heroic.metric.ShardedResultGroup;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.TimeZone;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+import javax.inject.Inject;
+import javax.inject.Named;
+import lombok.Data;
+
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Slf4j
+@Data
+public class CoreQueryLogger implements QueryLogger {
+    private static Logger queryAccessLog = LoggerFactory.getLogger("query.access.log");
+    private static Logger queryDoneLog = LoggerFactory.getLogger("query.done.log");
+
+    private OptionalLimit logQueriesThresholdDataPoints;
+
+    private static LongAdder totalQueriesProcessed = new LongAdder();
+
+    // Use AtomicLong since every time we do this we'll also read the value, so LongAdder is no use
+    private static AtomicLong queriesAboveThreshold = new AtomicLong();
+
+    @Inject
+    public CoreQueryLogger(@Named ("logQueriesThresholdDataPoints") final OptionalLimit
+                               logQueriesThresholdDataPoints) {
+        this.logQueriesThresholdDataPoints = logQueriesThresholdDataPoints;
+    }
+
+    public void logQueryAccess(Query query) {
+        String idString;
+        QueryOriginContext originContext;
+        if (query != null && query.getOriginContext().isPresent()) {
+            originContext = query.getOriginContext().get();
+            idString = originContext.getQueryId().toString();
+        } else {
+            originContext = QueryOriginContext.of();
+            idString = "";
+        }
+
+        TimeZone tz = TimeZone.getTimeZone("UTC");
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+        dateFormat.setTimeZone(tz);
+        String currentTimeAsISO = dateFormat.format(new Date());
+
+        boolean isIPv6 = originContext.getRemoteAddr().indexOf(':') != -1;
+        String json = "{" +
+            " \"@timestamp\": \"" + currentTimeAsISO + "\"," +
+            " \"@message\": {" +
+            " \"UUID\": \"" + originContext.getQueryId() + "\"," +
+            " \"fromIP\": \"" +
+            (isIPv6 ? "[" : "") + originContext.getRemoteAddr() + (isIPv6 ? "]" : "") +
+            ":" + originContext.getRemotePort() + "\"" + "," +
+            " \"fromHost\": \"" + originContext.getRemoteHost() + "\"," +
+            " \"user-agent\": \"" + originContext.getRemoteUserAgent() + "\"," +
+            " \"client-id\": \"" + originContext.getRemoteClientId() + "\"," +
+            " \"query\": " + originContext.getQueryString() +
+            "}" +
+            "}";
+
+        queryAccessLog.trace(json);
+    }
+
+    public void logQueryFailed(Query query, Throwable t) {
+        logQueryDone(query, null, "failed", t);
+    }
+    public void logQueryResolved(Query query, QueryResult queryResult) {
+        logQueryDone(query, queryResult, "resolved", null);
+    }
+    public void logQueryCancelled(Query query) {
+        logQueryDone(query, null, "cancelled", null);
+    }
+
+    public void logQueryDone(Query query, QueryResult result, String status, Throwable throwable) {
+        final QueryTrace trace = result.getTrace();
+        final List<ShardedResultGroup> groups = result.getGroups();
+        final QueryOriginContext originContext = query.getOriginContext()
+            .orElse(QueryOriginContext.of());
+
+        log.info("QueryResult:logQueryDone entering");
+
+        totalQueriesProcessed.increment();
+
+        int postAggregationDataPoints = 0;
+        for (ShardedResultGroup g : groups) {
+            postAggregationDataPoints += g.getMetrics().getData().size();
+        }
+
+        if (!logQueriesThresholdDataPoints.isGreaterOrEqual(postAggregationDataPoints)) {
+            log.info("QueryResult:logQueryDone Won't log because of threshold");
+            return;
+        }
+
+        long currQueriesAboveThreshold = queriesAboveThreshold.incrementAndGet();
+
+        TimeZone tz = TimeZone.getTimeZone("UTC");
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+        dateFormat.setTimeZone(tz);
+        String currentTimeAsISO = dateFormat.format(new Date());
+
+        boolean isIPv6 = originContext.getRemoteAddr().indexOf(':') != -1;
+        long postAggregationDataPointsPerS = 0;
+        if (trace.getElapsed() != 0) {
+            postAggregationDataPointsPerS =
+                (1000000 * postAggregationDataPoints) / trace.getElapsed();
+        }
+        String json = "{" +
+            " \"@timestamp\": \"" + currentTimeAsISO + "\"," +
+            " \"status\": \"" + status + "\"," +
+            (throwable == null ? "" : " \"error\": \"" + throwable.toString() + "\"") +
+            " \"@message\": {" +
+            " \"UUID\": \"" + originContext.getQueryId() + "\"," +
+            " \"numQueriesAboveThreshold\": " + currQueriesAboveThreshold + "," +
+            " \"totalQueries\": " + totalQueriesProcessed + "," +
+            " \"postAggregationDataPoints\": " + postAggregationDataPoints + "," +
+            " \"elapsed\": " + trace.getElapsed() + "," +
+            " \"postAggregationDataPoints/s\": " + postAggregationDataPointsPerS + "," +
+            " \"preAggregationSampleSize\": " + trace.getPreAggregationSampleSize() + "," +
+            " \"numSeries\": " + trace.getNumSeries() + "," +
+            " \"trace-what\": \"" + trace.getWhat().toString() + "\"," +
+            " \"fromIP\": \"" +
+            (isIPv6 ? "[" : "") + originContext.getRemoteAddr() + (isIPv6 ? "]" : "") +
+            ":" + originContext.getRemotePort() + "\"" + "," +
+            " \"fromHost\": \"" + originContext.getRemoteHost() + "\"," +
+            " \"user-agent\": \"" + originContext.getRemoteUserAgent() + "\"," +
+            " \"client-id\": \"" + originContext.getRemoteClientId() + "\"," +
+            " \"query\": " + originContext.getQueryString() + "," +
+            " \"children\": [";
+
+        json += jsonForQueryTraceChildren(trace.getChildren());
+
+        json += "]";
+        json += "}";
+        json += "}";
+
+        queryDoneLog.trace(json);
+    }
+
+    public String jsonForQueryTraceChildren(final List<QueryTrace> children) {
+
+        String out = new String();
+        Iterator<QueryTrace> iterator = children.iterator();
+        while (iterator.hasNext()) {
+            QueryTrace child = iterator.next();
+            out += "{" +
+                " \"what\": \"" + child.getWhat().toString() + "\"," +
+                " \"elapsed\": " + child.getElapsed() + "," +
+                " \"preAggregationSampleSize\": " + child.getPreAggregationSampleSize() +
+                "," +
+                " \"numSeries\": " + child.getNumSeries() + "," +
+                " \"children\": [";
+            out += jsonForQueryTraceChildren(child.getChildren());
+            out += "]";
+            out += "}";
+            out += (iterator.hasNext() ? ", " : "");
+        }
+        return out;
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
@@ -97,12 +97,14 @@ public class CoreQueryManager implements QueryManager {
     private final QueryCache queryCache;
     private final AggregationFactory aggregations;
     private final OptionalLimit groupLimit;
+    private final QueryLogger queryLogger;
 
     @Inject
     public CoreQueryManager(
         @Named("features") final Features features, final AsyncFramework async,
         final ClusterManager cluster, final QueryParser parser, final QueryCache queryCache,
-        final AggregationFactory aggregations, @Named("groupLimit") final OptionalLimit groupLimit
+        final AggregationFactory aggregations, @Named("groupLimit") final OptionalLimit groupLimit,
+        CoreQueryLogger queryLogger
     ) {
         this.features = features;
         this.async = async;
@@ -111,6 +113,7 @@ public class CoreQueryManager implements QueryManager {
         this.queryCache = queryCache;
         this.aggregations = aggregations;
         this.groupLimit = groupLimit;
+        this.queryLogger = queryLogger;
     }
 
     @Override
@@ -176,6 +179,11 @@ public class CoreQueryManager implements QueryManager {
 
         @Override
         public AsyncFuture<QueryResult> query(Query q) {
+            boolean shouldLogQueries = features.hasFeature(Feature.LOG_QUERIES);
+            if (shouldLogQueries) {
+                queryLogger.logQueryAccess(q);
+            }
+
             final List<AsyncFuture<QueryResultPart>> futures = new ArrayList<>();
 
             final MetricType source = q.getSource().orElse(MetricType.POINT);
@@ -232,8 +240,21 @@ public class CoreQueryManager implements QueryManager {
 
                 final OptionalLimit limit = options.getGroupLimit().orElse(groupLimit);
 
-                return async.collect(futures,
+                AsyncFuture<QueryResult> queryResult = async.collect(futures,
                     QueryResult.collectParts(QUERY, range, combiner, limit));
+
+                if (shouldLogQueries) {
+                    queryResult = queryResult.directTransform(_queryResult -> {
+                        queryLogger.logQueryResolved(q, _queryResult);
+                        return _queryResult;
+                    });
+                    /*
+                     * FIXME: Is this a suitable place to do catchFailed and catchCancelled to log
+                     * those? What to return? An empty QueryResult? Or is that handled somewhere else?
+                     */
+                }
+
+                return queryResult;
             });
         }
 

--- a/heroic-core/src/main/java/com/spotify/heroic/HeroicCore.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/HeroicCore.java
@@ -476,7 +476,8 @@ public class HeroicCore implements HeroicConfiguration {
 
         final QueryComponent query = DaggerCoreQueryComponent
             .builder()
-            .queryModule(new QueryModule(config.getMetric().getGroupLimit()))
+            .queryModule(new QueryModule(config.getMetric().getGroupLimit(),
+                config.getMetric().logQueriesThresholdDataPoints()))
             .corePrimaryComponent(primary)
             .clusterComponent(cluster)
             .cacheComponent(cache)

--- a/heroic-core/src/main/java/com/spotify/heroic/QueryModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/QueryModule.java
@@ -32,6 +32,7 @@ import javax.inject.Named;
 @Data
 public class QueryModule {
     private final OptionalLimit groupLimit;
+    private final OptionalLimit logQueriesThresholdDataPoints;
 
     @Provides
     @QueryScope
@@ -39,4 +40,12 @@ public class QueryModule {
     public OptionalLimit groupLimit() {
         return groupLimit;
     }
+
+    @Provides
+    @QueryScope
+    @Named("logQueriesThresholdDataPoints")
+    public OptionalLimit logQueriesThresholdDataPoints() {
+        return logQueriesThresholdDataPoints;
+    }
+
 }

--- a/heroic-core/src/main/java/com/spotify/heroic/http/query/CoreQueryOriginContextFactory.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/query/CoreQueryOriginContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Spotify AB.
+ * Copyright (c) 2016 Spotify AB.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,24 +19,22 @@
  * under the License.
  */
 
-package com.spotify.heroic;
+package com.spotify.heroic.http.query;
 
-import com.spotify.heroic.aggregation.Aggregation;
-import com.spotify.heroic.common.FeatureSet;
-import com.spotify.heroic.filter.Filter;
-import com.spotify.heroic.metric.MetricType;
-import lombok.Data;
+import com.spotify.heroic.QueryOriginContext;
+import javax.servlet.http.HttpServletRequest;
 
-import java.util.Optional;
+public class CoreQueryOriginContextFactory {
 
-@Data
-public class Query {
-    private final Optional<Aggregation> aggregation;
-    private final Optional<MetricType> source;
-    private final Optional<QueryDateRange> range;
-    private final Optional<Filter> filter;
-    private final Optional<QueryOptions> options;
-    /* set of experimental features to enable */
-    private final Optional<FeatureSet> features;
-    private final Optional<QueryOriginContext> originContext;
+    public static QueryOriginContext create(HttpServletRequest httpServletRequest, String query) {
+        String userAgent = httpServletRequest.getHeader("User-Agent");
+        String clientId = httpServletRequest.getHeader("X-Client-Id");
+        return QueryOriginContext.of(httpServletRequest.getRemoteAddr(),
+            httpServletRequest.getRemoteHost(),
+            httpServletRequest.getRemotePort(),
+            userAgent == null ? "" : userAgent,
+            clientId == null ? "" : clientId,
+            query);
+    }
+
 }

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/MetricManagerModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/MetricManagerModule.java
@@ -54,6 +54,7 @@ import static java.util.Optional.of;
 public class MetricManagerModule {
     public static final int DEFAULT_FETCH_PARALLELISM = 100;
     public static final boolean DEFAULT_FAIL_ON_LIMITS = false;
+    public static final long DEFAULT_LOG_QUERIES_THRESHOLD = 1000000;
 
     private final List<MetricModule> backends;
     private final Optional<List<String>> defaultBackends;
@@ -87,6 +88,11 @@ public class MetricManagerModule {
      * If {@code true}, will cause any limits applied to be reported as a failure.
      */
     private final boolean failOnLimits;
+
+    /**
+     * Limit which queries that are logged
+     */
+    private final OptionalLimit logQueriesThresholdDataPoints;
 
     @Provides
     @MetricScope
@@ -184,6 +190,13 @@ public class MetricManagerModule {
         return failOnLimits;
     }
 
+    @Provides
+    @MetricScope
+    @Named("logQueriesThresholdDataPoints")
+    public OptionalLimit logQueriesThresholdDataPoints() {
+        return logQueriesThresholdDataPoints;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -199,6 +212,7 @@ public class MetricManagerModule {
         private OptionalLimit dataLimit = OptionalLimit.empty();
         private Optional<Integer> fetchParallelism = empty();
         private Optional<Boolean> failOnLimits = empty();
+        private OptionalLimit logQueriesThresholdDataPoints = OptionalLimit.empty();
 
         public Builder backends(List<MetricModule> backends) {
             this.backends = of(backends);
@@ -240,6 +254,11 @@ public class MetricManagerModule {
             return this;
         }
 
+        public Builder logQueriesThresholdDataPoints(long logQueriesThresholdDataPoints) {
+            this.logQueriesThresholdDataPoints = OptionalLimit.of(logQueriesThresholdDataPoints);
+            return this;
+        }
+
         public Builder merge(final Builder o) {
             // @formatter:off
             return new Builder(
@@ -250,7 +269,8 @@ public class MetricManagerModule {
                 aggregationLimit.orElse(o.aggregationLimit),
                 dataLimit.orElse(o.dataLimit),
                 pickOptional(fetchParallelism, o.fetchParallelism),
-                pickOptional(failOnLimits, o.failOnLimits)
+                pickOptional(failOnLimits, o.failOnLimits),
+                logQueriesThresholdDataPoints.orElse(o.logQueriesThresholdDataPoints)
             );
             // @formatter:on
         }
@@ -265,7 +285,9 @@ public class MetricManagerModule {
                 aggregationLimit,
                 dataLimit,
                 fetchParallelism.orElse(DEFAULT_FETCH_PARALLELISM),
-                failOnLimits.orElse(DEFAULT_FAIL_ON_LIMITS)
+                failOnLimits.orElse(DEFAULT_FAIL_ON_LIMITS),
+                logQueriesThresholdDataPoints.orElse(
+                                              OptionalLimit.of(DEFAULT_LOG_QUERIES_THRESHOLD))
             );
             // @formatter:on
         }

--- a/heroic-core/src/test/java/com/spotify/heroic/CoreQueryManagerTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/CoreQueryManagerTest.java
@@ -39,7 +39,7 @@ public class CoreQueryManagerTest {
     public void setup() {
         manager =
             new CoreQueryManager(Features.empty(), async, cluster, parser, queryCache, aggregations,
-                OptionalLimit.empty());
+                OptionalLimit.empty(), false, OptionalLimit.empty());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,6 @@
 
     <profile>
       <id>repackaged</id>
-
       <modules>
         <module>repackaged/bigtable</module>
       </modules>


### PR DESCRIPTION
We already had a query.log, it was renamed to query.done.log
Now there's also a query.access.log where incoming queries are printed, together with a query-unique UUID so that query.access.log and query.done.log can be matched with each other. If a node dies, it should now be possible to know which queries that were active/outstanding when it happened.

log4j details:
* Change: query.log renamed to query.done.log
* New Logger: query.access.log
* Log level changed to TRACE for query logs