### PR TITLE
[metric/bigtable] Use readFlatRowsAsync() and fix quota

### DIFF
--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
@@ -24,6 +24,7 @@ package com.spotify.heroic.metric.bigtable;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -50,10 +51,8 @@ import com.spotify.heroic.metric.WriteMetric;
 import com.spotify.heroic.metric.bigtable.api.BigtableDataClient;
 import com.spotify.heroic.metric.bigtable.api.BigtableTableAdminClient;
 import com.spotify.heroic.metric.bigtable.api.ColumnFamily;
-import com.spotify.heroic.metric.bigtable.api.Family;
 import com.spotify.heroic.metric.bigtable.api.Mutations;
 import com.spotify.heroic.metric.bigtable.api.ReadRowsRequest;
-import com.spotify.heroic.metric.bigtable.api.Row;
 import com.spotify.heroic.metric.bigtable.api.RowFilter;
 import com.spotify.heroic.metric.bigtable.api.Table;
 import com.spotify.heroic.metrics.Meter;
@@ -76,6 +75,7 @@ import javax.inject.Named;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -380,17 +380,19 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
         final List<AsyncFuture<FetchData>> fetches = new ArrayList<>(prepared.size());
 
         for (final PreparedQuery p : prepared) {
-            final AsyncFuture<List<Row>> readRows = client.readRows(table, ReadRowsRequest
+            final AsyncFuture<List<FlatRow>> readRows = client.readRows(table, ReadRowsRequest
                 .builder()
                 .rowKey(p.keyBlob)
-                .filter(RowFilter
-                    .newColumnRangeBuilder(columnFamily)
-                    .startQualifierOpen(p.startKey)
-                    .endQualifierClosed(p.endKey)
-                    .build())
+                .filter(RowFilter.chain(Arrays.asList(
+                    RowFilter
+                        .newColumnRangeBuilder(columnFamily)
+                        .startQualifierOpen(p.startKey)
+                        .endQualifierClosed(p.endKey)
+                        .build(),
+                    RowFilter.onlyLatestCell())))
                 .build());
 
-            final Function<Family.LatestCellValueColumn, T> transform = cell -> {
+            final Function<FlatRow.Cell, T> transform = cell -> {
                 final long timestamp = p.base + deserializeOffset(cell.getQualifier());
                 return deserializer.apply(timestamp, cell.getValue());
             };
@@ -402,10 +404,8 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
 
                 final List<Iterable<T>> points = new ArrayList<>();
 
-                for (final Row row : result) {
-                    row.getFamily(columnFamily).ifPresent(f -> {
-                        points.add(Iterables.transform(f.latestCellValue(), transform));
-                    });
+                for (final FlatRow row : result) {
+                    points.add(Iterables.transform(row.getCells(), transform));
                 }
 
                 final QueryTrace trace = w.end();

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
@@ -400,11 +400,10 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
             final QueryTrace.NamedWatch w = QueryTrace.watch(FETCH_SEGMENT);
 
             fetches.add(readRows.directTransform(result -> {
-                watcher.readData(result.size());
-
                 final List<Iterable<T>> points = new ArrayList<>();
 
                 for (final FlatRow row : result) {
+                    watcher.readData(row.getCells().size());
                     points.add(Iterables.transform(row.getCells(), transform));
                 }
 

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableDataClient.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableDataClient.java
@@ -21,6 +21,7 @@
 
 package com.spotify.heroic.metric.bigtable.api;
 
+import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.protobuf.ByteString;
 import com.spotify.heroic.async.AsyncObservable;
 import eu.toolchain.async.AsyncFuture;
@@ -37,7 +38,7 @@ public interface BigtableDataClient {
      * @param request Request to use when reading rows.
      * @return A future that will be resolved when all rows are available.
      */
-    AsyncFuture<List<Row>> readRows(String tableName, ReadRowsRequest request);
+    AsyncFuture<List<FlatRow>> readRows(String tableName, ReadRowsRequest request);
 
     /**
      * Read the given set of rows in an observable way.

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/RowFilter.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/RowFilter.java
@@ -42,6 +42,15 @@ public interface RowFilter {
     }
 
     /**
+     * Build a filter that only matches the latest cell in each column.
+     *
+     * @return A filter that only matches the latest cell in each column.
+     */
+    static RowFilter onlyLatestCell() {
+        return new OnlyLatestCell();
+    }
+
+    /**
      * Apply all the given row filters.
      *
      * @param filters Filter to apply.
@@ -124,6 +133,17 @@ public interface RowFilter {
                 return new ColumnRange(family, startQualifierClosed, startQualifierOpen,
                     endQualifierClosed, endQualifierOpen);
             }
+        }
+    }
+
+    @Data
+    public class OnlyLatestCell implements RowFilter {
+        @Override
+        public com.google.bigtable.v2.RowFilter toPb() {
+            return com.google.bigtable.v2.RowFilter
+                .newBuilder()
+                .setCellsPerColumnLimitFilter(1)
+                .build();
         }
     }
 


### PR DESCRIPTION
This PR improves the Bigtable backend a bit.

- Using readFlatRowsAsync() instead of readRowsAsync() avoid a bunch of unnecessary intermediate objects and sorting. This should lower memory usage and GC pressure.
- Count the actual datapoints rather than just the rows.
    