### PR TITLE
[travis,pom] tweak build configuration to optimize thread usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 
+sudo: false
+
 jdk:
   - oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - tools/install-repackaged
 
 script:
-  - mvn -nsu -T 2 -D environment=test -P '!findbugs,codecov' verify
+  - mvn -nsu -T 1 -D threadCount=2 -D perCoreThreadCount=false -D environment=test -P '!findbugs,codecov' verify
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
   </licenses>
 
   <properties>
+    <threadCount>1</threadCount>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jersey.version>2.13</jersey.version>
@@ -135,9 +136,8 @@
             <version>2.19.1</version>
             <configuration>
               <argLine>${failsafeArgLine}</argLine>
-              <parallel>classesAndMethods</parallel>
-              <threadCount>2</threadCount>
-              <perCoreThreadCount>true</perCoreThreadCount>
+              <parallel>all</parallel>
+              <threadCount>${threadCount}</threadCount>
             </configuration>
             <executions>
               <execution>
@@ -763,9 +763,8 @@
         <version>2.19.1</version>
         <configuration>
           <argLine>${surefireArgLine}</argLine>
-          <parallel>classesAndMethods</parallel>
-          <threadCount>2</threadCount>
-          <perCoreThreadCount>true</perCoreThreadCount>
+          <parallel>all</parallel>
+          <threadCount>${threadCount}</threadCount>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Travis only provides two threads, this attempts to make sure we only use two threads and retain sensible defaults when building outside of Travis.