### PR TITLE
[rpc/grpc] use 9698 as a default port (fixes #139, #111)

### DIFF
--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractLocalClusterIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractLocalClusterIT.java
@@ -153,7 +153,7 @@ public abstract class AbstractLocalClusterIT {
                 discovery = new StaticListDiscoveryModule(uris);
                 break;
             case "grpc":
-                protocol = GrpcRpcProtocolModule.builder().build();
+                protocol = GrpcRpcProtocolModule.builder().port(0).build();
                 discovery = new StaticListDiscoveryModule(ImmutableList.of());
                 break;
             default:

--- a/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcProtocolModule.java
+++ b/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcProtocolModule.java
@@ -47,7 +47,7 @@ public class GrpcRpcProtocolModule implements RpcProtocolModule {
     private static final Object PARENT = new Object();
 
     private static final String DEFAULT_HOST = "0.0.0.0";
-    private static final int DEFAULT_PORT = 0;
+    private static final int DEFAULT_PORT = 9698;
     private static final int DEFAULT_PARENT_THREADS = 2;
     private static final int DEFAULT_CHILD_THREADS = 100;
     private static final int DEFAULT_MAX_FRAME_SIZE = 10 * 1000000;


### PR DESCRIPTION
Also relates to #142 

Port number as suggested by @zfrank