### PR TITLE
[aggregations] Filter out time series with 0 datapoints in TopK/BottomK

### DIFF
--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/FilterKAreaStrategy.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/FilterKAreaStrategy.java
@@ -28,6 +28,12 @@ import lombok.Data;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * This filter strategy calculates the area under the graphs of the time series and
+ * selects the time series with either the biggest (TopK) or smallest (BottomK) area.
+ *
+ *  Time series without any data points are disregarded and never part of the result.
+ */
 @Data
 public class FilterKAreaStrategy implements FilterStrategy {
     private final FilterKAreaType filterType;
@@ -37,6 +43,7 @@ public class FilterKAreaStrategy implements FilterStrategy {
     public <T> List<T> filter(List<FilterableMetrics<T>> metrics) {
         return metrics
             .stream()
+            .filter(m -> m.getMetricSupplier().get().size() > 0)
             .map(Area::new)
             .sorted((a, b) -> filterType.compare(a.getValue(), b.getValue()))
             .limit(k)

--- a/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/FilterKAreaStrategyTest.java
+++ b/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/FilterKAreaStrategyTest.java
@@ -1,0 +1,27 @@
+package com.spotify.heroic.aggregation.simple;
+
+import com.spotify.heroic.metric.MetricCollection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FilterKAreaStrategyTest {
+
+    @Test
+    public void testNoDatapoints() {
+        List<FilterableMetrics<Integer>> metrics = Arrays.asList(new FilterableMetrics(null,
+            () -> MetricCollection.points(Collections.EMPTY_LIST)));
+        FilterKAreaStrategy filter = new FilterKAreaStrategy(FilterKAreaType.BOTTOM, 1);
+
+        // We expect timeseries with 0 datapoints to be filtered away
+        assertEquals(filter.filter(metrics).size(), 0);
+
+    }
+}


### PR DESCRIPTION
Metrics with 0 data points (e.g. time series, which are no longer reported but still in the index) should not be considered for TopK and BottomK.