### PR TITLE
[all] Add metric for ratio of live Kafka ConsumerThread's

### DIFF
--- a/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/KafkaConsumerModule.java
+++ b/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/KafkaConsumerModule.java
@@ -200,6 +200,9 @@ public class KafkaConsumerModule implements ConsumerModule {
                             buildThreads(async, reporter, streams, consumer, consuming, errors,
                                 consumed);
 
+                        // Report the wanted count of threads before starting the threads below
+                        reporter.reportConsumerThreadsWanted(threads.size());
+
                         for (final ConsumerThread t : threads) {
                             t.start();
                         }

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/ConsumerReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/ConsumerReporter.java
@@ -28,5 +28,9 @@ public interface ConsumerReporter {
 
     void reportConsumerSchemaError();
 
+    void reportConsumerThreadsWanted(final long count);
+    void reportConsumerThreadsIncrement();
+    void reportConsumerThreadsDecrement();
+
     void reportMessageDrift(final long ms);
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopConsumerReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopConsumerReporter.java
@@ -40,6 +40,18 @@ public class NoopConsumerReporter implements ConsumerReporter {
     }
 
     @Override
+    public void reportConsumerThreadsWanted(final long count) {
+    }
+
+    @Override
+    public void reportConsumerThreadsIncrement() {
+    }
+
+    @Override
+    public void reportConsumerThreadsDecrement() {
+    }
+
+    @Override
     public void reportMessageDrift(final long ms) {
     }
 

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticRatioGauge.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticRatioGauge.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.statistics.semantic;
+
+import com.codahale.metrics.RatioGauge;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SemanticRatioGauge extends RatioGauge {
+    private final AtomicLong numerator = new AtomicLong();
+    private final AtomicLong denominator = new AtomicLong();
+
+    public SemanticRatioGauge(final long numerator, final long denominator) {
+        this.numerator.set(numerator);
+        this.denominator.set(denominator);
+    }
+
+    public void setNumerator(final long value) {
+        numerator.set(value);
+    }
+
+    public void incNumerator() {
+        numerator.incrementAndGet();
+    }
+
+    public void decNumerator() {
+        numerator.decrementAndGet();
+    }
+
+    public void setDenominator(final long value) {
+        denominator.set(value);
+    }
+
+    public void incDenominator() {
+        denominator.incrementAndGet();
+    }
+
+    public void decDenominator() {
+        denominator.decrementAndGet();
+    }
+
+    @Override
+    protected Ratio getRatio() {
+        return Ratio.of(numerator.get(), denominator.get());
+    }
+}

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/Units.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/Units.java
@@ -35,4 +35,5 @@ final class Units {
     public static final String DROP = "drop";
     public static final String COUNT = "count";
     public static final String SAMPLE = "sample";
+    public static final String RATIO = "%";
 }


### PR DESCRIPTION
The new metric is of type "ratio" (added in this commit), and named
"consumer-threads-live-ratio". In normal operation it should always be 1.
Anything below 1 (except during startup), is likely a good basis for signalling
an alert.