### PR TITLE
[core] Faster shutdown of Heroic

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/dagger/LoadingModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/dagger/LoadingModule.java
@@ -120,8 +120,10 @@ public class LoadingModule {
     @Provides
     @LoadingScope
     ScheduledExecutorService scheduledExecutorService() {
-        return new ScheduledThreadPoolExecutor(10,
+        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(10,
             new ThreadFactoryBuilder().setNameFormat("heroic-scheduler#%d").build());
+        executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+        return executor;
     }
 
     @Provides


### PR DESCRIPTION
This change affects the shutdown behaviour of core ScheduledExecutorService so that it doesn't wait for scheduled/delayed tasks that aren't yet running but are scheduled to run at some time in the future. Previous to this the cluster refresh in clustered configurations would always be waited upon, introducing a delay in the shutdown.