### PR TITLE
[component, core, statistics] Add counters for tracking samples in mem

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/metric/FetchQuotaWatcher.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/FetchQuotaWatcher.java
@@ -26,7 +26,6 @@ public interface FetchQuotaWatcher {
      * Indicates that backend has read {@code n} more datapoints.
      *
      * @param n The number of datapoints read by the backend.
-     * @return A {@code boolean} indicating weither the operation may continue or not.
      * @throws QuotaViolationException if quota has been violated.
      */
     void readData(long n);

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/DataInMemoryReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/DataInMemoryReporter.java
@@ -21,14 +21,31 @@
 
 package com.spotify.heroic.statistics;
 
-import com.spotify.heroic.metric.MetricBackend;
+/*
+ * Keep track of amount of expected in-memory data. One instance of this class per operation (i.e.
+ * a query).
+ */
+public interface DataInMemoryReporter {
+    /**
+     * report that data has been read into memory
+     *
+     * @param n amount of data
+     */
+    void reportDataHasBeenRead(long n);
 
-public interface MetricBackendReporter {
-    MetricBackend decorate(MetricBackend backend);
+    /**
+     * report that data is no longer needed in memory
+     * <p>
+     * The data in question is expected to be garbage collected. If it isn't, then something else is
+     * unexpectantly having a reference to it, which could indicate a problem/bug.
+     *
+     * @param n amount of data
+     */
+    void reportDataNoLongerNeeded(long n);
 
-    DataInMemoryReporter newDataInMemoryReporter();
-
-    FutureReporter.Context reportFindSeries();
-
-    FutureReporter.Context reportQueryMetrics();
+    /**
+     * report that the whole operation is done, meaning that all data referenced in this
+     * DataInMemory instance is expected to be garbage collected.
+     */
+    void reportOperationEnded();
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
@@ -22,16 +22,40 @@
 package com.spotify.heroic.statistics.noop;
 
 import com.spotify.heroic.metric.MetricBackend;
+import com.spotify.heroic.statistics.DataInMemoryReporter;
 import com.spotify.heroic.statistics.FutureReporter;
 import com.spotify.heroic.statistics.MetricBackendReporter;
 
 public class NoopMetricBackendReporter implements MetricBackendReporter {
+
+    public static final DataInMemoryReporter DATA_IN_MEMORY_REPORTER = new DataInMemoryReporter() {
+        @Override
+        public void reportDataHasBeenRead(final long n) {
+
+        }
+
+        @Override
+        public void reportDataNoLongerNeeded(final long n) {
+
+        }
+
+        @Override
+        public void reportOperationEnded() {
+
+        }
+    };
+
     private NoopMetricBackendReporter() {
     }
 
     @Override
     public MetricBackend decorate(final MetricBackend backend) {
         return backend;
+    }
+
+    @Override
+    public DataInMemoryReporter newDataInMemoryReporter() {
+        return DATA_IN_MEMORY_REPORTER;
     }
 
     @Override

--- a/heroic-core/src/test/java/com/spotify/heroic/metric/LocalMetricManagerTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/metric/LocalMetricManagerTest.java
@@ -1,0 +1,67 @@
+package com.spotify.heroic.metric;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.doReturn;
+
+import com.spotify.heroic.common.GroupSet;
+import com.spotify.heroic.common.Groups;
+import com.spotify.heroic.common.OptionalLimit;
+import com.spotify.heroic.metadata.MetadataManager;
+import com.spotify.heroic.statistics.MetricBackendReporter;
+import eu.toolchain.async.AsyncFramework;
+import eu.toolchain.async.AsyncFuture;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/*
+ * Start of a test for LocalMetricManager
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class LocalMetricManagerTest {
+    private LocalMetricManager manager;
+
+    @Mock
+    private AsyncFramework async;
+
+    @Mock
+    private MetadataManager metadataManager;
+
+    @Mock
+    private MetricBackendReporter reporter;
+
+    @Mock
+    private MetadataManager metadata;
+
+    @Mock
+    private MetricBackend metricBackend;
+
+    @Mock
+    private AsyncFuture<FetchData> fetchDataFuture;
+
+    @Before
+    public void setup() {
+        final OptionalLimit groupLimit = OptionalLimit.empty();
+        final OptionalLimit seriesLimit = OptionalLimit.empty();
+        final OptionalLimit aggregationLimit = OptionalLimit.empty();
+        final OptionalLimit dataLimit = OptionalLimit.empty();
+        final int fetchParallelism = 20;
+        final boolean failOnLimits = true;
+        final Groups groups = Groups.of("foo");
+        doReturn(groups).when(metricBackend).groups();
+        final GroupSet<MetricBackend> groupSet =
+            GroupSet.build(Collections.singletonList(metricBackend), Optional.empty());
+
+        manager = new LocalMetricManager(groupLimit, seriesLimit, aggregationLimit, dataLimit,
+            fetchParallelism, failOnLimits, async, groupSet, metadata, reporter);
+    }
+
+    @Test
+    public void testUseDefaultBackend() {
+        assertNotNull(manager.useDefaultGroup());
+    }
+}

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/Units.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/Units.java
@@ -34,4 +34,5 @@ final class Units {
     public static final String MILLISECOND = "ms";
     public static final String DROP = "drop";
     public static final String COUNT = "count";
+    public static final String SAMPLE = "sample";
 }


### PR DESCRIPTION
New counters:
1) sample-size-live:
Incremented on data being read from backend.
Decremented when processing of data is done, i.e. when it is expected that data is freed.
2) sample-size-accumulated:
Incremented on data being read from backend.
Decremented when the whole request finishes.

Also started adding test scaffolding for LocalMetricManagerTest. It's too much work to do the full test at this time, but here's at least the test scaffolding.