### PR TITLE
[core] Use the new recursion safety feature in tiny-async

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/dagger/LoadingModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/dagger/LoadingModule.java
@@ -107,7 +107,12 @@ public class LoadingModule {
     @Provides
     @LoadingScope
     AsyncFramework async(ExecutorService executor, ScheduledExecutorService scheduler) {
-        return TinyAsync.builder().executor(executor).scheduler(scheduler).build();
+        return TinyAsync
+            .builder()
+            .recursionSafe(true)
+            .executor(executor)
+            .scheduler(scheduler)
+            .build();
     }
 
     @Provides


### PR DESCRIPTION
This makes DelayedCollectCoordinator able to handle when there's many AsyncFuture's linked that are immediately resolved. Previous to this change, that scenario would result in a stack overflow.

This requires tiny-async 1.11.0, which we just switched to.