### PR TITLE
Implement Query Logging

### DIFF
--- a/docs/heroic-querylog-logstash.conf
+++ b/docs/heroic-querylog-logstash.conf
@@ -1,0 +1,56 @@
+input {
+  file {
+    path => "/var/log/heroic/heroic-*.query_log"
+    type => "query_log"
+  }
+  file {
+    path => "/var/log/heroic/heroic-*.log"
+    type => "log"
+  }
+}
+
+filter {
+  # use timestamp from the log
+  if [type] == "query_log" {
+    json {
+      source => "message"
+      remove_field => "message"
+    }
+    date {
+      locale => "en"
+      match => ["timestamp", "ISO8601"]
+      timezone => "UTC"
+      target => "@timestamp"
+      remove_field => "timestamp"
+    }
+  } else if [type] == "log" {
+    json {
+      source => "message"
+    }
+    date {
+      locale => "en"
+      match => ["timeMillis", "UNIX_MS"]
+      timezone => "UTC"
+      target => "@timestamp"
+      remove_field => "timeMillis"
+    }
+  }
+}
+
+output {
+  # Send everything to Elasticsearch
+  if [type] == "query_log" {
+    elasticsearch {
+      index => "heroicapi-%{[@message][type]}-%{+YYYY.MM.dd}"
+      document_type => "entry"
+      hosts => []
+    }
+  } else if [type] == "log" {
+    elasticsearch {
+      index => "heroic-log-%{+YYYY.MM.dd}"
+      document_type => "entry"
+      hosts => []
+    }
+  }
+}
+

--- a/docs/heroic.example.yml
+++ b/docs/heroic.example.yml
@@ -188,3 +188,7 @@ metadata:
 #  # Timeout in milliseconds for reading from a server.
 #  # @default 120000
 #  #readTimeout: 120000
+
+## Detailed Query Logging
+#queryLogging:
+#  type: slf4j

--- a/docs/log4j2-file.xml
+++ b/docs/log4j2-file.xml
@@ -23,6 +23,18 @@
       </Policies>
       <DefaultRolloverStrategy max="100"/>
     </RollingFile>
+    <!-- Remove if you don't use queryLogging -->
+    <RollingFile name="query_log" fileName="/var/log/heroic/heroic.query_log"
+                 filePattern="/var/log/heroic/heroic-%d{MM-dd-yyyy}-%i.query_log.gz">
+      <PatternLayout>
+        <Pattern>%m%n</Pattern>
+      </PatternLayout>
+      <Policies>
+        <TimeBasedTriggeringPolicy />
+        <SizeBasedTriggeringPolicy size="100 MB"/>
+      </Policies>
+      <DefaultRolloverStrategy max="100"/>
+    </RollingFile>
   </Appenders>
   <Loggers>
     <Logger name="org.eclipse.jetty.server.RequestLog" level="INFO" additivity="false">
@@ -30,6 +42,10 @@
     </Logger>
     <Logger name="com.spotify.heroic" level="INFO" additivity="false">
       <AppenderRef ref="primary" />
+    </Logger>
+    <!-- Remove if you don't use queryLogging -->
+    <Logger name="com.spotify.heroic.query_logging" level="TRACE" additivity="false">
+      <AppenderRef ref="query_log" />
     </Logger>
     <Logger name="org.elasticsearch" level="INFO" additivity="false">
       <AppenderRef ref="primary" />

--- a/heroic-all/src/main/java/com/spotify/heroic/HeroicModules.java
+++ b/heroic-all/src/main/java/com/spotify/heroic/HeroicModules.java
@@ -69,7 +69,9 @@ public class HeroicModules {
         new com.spotify.heroic.rpc.grpc.Module(),
         new com.spotify.heroic.rpc.jvm.Module(),
 
-        new com.spotify.heroic.statistics.semantic.Module()
+        new com.spotify.heroic.statistics.semantic.Module(),
+
+        new com.spotify.heroic.querylogging.Module()
     );
 
     public static final Map<String, HeroicProfile> PROFILES = ImmutableMap.<String,

--- a/heroic-all/src/main/java/com/spotify/heroic/HeroicModules.java
+++ b/heroic-all/src/main/java/com/spotify/heroic/HeroicModules.java
@@ -34,6 +34,7 @@ import com.spotify.heroic.profile.ElasticsearchSuggestProfile;
 import com.spotify.heroic.profile.KafkaConsumerProfile;
 import com.spotify.heroic.profile.MemoryCacheProfile;
 import com.spotify.heroic.profile.MemoryProfile;
+import com.spotify.heroic.profile.QueryLoggingProfile;
 import com.spotify.heroic.profile.WebProfile;
 
 import java.io.OutputStreamWriter;
@@ -87,6 +88,7 @@ public class HeroicModules {
         .put("collectd", new CollectdConsumerProfile())
         .put("memory-cache", new MemoryCacheProfile())
         .put("web", new WebProfile())
+        .put("query-logging", new QueryLoggingProfile())
     .build();
     // @formatter:on
 

--- a/heroic-all/src/main/java/com/spotify/heroic/profile/QueryLoggingProfile.java
+++ b/heroic-all/src/main/java/com/spotify/heroic/profile/QueryLoggingProfile.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.profile;
+
+import static com.spotify.heroic.ParameterSpecification.parameter;
+
+import com.google.common.collect.ImmutableList;
+import com.spotify.heroic.ExtraParameters;
+import com.spotify.heroic.HeroicConfig;
+import com.spotify.heroic.ParameterSpecification;
+import com.spotify.heroic.querylogging.Slf4jQueryLoggingModule;
+import java.util.List;
+import java.util.Optional;
+
+public class QueryLoggingProfile extends HeroicProfileBase {
+    @Override
+    public HeroicConfig.Builder build(final ExtraParameters params) throws Exception {
+        final HeroicConfig.Builder builder = HeroicConfig.builder();
+
+        final String level = params.get("level").orElse("TRACE");
+
+        // @formatter:off
+        return builder
+            .queryLogging(
+                new Slf4jQueryLoggingModule(Optional.of("query_log"), Optional.of(level))
+            );
+        // @formatter:on
+    }
+
+    @Override
+    public Optional<String> scope() {
+        return Optional.of("query-logging");
+    }
+
+    @Override
+    public String description() {
+        // @formatter:off
+        return "Configures a basic query logger";
+        // @formatter:on
+    }
+
+    @Override
+    public List<ParameterSpecification> options() {
+        // @formatter:off
+        return ImmutableList.of(
+            parameter("level", "Specifies log level", "<level>")
+        );
+        // @formatter:on
+    }
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/QueryBuilder.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/QueryBuilder.java
@@ -21,6 +21,10 @@
 
 package com.spotify.heroic;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.spotify.heroic.common.Optionals.pickOptional;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import com.spotify.heroic.aggregation.Aggregation;
 import com.spotify.heroic.aggregation.Group;
 import com.spotify.heroic.common.FeatureSet;
@@ -29,15 +33,11 @@ import com.spotify.heroic.filter.Filter;
 import com.spotify.heroic.filter.MatchKeyFilter;
 import com.spotify.heroic.filter.MatchTagFilter;
 import com.spotify.heroic.metric.MetricType;
-import lombok.RequiredArgsConstructor;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.spotify.heroic.common.Optionals.pickOptional;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class QueryBuilder {
@@ -49,6 +49,7 @@ public class QueryBuilder {
     private Optional<QueryDateRange> range = Optional.empty();
     private Optional<Aggregation> aggregation = Optional.empty();
     private Optional<QueryOptions> options = Optional.empty();
+    private Optional<JsonNode> clientContext = Optional.empty();
     private Optional<FeatureSet> features = Optional.empty();
 
     /**
@@ -122,6 +123,12 @@ public class QueryBuilder {
     public QueryBuilder options(final Optional<QueryOptions> options) {
         checkNotNull(options, "options");
         this.options = pickOptional(this.options, options);
+        return this;
+    }
+
+    public QueryBuilder clientContext(final Optional<JsonNode> clientContext) {
+        checkNotNull(clientContext, "clientContext");
+        this.clientContext = pickOptional(this.clientContext, clientContext);
         return this;
     }
 

--- a/heroic-component/src/main/java/com/spotify/heroic/QueryManager.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/QueryManager.java
@@ -31,6 +31,7 @@ import com.spotify.heroic.metadata.FindTags;
 import com.spotify.heroic.metadata.WriteMetadata;
 import com.spotify.heroic.metric.QueryResult;
 import com.spotify.heroic.metric.WriteMetric;
+import com.spotify.heroic.querylogging.QueryContext;
 import com.spotify.heroic.suggest.KeySuggest;
 import com.spotify.heroic.suggest.TagKeyCount;
 import com.spotify.heroic.suggest.TagSuggest;
@@ -44,7 +45,7 @@ public interface QueryManager extends UsableGroupManager<QueryManager.Group> {
     QueryBuilder newQueryFromString(String query);
 
     interface Group {
-        AsyncFuture<QueryResult> query(Query query);
+        AsyncFuture<QueryResult> query(Query query, QueryContext queryContext);
 
         AsyncFuture<FindTags> findTags(final FindTags.Request request);
 

--- a/heroic-component/src/main/java/com/spotify/heroic/common/Histogram.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/Histogram.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.common;
+
+import com.google.common.collect.TreeMultiset;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.Data;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * Utility class to build basic statistics about quantities.
+ */
+@Data
+public class Histogram {
+    private final Optional<Long> median;
+    private final Optional<Long> p75;
+    private final Optional<Long> p99;
+    private final Optional<Long> min;
+    private final Optional<Long> max;
+    private final Optional<Double> mean;
+    private final Optional<Long> sum;
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final TreeMultiset<Long> samples = TreeMultiset.create(Long::compareTo);
+
+        public void add(final long sample) {
+            samples.add(sample);
+        }
+
+        public Histogram build() {
+            final List<Long> entries = samples.stream().collect(Collectors.toList());
+
+            final Optional<Long> median = nth(entries, 0.50);
+            final Optional<Long> p75 = nth(entries, 0.75);
+            final Optional<Long> p99 = nth(entries, 0.99);
+            final Optional<Long> min = nth(entries, 0.00);
+            final Optional<Long> max = nth(entries, 1.00);
+            final Pair<Optional<Double>, Optional<Long>> mean = meanAndSum(entries);
+
+            return new Histogram(median, p75, p99, min, max, mean.getLeft(), mean.getRight());
+        }
+
+        private Pair<Optional<Double>, Optional<Long>> meanAndSum(final List<Long> entries) {
+            long sum = 0L;
+            long count = 0L;
+
+            for (final long value : entries) {
+                sum += value;
+                count += 1;
+            }
+
+            if (count <= 0L) {
+                return Pair.of(Optional.empty(), Optional.empty());
+            }
+
+            final Optional<Double> mean = Optional.of((double) sum / (double) count);
+            return Pair.of(mean, Optional.of(sum));
+        }
+
+        /**
+         * Simplified accessor for n.
+         */
+        private Optional<Long> nth(final List<Long> samples, final double n) {
+            if (samples.isEmpty()) {
+                return Optional.empty();
+            }
+
+            final int index = Math.min(samples.size() - 1,
+                Math.max(0, (int) Math.round(((double) samples.size()) * n) - 1));
+
+            return Optional.of(samples.get(index));
+        }
+    }
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/dagger/CoreComponent.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/dagger/CoreComponent.java
@@ -29,18 +29,18 @@ import com.spotify.heroic.generator.GeneratorComponent;
 import com.spotify.heroic.ingestion.IngestionComponent;
 import com.spotify.heroic.metadata.MetadataComponent;
 import com.spotify.heroic.metric.MetricComponent;
+import com.spotify.heroic.querylogging.QueryLoggingComponent;
 import com.spotify.heroic.suggest.SuggestComponent;
 import dagger.Component;
 
-@Component(
-    dependencies = {
-        PrimaryComponent.class, MetadataComponent.class, MetricComponent.class,
-        AnalyticsComponent.class, SuggestComponent.class, ConsumersComponent.class,
-        QueryComponent.class, IngestionComponent.class, ClusterComponent.class,
-        GeneratorComponent.class
-    })
+@Component(dependencies = {
+    PrimaryComponent.class, MetadataComponent.class, MetricComponent.class,
+    AnalyticsComponent.class, SuggestComponent.class, ConsumersComponent.class,
+    QueryComponent.class, QueryLoggingComponent.class, IngestionComponent.class,
+    ClusterComponent.class, GeneratorComponent.class
+})
 public interface CoreComponent
     extends PrimaryComponent, MetadataComponent, MetricComponent, AnalyticsComponent,
-    SuggestComponent, ConsumersComponent, QueryComponent, IngestionComponent, ClusterComponent,
-    GeneratorComponent {
+    SuggestComponent, ConsumersComponent, QueryComponent, QueryLoggingComponent,
+    IngestionComponent, ClusterComponent, GeneratorComponent {
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/FullQuery.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/FullQuery.java
@@ -93,6 +93,20 @@ public final class FullQuery {
         return new FullQuery(newTrace, errors, groups, statistics, limits);
     }
 
+    public Summary summarize() {
+        return new Summary(trace, errors, ResultGroup.summarize(groups), statistics, limits);
+    }
+
+    // Only include data suitable to log to query log
+    @Data
+    public class Summary {
+        private final QueryTrace trace;
+        private final List<RequestError> errors;
+        private final ResultGroup.MultiSummary groups;
+        private final Statistics statistics;
+        private final ResultLimits limits;
+    }
+
     @Data
     public static class Request {
         private final MetricType source;
@@ -100,5 +114,18 @@ public final class FullQuery {
         private final DateRange range;
         private final AggregationInstance aggregation;
         private final QueryOptions options;
+
+        public Summary summarize() {
+            return new Summary(source, filter, range, aggregation, options);
+        }
+
+        @Data
+        public class Summary {
+            private final MetricType source;
+            private final Filter filter;
+            private final DateRange range;
+            private final AggregationInstance aggregation;
+            private final QueryOptions options;
+        }
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/FullQuery.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/FullQuery.java
@@ -29,6 +29,7 @@ import com.spotify.heroic.cluster.ClusterShard;
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Statistics;
 import com.spotify.heroic.filter.Filter;
+import com.spotify.heroic.querylogging.QueryContext;
 import eu.toolchain.async.Collector;
 import eu.toolchain.async.Transform;
 import java.util.List;
@@ -114,6 +115,7 @@ public final class FullQuery {
         private final DateRange range;
         private final AggregationInstance aggregation;
         private final QueryOptions options;
+        private final QueryContext context;
 
         public Summary summarize() {
             return new Summary(source, filter, range, aggregation, options);

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/MetricCollection.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/MetricCollection.java
@@ -21,21 +21,20 @@
 
 package com.spotify.heroic.metric;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
 import com.spotify.heroic.aggregation.AggregationSession;
 import com.spotify.heroic.common.Series;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
 
 /**
  * A collection of metrics.

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetrics.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetrics.java
@@ -19,7 +19,7 @@
  * under the License.
  */
 
-package com.spotify.heroic.http.query;
+package com.spotify.heroic.metric;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -30,7 +30,6 @@ import com.spotify.heroic.aggregation.Aggregation;
 import com.spotify.heroic.aggregation.Chain;
 import com.spotify.heroic.common.FeatureSet;
 import com.spotify.heroic.filter.Filter;
-import com.spotify.heroic.metric.MetricType;
 import lombok.Data;
 
 import java.util.List;

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetrics.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetrics.java
@@ -21,8 +21,11 @@
 
 package com.spotify.heroic.metric;
 
+import static com.spotify.heroic.common.Optionals.firstPresent;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.spotify.heroic.QueryBuilder;
 import com.spotify.heroic.QueryDateRange;
 import com.spotify.heroic.QueryOptions;
@@ -30,15 +33,12 @@ import com.spotify.heroic.aggregation.Aggregation;
 import com.spotify.heroic.aggregation.Chain;
 import com.spotify.heroic.common.FeatureSet;
 import com.spotify.heroic.filter.Filter;
-import lombok.Data;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
-
-import static com.spotify.heroic.common.Optionals.firstPresent;
+import lombok.Data;
 
 @Data
 public class QueryMetrics {
@@ -48,6 +48,7 @@ public class QueryMetrics {
     private final Optional<QueryDateRange> range;
     private final Optional<Filter> filter;
     private final Optional<QueryOptions> options;
+    private final Optional<JsonNode> clientContext;
 
     /* legacy state */
     private final Optional<String> key;
@@ -57,7 +58,8 @@ public class QueryMetrics {
 
     public QueryMetrics(
         Optional<String> query, Optional<Aggregation> aggregation, Optional<MetricType> source,
-        Optional<QueryDateRange> range, Optional<Filter> filter, Optional<QueryOptions> options
+        Optional<QueryDateRange> range, Optional<Filter> filter, Optional<QueryOptions> options,
+        final Optional<JsonNode> clientContext
     ) {
         this.query = query;
         this.aggregation = aggregation;
@@ -65,6 +67,7 @@ public class QueryMetrics {
         this.range = range;
         this.filter = filter;
         this.options = options;
+        this.clientContext = clientContext;
 
         this.key = Optional.empty();
         this.tags = Optional.empty();
@@ -79,10 +82,12 @@ public class QueryMetrics {
         @JsonProperty("aggregators") Optional<List<Aggregation>> aggregators,
         @JsonProperty("source") Optional<String> source,
         @JsonProperty("range") Optional<QueryDateRange> range,
-        @JsonProperty("filter") Optional<Filter> filter, @JsonProperty("key") Optional<String> key,
+        @JsonProperty("filter") Optional<Filter> filter,
+        @JsonProperty("options") Optional<QueryOptions> options,
+        @JsonProperty("clientContext") Optional<JsonNode> clientContext,
+        @JsonProperty("key") Optional<String> key,
         @JsonProperty("tags") Optional<Map<String, String>> tags,
         @JsonProperty("groupBy") Optional<List<String>> groupBy,
-        @JsonProperty("options") Optional<QueryOptions> options,
         @JsonProperty("features") Optional<FeatureSet> features,
         /* ignored */ @JsonProperty("noCache") Boolean noCache
     ) {
@@ -93,6 +98,7 @@ public class QueryMetrics {
         this.range = range;
         this.filter = filter;
         this.options = options;
+        this.clientContext = clientContext;
 
         this.key = key;
         this.tags = tags;
@@ -110,7 +116,8 @@ public class QueryMetrics {
                 .range(range)
                 .aggregation(aggregation)
                 .source(source)
-                .options(options);
+                .options(options)
+                .clientContext(clientContext);
         };
 
         return query

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetricsResponse.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetricsResponse.java
@@ -19,7 +19,7 @@
  * under the License.
  */
 
-package com.spotify.heroic.http.query;
+package com.spotify.heroic.metric;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -27,12 +27,6 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Statistics;
-import com.spotify.heroic.metric.MetricCollection;
-import com.spotify.heroic.metric.QueryTrace;
-import com.spotify.heroic.metric.RequestError;
-import com.spotify.heroic.metric.ResultLimits;
-import com.spotify.heroic.metric.SeriesValues;
-import com.spotify.heroic.metric.ShardedResultGroup;
 import lombok.Data;
 import lombok.NonNull;
 

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetricsResponse.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetricsResponse.java
@@ -27,9 +27,6 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Statistics;
-import lombok.Data;
-import lombok.NonNull;
-
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,6 +34,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
+import lombok.Data;
+import lombok.NonNull;
 
 @Data
 @JsonSerialize(using = QueryMetricsResponse.Serializer.class)
@@ -232,5 +231,21 @@ public class QueryMetricsResponse {
 
             g.writeEndObject();
         }
+    }
+
+    public Summary summarize() {
+        return new Summary(range, ShardedResultGroup.summarize(result), statistics, errors, trace,
+            limits);
+    }
+
+    // Only include data suitable to log to query log
+    @Data
+    public class Summary {
+        private final DateRange range;
+        private final ShardedResultGroup.MultiSummary result;
+        private final Statistics statistics;
+        private final List<RequestError> errors;
+        private final QueryTrace trace;
+        private final ResultLimits limits;
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetricsResponse.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetricsResponse.java
@@ -168,7 +168,7 @@ public class QueryMetricsResponse {
                 final SeriesValues series = SeriesValues.fromSeries(group.getSeries().iterator());
 
                 g.writeStringField("type", collection.getType().identifier());
-                g.writeStringField("hash", Integer.toHexString(group.hashCode()));
+                g.writeStringField("hash", Integer.toHexString(group.hashGroup()));
                 g.writeObjectField("shard", group.getShard());
                 g.writeNumberField("cadence", group.getCadence());
                 g.writeObjectField("values", collection.getData());

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetricsResponse.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetricsResponse.java
@@ -34,12 +34,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.UUID;
+
 import lombok.Data;
 import lombok.NonNull;
 
 @Data
 @JsonSerialize(using = QueryMetricsResponse.Serializer.class)
 public class QueryMetricsResponse {
+    @NonNull
+    private final UUID queryId;
+
     @NonNull
     private final DateRange range;
 
@@ -68,6 +73,7 @@ public class QueryMetricsResponse {
 
             g.writeStartObject();
 
+            g.writeObjectField("queryId", response.getQueryId());
             g.writeObjectField("range", response.getRange());
             g.writeObjectField("trace", response.getTrace());
             g.writeObjectField("limits", response.getLimits());

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/SeriesSetsSummarizer.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/SeriesSetsSummarizer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.metric;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.spotify.heroic.common.Histogram;
+import com.spotify.heroic.common.Series;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.Data;
+
+@Data
+public class SeriesSetsSummarizer {
+    private HashSet<String> uniqueKeys = new HashSet<>();
+    private Multimap<String, String> tags = HashMultimap.create();
+    private final Histogram.Builder seriesSize = Histogram.builder();
+
+    public void add(Set<Series> series) {
+        this.seriesSize.add(series.size());
+
+        for (final Series s : series) {
+            uniqueKeys.add(s.getKey());
+
+            for (Map.Entry<String, String> e : s.getTags().entrySet()) {
+                tags.put(e.getKey(), e.getValue());
+            }
+        }
+    }
+
+    public Summary end() {
+        final Histogram.Builder tagsSize = Histogram.builder();
+
+        for (final Map.Entry<String, Collection<String>> e : this.tags.asMap().entrySet()) {
+            tagsSize.add(e.getValue().size());
+        }
+
+        return new Summary(uniqueKeys.size(), tagsSize.build(), seriesSize.build());
+    }
+
+    @Data
+    public static class Summary {
+        final long uniqueKeys;
+        final Histogram tagsSize;
+        final Histogram seriesSize;
+    }
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/ShardedResultGroup.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/ShardedResultGroup.java
@@ -21,12 +21,15 @@
 
 package com.spotify.heroic.metric;
 
+import com.google.common.collect.ImmutableSet;
+import com.spotify.heroic.common.Histogram;
 import com.spotify.heroic.common.Series;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
-import java.util.Map;
-import java.util.Set;
 
 @Data
 @EqualsAndHashCode
@@ -39,5 +42,33 @@ public final class ShardedResultGroup {
 
     public boolean isEmpty() {
         return metrics.isEmpty();
+    }
+
+    public static MultiSummary summarize(List<ShardedResultGroup> resultGroups) {
+        final ImmutableSet.Builder<Map<String, String>> shardSummary = ImmutableSet.builder();
+        final Histogram.Builder keySize = Histogram.builder();
+        final SeriesSetsSummarizer seriesSummarizer = new SeriesSetsSummarizer();
+        final Histogram.Builder dataSize = Histogram.builder();
+        Optional<Long> cadence = Optional.empty();
+
+        for (ShardedResultGroup rg : resultGroups) {
+            shardSummary.add(rg.getShard());
+            keySize.add(rg.getKey().size());
+            seriesSummarizer.add(rg.getSeries());
+            dataSize.add(rg.getMetrics().size());
+            cadence = Optional.of(rg.getCadence());
+        }
+
+        return new MultiSummary(shardSummary.build(), keySize.build(), seriesSummarizer.end(),
+            dataSize.build(), cadence);
+    }
+
+    @Data
+    public static class MultiSummary {
+        private final Set<Map<String, String>> shards;
+        private final Histogram keySize;
+        private final SeriesSetsSummarizer.Summary series;
+        private final Histogram dataSize;
+        private final Optional<Long> cadence;
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/ShardedResultGroup.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/ShardedResultGroup.java
@@ -21,7 +21,12 @@
 
 package com.spotify.heroic.metric;
 
+import static com.google.common.hash.Hashing.murmur3_32;
+
+import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hasher;
 import com.spotify.heroic.common.Histogram;
 import com.spotify.heroic.common.Series;
 import java.util.List;
@@ -42,6 +47,20 @@ public final class ShardedResultGroup {
 
     public boolean isEmpty() {
         return metrics.isEmpty();
+    }
+
+    public int hashCode() {
+        final Hasher hasher = murmur3_32().newHasher();
+        for (Map.Entry<String, String> e : shard.entrySet()) {
+            hasher.putString(e.getKey(), Charsets.UTF_8);
+            hasher.putString(e.getValue(), Charsets.UTF_8);
+        }
+        for (Map.Entry<String, String> e : key.entrySet()) {
+            hasher.putString(e.getKey(), Charsets.UTF_8);
+            hasher.putString(e.getValue(), Charsets.UTF_8);
+        }
+        HashCode code = hasher.hash();
+        return code.asInt();
     }
 
     public static MultiSummary summarize(List<ShardedResultGroup> resultGroups) {

--- a/heroic-component/src/main/java/com/spotify/heroic/querylogging/HttpContext.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/querylogging/HttpContext.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.querylogging;
+
+import java.util.Optional;
+import lombok.Data;
+
+@Data
+public class HttpContext {
+    /**
+     * The remote address that connected to this node.
+     */
+    private final String remoteAddress;
+    /**
+     * The remote host (usually same as address) that connected to this node.
+     */
+    private final String remoteHost;
+    /**
+     * The client address that performed the request.
+     * Most notably, if X-Forwarded-For is set, this will be the value of it.
+     * Otherwise it is the same as {@link #remoteAddress}.
+     */
+    private final String clientAddress;
+    /**
+     * The user agent of the client that performed the request.
+     */
+    private final Optional<String> userAgent;
+    /**
+     * The id of the client that performed the request.
+     */
+    private final Optional<String> clientId;
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryContext.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryContext.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.querylogging;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class QueryContext {
+    private static final JsonNode EMPTY = JsonNodeFactory.instance.nullNode();
+
+    private final UUID queryId;
+    private final JsonNode clientContext;
+
+    public static QueryContext empty() {
+        return create(Optional.empty());
+    }
+
+    public static QueryContext create(final Optional<JsonNode> clientContext) {
+        return new QueryContext(UUID.randomUUID(), clientContext.orElse(EMPTY));
+    }
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryLogger.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryLogger.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.querylogging;
+
+import com.spotify.heroic.Query;
+import com.spotify.heroic.metric.FullQuery;
+import com.spotify.heroic.metric.QueryMetrics;
+import com.spotify.heroic.metric.QueryMetricsResponse;
+
+public interface QueryLogger {
+
+    void logHttpQueryText(QueryContext context, String queryString, HttpContext httpContext);
+
+    void logHttpQueryJson(QueryContext context, QueryMetrics query, HttpContext httpContext);
+
+    void logQuery(QueryContext context, Query query);
+
+    void logOutgoingRequestToShards(QueryContext context, FullQuery.Request request);
+
+    void logIncomingRequestAtNode(QueryContext context, FullQuery.Request request);
+
+    void logOutgoingResponseAtNode(QueryContext context, FullQuery response);
+
+    void logIncomingResponseFromShard(QueryContext context, FullQuery response);
+
+    void logFinalResponse(QueryContext context, QueryMetricsResponse queryMetricsResponse);
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryLoggerFactory.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryLoggerFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.querylogging;
+
+public interface QueryLoggerFactory {
+    QueryLogger create(String component);
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryLoggingComponent.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryLoggingComponent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.querylogging;
+
+public interface QueryLoggingComponent {
+    QueryLoggerFactory queryLoggerFactory();
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryLoggingModule.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryLoggingModule.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.querylogging;
+
+import com.spotify.heroic.dagger.PrimaryComponent;
+
+public interface QueryLoggingModule {
+    QueryLoggingComponent component(PrimaryComponent early);
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryLoggingScope.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryLoggingScope.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.querylogging;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import javax.inject.Scope;
+
+@Scope
+@Retention(RetentionPolicy.RUNTIME)
+public @interface QueryLoggingScope {
+}

--- a/heroic-component/src/test/java/com/spotify/heroic/common/HistogramTest.java
+++ b/heroic-component/src/test/java/com/spotify/heroic/common/HistogramTest.java
@@ -1,0 +1,57 @@
+package com.spotify.heroic.common;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Optional;
+import org.junit.Test;
+
+public class HistogramTest {
+    @Test
+    public void basic() {
+        final Histogram.Builder builder = Histogram.builder();
+
+        builder.add(100L);
+        builder.add(200L);
+        builder.add(300L);
+        builder.add(400L);
+
+        final Histogram h = builder.build();
+
+        assertEquals(Optional.of(100L), h.getMin());
+        assertEquals(Optional.of(400L), h.getMax());
+        assertEquals(Optional.of(300L), h.getP75());
+        assertEquals(Optional.of(400L), h.getP99());
+        assertEquals(Optional.of(250.0), h.getMean());
+        assertEquals(Optional.of(1000L), h.getSum());
+    }
+
+    @Test
+    public void empty() {
+        final Histogram.Builder builder = Histogram.builder();
+
+        final Histogram h = builder.build();
+
+        assertEquals(Optional.empty(), h.getMin());
+        assertEquals(Optional.empty(), h.getMax());
+        assertEquals(Optional.empty(), h.getP75());
+        assertEquals(Optional.empty(), h.getP99());
+        assertEquals(Optional.empty(), h.getMean());
+        assertEquals(Optional.empty(), h.getSum());
+    }
+
+    @Test
+    public void one() {
+        final Histogram.Builder builder = Histogram.builder();
+
+        builder.add(100L);
+
+        final Histogram h = builder.build();
+
+        assertEquals(Optional.of(100L), h.getMin());
+        assertEquals(Optional.of(100L), h.getMax());
+        assertEquals(Optional.of(100L), h.getP75());
+        assertEquals(Optional.of(100L), h.getP99());
+        assertEquals(Optional.of(100.0), h.getMean());
+        assertEquals(Optional.of(100L), h.getSum());
+    }
+}

--- a/heroic-component/src/test/java/com/spotify/heroic/metric/ShardedResultGroupTest.java
+++ b/heroic-component/src/test/java/com/spotify/heroic/metric/ShardedResultGroupTest.java
@@ -1,0 +1,22 @@
+package com.spotify.heroic.metric;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotEquals;
+
+public class ShardedResultGroupTest {
+    @Test
+    public void testHashGroup() {
+        final ShardedResultGroup g1 =
+            new ShardedResultGroup(ImmutableMap.of("aa", "bb"), ImmutableMap.of("cc", "dd"),
+                ImmutableSet.of(), MetricCollection.empty(), 0L);
+
+        final ShardedResultGroup g2 =
+            new ShardedResultGroup(ImmutableMap.of("", ""), ImmutableMap.of("aabb", "ccdd"),
+                ImmutableSet.of(), MetricCollection.empty(), 0L);
+
+        assertNotEquals(g1.hashGroup(), g2.hashGroup());
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/CoreQueryComponent.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/CoreQueryComponent.java
@@ -24,12 +24,14 @@ package com.spotify.heroic;
 import com.spotify.heroic.cache.CacheComponent;
 import com.spotify.heroic.cluster.ClusterComponent;
 import com.spotify.heroic.dagger.CorePrimaryComponent;
+import com.spotify.heroic.querylogging.QueryLoggingComponent;
 import dagger.Component;
 
 @QueryScope
 @Component(
     modules = QueryModule.class,
-    dependencies = {CorePrimaryComponent.class, ClusterComponent.class, CacheComponent.class})
+    dependencies = {CorePrimaryComponent.class, ClusterComponent.class, CacheComponent.class,
+        QueryLoggingComponent.class})
 public interface CoreQueryComponent extends QueryComponent {
     @Override
     CoreQueryManager queryManager();

--- a/heroic-core/src/main/java/com/spotify/heroic/HeroicConfig.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/HeroicConfig.java
@@ -21,6 +21,13 @@
 
 package com.spotify.heroic;
 
+import static com.spotify.heroic.common.Optionals.mergeOptional;
+import static com.spotify.heroic.common.Optionals.mergeOptionalList;
+import static com.spotify.heroic.common.Optionals.pickOptional;
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -40,16 +47,12 @@ import com.spotify.heroic.ingestion.IngestionModule;
 import com.spotify.heroic.jetty.JettyServerConnector;
 import com.spotify.heroic.metadata.MetadataManagerModule;
 import com.spotify.heroic.metric.MetricManagerModule;
+import com.spotify.heroic.querylogging.QueryLoggingModule;
+import com.spotify.heroic.querylogging.noop.NoopQueryLoggingModule;
 import com.spotify.heroic.shell.ShellServerModule;
 import com.spotify.heroic.statistics.StatisticsModule;
 import com.spotify.heroic.statistics.noop.NoopStatisticsModule;
 import com.spotify.heroic.suggest.SuggestManagerModule;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -59,13 +62,11 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-
-import static com.spotify.heroic.common.Optionals.mergeOptional;
-import static com.spotify.heroic.common.Optionals.mergeOptionalList;
-import static com.spotify.heroic.common.Optionals.pickOptional;
-import static java.util.Objects.requireNonNull;
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -112,6 +113,7 @@ public class HeroicConfig {
     private final AnalyticsModule analytics;
     private final CoreGeneratorModule generator;
     private final StatisticsModule statistics;
+    private final QueryLoggingModule queryLogging;
 
     private final String version;
     private final String service;
@@ -191,6 +193,7 @@ public class HeroicConfig {
         private Optional<AnalyticsModule.Builder> analytics = empty();
         private Optional<CoreGeneratorModule.Builder> generator = empty();
         private Optional<StatisticsModule> statistics = empty();
+        private Optional<QueryLoggingModule> queryLogging = empty();
 
         private Optional<String> version = empty();
         private Optional<String> service = empty();
@@ -281,6 +284,11 @@ public class HeroicConfig {
             return this;
         }
 
+        public Builder queryLogging(QueryLoggingModule queryLogging) {
+            this.queryLogging = of(queryLogging);
+            return this;
+        }
+
         public Builder merge(Builder o) {
             // @formatter:off
             return new Builder(
@@ -305,6 +313,7 @@ public class HeroicConfig {
                 pickOptional(analytics, o.analytics),
                 mergeOptional(generator, o.generator, CoreGeneratorModule.Builder::merge),
                 pickOptional(statistics, o.statistics),
+                pickOptional(queryLogging, o.queryLogging),
                 pickOptional(service, o.service),
                 pickOptional(version, o.version)
             );
@@ -344,6 +353,7 @@ public class HeroicConfig {
                 analytics.map(AnalyticsModule.Builder::build).orElseGet(NullAnalyticsModule::new),
                 generator.orElseGet(CoreGeneratorModule::builder).build(),
                 statistics.orElseGet(NoopStatisticsModule::new),
+                queryLogging.orElseGet(NoopQueryLoggingModule::new),
                 version.orElse(defaultVersion),
                 service.orElse(DEFAULT_SERVICE)
             );

--- a/heroic-core/src/main/java/com/spotify/heroic/HeroicMappers.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/HeroicMappers.java
@@ -58,6 +58,7 @@ import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.PointSerialization;
 import com.spotify.heroic.metric.Spread;
 import com.spotify.heroic.metric.SpreadSerialization;
+import com.spotify.heroic.querylogging.QueryLoggingModule;
 import com.spotify.heroic.statistics.StatisticsModule;
 import com.spotify.heroic.suggest.SuggestModule;
 
@@ -86,6 +87,7 @@ public final class HeroicMappers {
         m.addMixIn(JettyConnectionFactory.Builder.class, TypeNameMixin.class);
         m.addMixIn(AnalyticsModule.Builder.class, TypeNameMixin.class);
         m.addMixIn(StatisticsModule.class, TypeNameMixin.class);
+        m.addMixIn(QueryLoggingModule.class, TypeNameMixin.class);
 
         m.registerModule(commonSerializers());
 

--- a/heroic-core/src/main/java/com/spotify/heroic/QueryModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/QueryModule.java
@@ -26,9 +26,8 @@ import com.spotify.heroic.statistics.ApiReporter;
 import com.spotify.heroic.statistics.HeroicReporter;
 import dagger.Module;
 import dagger.Provides;
-import lombok.Data;
-
 import javax.inject.Named;
+import lombok.Data;
 
 @Module
 @Data

--- a/heroic-core/src/main/java/com/spotify/heroic/filter/FilterRegistry.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/filter/FilterRegistry.java
@@ -21,6 +21,9 @@
 
 package com.spotify.heroic.filter;
 
+import static com.spotify.heroic.filter.FilterEncoding.filter;
+import static com.spotify.heroic.filter.FilterEncoding.string;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -34,15 +37,11 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.ImmutableMap;
 import com.spotify.heroic.grammar.QueryParser;
-import lombok.RequiredArgsConstructor;
-
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-
-import static com.spotify.heroic.filter.FilterEncoding.filter;
-import static com.spotify.heroic.filter.FilterEncoding.string;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class FilterRegistry {

--- a/heroic-core/src/main/java/com/spotify/heroic/http/CoreHttpContextFactory.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/CoreHttpContextFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.http;
+
+import com.spotify.heroic.querylogging.HttpContext;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+
+public class CoreHttpContextFactory {
+    public static HttpContext create(final HttpServletRequest servletRequest) {
+        final Optional<String> xForwardedFor =
+            Optional.ofNullable(servletRequest.getHeader("X-Forwarded-For"));
+        final String remoteAddress = servletRequest.getRemoteAddr();
+        final String clientAddress = xForwardedFor.orElse(remoteAddress);
+        final Optional<String> userAgent =
+            Optional.ofNullable(servletRequest.getHeader("User-Agent"));
+        final Optional<String> clientId =
+            Optional.ofNullable(servletRequest.getHeader("X-Client-Id"));
+
+        return new HttpContext(remoteAddress, servletRequest.getRemoteHost(), clientAddress,
+            userAgent, clientId);
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryBatch.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryBatch.java
@@ -22,6 +22,7 @@
 package com.spotify.heroic.http.query;
 
 import com.spotify.heroic.QueryDateRange;
+import com.spotify.heroic.metric.QueryMetrics;
 import lombok.Data;
 
 import java.util.Map;

--- a/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryBatchResponse.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryBatchResponse.java
@@ -21,6 +21,7 @@
 
 package com.spotify.heroic.http.query;
 
+import com.spotify.heroic.metric.QueryMetricsResponse;
 import lombok.Data;
 
 import java.util.Map;

--- a/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryResource.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryResource.java
@@ -25,6 +25,8 @@ import com.google.common.collect.ImmutableMap;
 import com.spotify.heroic.Query;
 import com.spotify.heroic.QueryManager;
 import com.spotify.heroic.common.JavaxRestFramework;
+import com.spotify.heroic.metric.QueryMetrics;
+import com.spotify.heroic.metric.QueryMetricsResponse;
 import com.spotify.heroic.metric.QueryResult;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;

--- a/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryResource.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryResource.java
@@ -25,15 +25,24 @@ import com.google.common.collect.ImmutableMap;
 import com.spotify.heroic.Query;
 import com.spotify.heroic.QueryManager;
 import com.spotify.heroic.common.JavaxRestFramework;
+import com.spotify.heroic.http.CoreHttpContextFactory;
 import com.spotify.heroic.metric.QueryMetrics;
 import com.spotify.heroic.metric.QueryMetricsResponse;
 import com.spotify.heroic.metric.QueryResult;
+import com.spotify.heroic.querylogging.HttpContext;
+import com.spotify.heroic.querylogging.QueryContext;
+import com.spotify.heroic.querylogging.QueryLogger;
+import com.spotify.heroic.querylogging.QueryLoggerFactory;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.Data;
-import org.apache.commons.lang3.tuple.Pair;
-
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -41,13 +50,10 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
+import lombok.Data;
+import org.apache.commons.lang3.tuple.Triple;
 
 @Path("query")
 @Produces(MediaType.APPLICATION_JSON)
@@ -56,26 +62,36 @@ public class QueryResource {
     private final JavaxRestFramework httpAsync;
     private final QueryManager query;
     private final AsyncFramework async;
+    private final QueryLogger queryLogger;
 
     @Inject
-    public QueryResource(JavaxRestFramework httpAsync, QueryManager query, AsyncFramework async) {
+    public QueryResource(
+        final JavaxRestFramework httpAsync, final QueryManager query, final AsyncFramework async,
+        final QueryLoggerFactory queryLoggerFactory
+    ) {
         this.httpAsync = httpAsync;
         this.query = query;
         this.async = async;
+        this.queryLogger = queryLoggerFactory.create("QueryResource");
     }
 
     @POST
     @Path("metrics")
     @Consumes(MediaType.TEXT_PLAIN)
     public void metricsText(
-        @Suspended final AsyncResponse response, @QueryParam("group") String group, String query
+        @Suspended final AsyncResponse response, @QueryParam("group") String group,
+        @Context final HttpServletRequest servletReq, final String query
     ) {
+        final HttpContext httpContext = CoreHttpContextFactory.create(servletReq);
+        final QueryContext queryContext = QueryContext.empty();
+        queryLogger.logHttpQueryText(queryContext, query, httpContext);
+
         final Query q = this.query.newQueryFromString(query).build();
 
         final QueryManager.Group g = this.query.useOptionalGroup(Optional.ofNullable(group));
-        final AsyncFuture<QueryResult> callback = g.query(q);
+        final AsyncFuture<QueryResult> callback = g.query(q, queryContext);
 
-        bindMetricsResponse(response, callback);
+        bindMetricsResponse(response, callback, queryContext);
     }
 
     @POST
@@ -83,35 +99,47 @@ public class QueryResource {
     @Consumes(MediaType.APPLICATION_JSON)
     public void metrics(
         @Suspended final AsyncResponse response, @QueryParam("group") String group,
-        QueryMetrics query
+        @Context final HttpServletRequest servletReq, final QueryMetrics query
     ) {
+        final HttpContext httpContext = CoreHttpContextFactory.create(servletReq);
+        final QueryContext queryContext = QueryContext.create(query.getClientContext());
+        queryLogger.logHttpQueryJson(queryContext, query, httpContext);
+
         final Query q = query.toQueryBuilder(this.query::newQueryFromString).build();
 
         final QueryManager.Group g = this.query.useOptionalGroup(Optional.ofNullable(group));
-        final AsyncFuture<QueryResult> callback = g.query(q);
+        final AsyncFuture<QueryResult> callback = g.query(q, queryContext);
 
-        bindMetricsResponse(response, callback);
+        bindMetricsResponse(response, callback, queryContext);
     }
 
     @POST
     @Path("batch")
     public void metrics(
         @Suspended final AsyncResponse response, @QueryParam("backend") String group,
-        final QueryBatch query
+        @Context final HttpServletRequest servletReq, final QueryBatch query
     ) {
+        final HttpContext httpContext = CoreHttpContextFactory.create(servletReq);
         final QueryManager.Group g = this.query.useOptionalGroup(Optional.ofNullable(group));
 
-        final List<AsyncFuture<Pair<String, QueryResult>>> futures = new ArrayList<>();
+        final List<AsyncFuture<Triple<String, QueryContext, QueryResult>>> futures =
+            new ArrayList<>();
 
         query.getQueries().ifPresent(queries -> {
             for (final Map.Entry<String, QueryMetrics> e : queries.entrySet()) {
-                final Query q = e
-                    .getValue()
+                final String queryKey = e.getKey();
+                final QueryMetrics qm = e.getValue();
+                final Query q = qm
                     .toQueryBuilder(this.query::newQueryFromString)
                     .rangeIfAbsent(query.getRange())
                     .build();
 
-                futures.add(g.query(q).directTransform(r -> Pair.of(e.getKey(), r)));
+                final QueryContext queryContext = QueryContext.create(qm.getClientContext());
+                queryLogger.logHttpQueryJson(queryContext, qm, httpContext);
+
+                futures.add(g
+                    .query(q, queryContext)
+                    .directTransform(r -> Triple.of(queryKey, queryContext, r)));
             }
         });
 
@@ -120,11 +148,17 @@ public class QueryResource {
                 final ImmutableMap.Builder<String, QueryMetricsResponse> results =
                     ImmutableMap.builder();
 
-                for (final Pair<String, QueryResult> e : entries) {
+                for (final Triple<String, QueryContext, QueryResult> e : entries) {
+                    final String queryKey = e.getLeft();
+                    final QueryContext queryContext = e.getMiddle();
                     final QueryResult r = e.getRight();
-                    results.put(e.getLeft(),
-                        new QueryMetricsResponse(r.getRange(), r.getGroups(), r.getErrors(),
-                            r.getTrace(), r.getLimits()));
+                    final QueryMetricsResponse qmr =
+                        new QueryMetricsResponse(queryContext.getQueryId(), r.getRange(),
+                            r.getGroups(), r.getErrors(), r.getTrace(), r.getLimits());
+
+                    queryLogger.logFinalResponse(queryContext, qmr);
+
+                    results.put(queryKey, qmr);
                 }
 
                 return new QueryBatchResponse(results.build());
@@ -136,13 +170,18 @@ public class QueryResource {
     }
 
     private void bindMetricsResponse(
-        final AsyncResponse response, final AsyncFuture<QueryResult> callback
+        final AsyncResponse response, final AsyncFuture<QueryResult> callback,
+        final QueryContext queryContext
     ) {
         response.setTimeout(300, TimeUnit.SECONDS);
 
-        httpAsync.bind(response, callback,
-            r -> new QueryMetricsResponse(r.getRange(), r.getGroups(), r.getErrors(), r.getTrace(),
-                r.getLimits()));
+        httpAsync.bind(response, callback, r -> {
+            QueryMetricsResponse qmr =
+                new QueryMetricsResponse(queryContext.getQueryId(), r.getRange(), r.getGroups(),
+                    r.getErrors(), r.getTrace(), r.getLimits());
+            queryLogger.logFinalResponse(queryContext, qmr);
+            return qmr;
+        });
     }
 
     @Data

--- a/heroic-core/src/main/java/com/spotify/heroic/http/render/RenderResource.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/render/RenderResource.java
@@ -23,10 +23,12 @@ package com.spotify.heroic.http.render;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spotify.heroic.Query;
+import com.spotify.heroic.querylogging.QueryContext;
 import com.spotify.heroic.QueryManager;
 import com.spotify.heroic.metric.QueryResult;
-import org.jfree.chart.JFreeChart;
-
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.util.Map;
 import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -37,9 +39,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
-import java.util.Map;
+import org.jfree.chart.JFreeChart;
 
 @Path("render")
 public class RenderResource {
@@ -87,9 +87,10 @@ public class RenderResource {
             highlight = null;
         }
 
+        final QueryContext queryContext = QueryContext.empty();
         final Query q = query.newQueryFromString(queryString).build();
 
-        final QueryResult result = this.query.useGroup(backendGroup).query(q).get();
+        final QueryResult result = this.query.useGroup(backendGroup).query(q, queryContext).get();
 
         final JFreeChart chart =
             RenderUtils.createChart(result.getGroups(), title, highlight, threshold, height);

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/CoreMetricComponent.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/CoreMetricComponent.java
@@ -25,13 +25,14 @@ import com.spotify.heroic.analytics.AnalyticsComponent;
 import com.spotify.heroic.dagger.CorePrimaryComponent;
 import com.spotify.heroic.lifecycle.LifeCycle;
 import com.spotify.heroic.metadata.MetadataComponent;
+import com.spotify.heroic.querylogging.QueryLoggingComponent;
 import dagger.Component;
-
 import javax.inject.Named;
 
 @MetricScope
 @Component(modules = MetricManagerModule.class, dependencies = {
-    CorePrimaryComponent.class, MetadataComponent.class, AnalyticsComponent.class
+    CorePrimaryComponent.class, MetadataComponent.class, AnalyticsComponent.class,
+    QueryLoggingComponent.class
 })
 public interface CoreMetricComponent extends MetricComponent {
     @Override

--- a/heroic-core/src/main/java/com/spotify/heroic/querylogging/Module.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/querylogging/Module.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.querylogging;
+
+import com.spotify.heroic.HeroicConfigurationContext;
+import com.spotify.heroic.HeroicModule;
+import com.spotify.heroic.dagger.LoadingComponent;
+
+public class Module implements HeroicModule {
+    @Override
+    public Runnable setup(LoadingComponent loading) {
+        final HeroicConfigurationContext config = loading.heroicConfigurationContext();
+
+        return () -> {
+            config.registerType("slf4j", Slf4jQueryLoggingModule.class);
+        };
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/querylogging/Slf4jQueryLogger.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/querylogging/Slf4jQueryLogger.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.querylogging;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.heroic.Query;
+import com.spotify.heroic.metric.FullQuery;
+import com.spotify.heroic.metric.QueryMetrics;
+import com.spotify.heroic.metric.QueryMetricsResponse;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.function.Consumer;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@QueryLoggingScope
+@Slf4j
+@RequiredArgsConstructor
+public class Slf4jQueryLogger implements QueryLogger {
+    private final Consumer<String> queryLog;
+    private final ObjectMapper objectMapper;
+    private final String component;
+
+    @Override
+    public void logHttpQueryText(
+        final QueryContext context, final String query, final HttpContext httpContext
+    ) {
+        performAndCatch(() -> {
+            final JsonNode queryJsonNode = objectMapper.valueToTree(query);
+            final HttpQueryData data = new HttpQueryData(httpContext, queryJsonNode);
+            serializeAndLog(context, "http-query-text", data);
+        });
+    }
+
+    @Override
+    public void logHttpQueryJson(
+        final QueryContext context, final QueryMetrics query, final HttpContext httpContext
+    ) {
+        performAndCatch(() -> {
+            final JsonNode queryJsonNode = objectMapper.valueToTree(query);
+            final HttpQueryData data = new HttpQueryData(httpContext, queryJsonNode);
+            serializeAndLog(context, "http-query-json", data);
+        });
+    }
+
+    @Override
+    public void logQuery(final QueryContext context, final Query query) {
+        serializeAndLog(context, "query", query);
+    }
+
+    @Override
+    public void logOutgoingRequestToShards(
+        final QueryContext context, final FullQuery.Request request
+    ) {
+        performAndCatch(() -> {
+            final FullQuery.Request.Summary summary = request.summarize();
+            serializeAndLog(context, "outgoing-request-to-shards", summary);
+        });
+    }
+
+    @Override
+    public void logIncomingRequestAtNode(
+        final QueryContext context, final FullQuery.Request request
+    ) {
+        performAndCatch(() -> {
+            final FullQuery.Request.Summary summary = request.summarize();
+            serializeAndLog(context, "incoming-request-at-node", summary);
+        });
+    }
+
+    @Override
+    public void logOutgoingResponseAtNode(final QueryContext context, final FullQuery response) {
+        performAndCatch(() -> {
+            final FullQuery.Summary summary = response.summarize();
+            serializeAndLog(context, "outgoing-response-at-node", summary);
+        });
+    }
+
+    @Override
+    public void logIncomingResponseFromShard(
+        final QueryContext context, final FullQuery response
+    ) {
+        performAndCatch(() -> {
+            final FullQuery.Summary summary = response.summarize();
+            serializeAndLog(context, "incoming-response-from-shard", summary);
+        });
+    }
+
+    @Override
+    public void logFinalResponse(
+        final QueryContext context, final QueryMetricsResponse queryMetricsResponse
+    ) {
+        performAndCatch(() -> {
+            final QueryMetricsResponse.Summary summary = queryMetricsResponse.summarize();
+            serializeAndLog(context, "final-response", summary);
+        });
+    }
+
+    private <T> void serializeAndLog(
+        final QueryContext context, final String type, final T data
+    ) {
+        performAndCatch(() -> {
+            final MessageFormat<T> message =
+                new MessageFormat<>(component, context.getQueryId(), context.getClientContext(),
+                    type, data);
+
+            final String timestamp = Instant.now().toString();
+            final LogFormat logFormat = new LogFormat(timestamp, message);
+            try {
+                queryLog.accept(objectMapper.writeValueAsString(logFormat));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private void performAndCatch(Runnable toRun) {
+        try {
+            toRun.run();
+        } catch (Exception e) {
+            log.error("Failed while trying to log query", e);
+        }
+    }
+
+    @Data
+    public class LogFormat {
+        @JsonProperty("@timestamp")
+        private final String timestamp;
+        @JsonProperty("@message")
+        private final MessageFormat message;
+    }
+
+    @Data
+    public class MessageFormat<T> {
+        private final String component;
+        private final UUID queryId;
+        private final JsonNode clientContext;
+        private final String type;
+        private final T data;
+    }
+
+    @Data
+    public class HttpQueryData {
+        private final HttpContext httpContext;
+        private final JsonNode query;
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/querylogging/Slf4jQueryLoggerFactory.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/querylogging/Slf4jQueryLoggerFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.querylogging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.function.Consumer;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.core.MediaType;
+
+@QueryLoggingScope
+public class Slf4jQueryLoggerFactory implements QueryLoggerFactory {
+    private final Consumer<String> logger;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public Slf4jQueryLoggerFactory(
+        @Named("logger") Consumer<String> logger,
+        @Named(MediaType.APPLICATION_JSON) ObjectMapper objectMapper
+    ) {
+        this.logger = logger;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Slf4jQueryLogger create(String component) {
+        return new Slf4jQueryLogger(logger, objectMapper, component);
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/querylogging/Slf4jQueryLoggingComponent.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/querylogging/Slf4jQueryLoggingComponent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.querylogging;
+
+import com.spotify.heroic.dagger.PrimaryComponent;
+import dagger.Component;
+
+@QueryLoggingScope
+@Component(modules = Slf4jQueryLoggingModule.class, dependencies = PrimaryComponent.class)
+public interface Slf4jQueryLoggingComponent extends QueryLoggingComponent {
+    @Override
+    Slf4jQueryLoggerFactory queryLoggerFactory();
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/querylogging/Slf4jQueryLoggingModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/querylogging/Slf4jQueryLoggingModule.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.querylogging;
+
+import static org.slf4j.event.Level.TRACE;
+
+import com.spotify.heroic.dagger.PrimaryComponent;
+import dagger.Module;
+import dagger.Provides;
+import java.util.Optional;
+import java.util.function.Consumer;
+import javax.inject.Named;
+import lombok.Data;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+@Data
+@Module
+public class Slf4jQueryLoggingModule implements QueryLoggingModule {
+    private final Optional<String> name;
+    private final Optional<String> level;
+
+    @QueryLoggingScope
+    @Provides
+    @Named("logger")
+    public Consumer<String> logger() {
+        final String name = this.name.orElse("com.spotify.heroic.query_logging");
+        final Level level = this.level.map(Level::valueOf).orElse(TRACE);
+
+        final Logger logger = LoggerFactory.getLogger(name);
+
+        switch (level) {
+            case INFO:
+                return logger::info;
+            default:
+            case TRACE:
+                return logger::trace;
+        }
+    }
+
+    @Override
+    public Slf4jQueryLoggingComponent component(PrimaryComponent primary) {
+        return DaggerSlf4jQueryLoggingComponent
+            .builder()
+            .primaryComponent(primary)
+            .slf4jQueryLoggingModule(this)
+            .build();
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/querylogging/noop/NoopQueryLogger.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/querylogging/noop/NoopQueryLogger.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.querylogging.noop;
+
+import com.spotify.heroic.Query;
+import com.spotify.heroic.metric.FullQuery;
+import com.spotify.heroic.metric.QueryMetrics;
+import com.spotify.heroic.metric.QueryMetricsResponse;
+import com.spotify.heroic.querylogging.HttpContext;
+import com.spotify.heroic.querylogging.QueryContext;
+import com.spotify.heroic.querylogging.QueryLogger;
+import com.spotify.heroic.querylogging.QueryLoggingScope;
+import lombok.extern.slf4j.Slf4j;
+
+@QueryLoggingScope
+@Slf4j
+public class NoopQueryLogger implements QueryLogger {
+    @Override
+    public void logHttpQueryText(
+        final QueryContext context, final String query, final HttpContext httpContext
+    ) {
+    }
+
+    @Override
+    public void logHttpQueryJson(
+        final QueryContext context, final QueryMetrics query, final HttpContext httpContext
+    ) {
+    }
+
+    public void logHttpQueryObject(
+        final QueryContext context, final Object query, final HttpContext httpContext
+    ) {
+    }
+
+    @Override
+    public void logQuery(final QueryContext context, final Query query) {
+    }
+
+    @Override
+    public void logOutgoingRequestToShards(
+        final QueryContext context, final FullQuery.Request request
+    ) {
+    }
+
+    @Override
+    public void logIncomingRequestAtNode(
+        final QueryContext context, final FullQuery.Request request
+    ) {
+    }
+
+    @Override
+    public void logOutgoingResponseAtNode(final QueryContext context, final FullQuery response) {
+    }
+
+    @Override
+    public void logIncomingResponseFromShard(
+        final QueryContext context, final FullQuery response
+    ) {
+    }
+
+    @Override
+    public void logFinalResponse(
+        final QueryContext context, final QueryMetricsResponse queryMetricsResponse
+    ) {
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/querylogging/noop/NoopQueryLoggerFactory.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/querylogging/noop/NoopQueryLoggerFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.querylogging.noop;
+
+import com.spotify.heroic.querylogging.QueryLogger;
+import com.spotify.heroic.querylogging.QueryLoggerFactory;
+import javax.inject.Inject;
+
+public class NoopQueryLoggerFactory implements QueryLoggerFactory {
+
+    @Inject
+    public NoopQueryLoggerFactory() {
+    }
+
+    @Override
+    public QueryLogger create(String component) {
+        return new NoopQueryLogger();
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/querylogging/noop/NoopQueryLoggingComponent.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/querylogging/noop/NoopQueryLoggingComponent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.querylogging.noop;
+
+import com.spotify.heroic.dagger.PrimaryComponent;
+import com.spotify.heroic.querylogging.QueryLoggingComponent;
+import com.spotify.heroic.querylogging.QueryLoggingScope;
+import dagger.Component;
+
+@QueryLoggingScope
+@Component(modules = NoopQueryLoggingModule.class, dependencies = PrimaryComponent.class)
+public interface NoopQueryLoggingComponent extends QueryLoggingComponent {
+    @Override
+    NoopQueryLoggerFactory queryLoggerFactory();
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/querylogging/noop/NoopQueryLoggingModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/querylogging/noop/NoopQueryLoggingModule.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.querylogging.noop;
+
+import com.spotify.heroic.dagger.PrimaryComponent;
+import com.spotify.heroic.querylogging.QueryLoggingModule;
+import dagger.Module;
+
+@Module
+public class NoopQueryLoggingModule implements QueryLoggingModule {
+
+    @Override
+    public NoopQueryLoggingComponent component(PrimaryComponent primary) {
+        return DaggerNoopQueryLoggingComponent.builder().primaryComponent(primary).build();
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/Query.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/Query.java
@@ -23,6 +23,7 @@ package com.spotify.heroic.shell.task;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.spotify.heroic.querylogging.QueryContext;
 import com.spotify.heroic.QueryDateRange;
 import com.spotify.heroic.QueryManager;
 import com.spotify.heroic.QueryOptions;
@@ -73,6 +74,7 @@ public class Query implements ShellTask {
         final Parameters params = (Parameters) base;
 
         final String queryString = params.query.stream().collect(Collectors.joining(" "));
+        final QueryContext queryContext = QueryContext.empty();
 
         final ObjectMapper indent = mapper.copy();
         indent.configure(SerializationFeature.INDENT_OUTPUT, true);
@@ -95,7 +97,7 @@ public class Query implements ShellTask {
                 .newQueryFromString(queryString)
                 .options(Optional.of(options))
                 .rangeIfAbsent(range)
-                .build())
+                .build(), queryContext)
             .directTransform(result -> {
                 for (final RequestError e : result.getErrors()) {
                     io.out().println(String.format("ERR: %s", e.toString()));

--- a/heroic-core/src/test/java/com/spotify/heroic/CoreQueryManagerTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/CoreQueryManagerTest.java
@@ -1,7 +1,9 @@
 package com.spotify.heroic;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.spotify.heroic.aggregation.AggregationFactory;
 import com.spotify.heroic.cache.QueryCache;
@@ -10,6 +12,8 @@ import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Features;
 import com.spotify.heroic.common.OptionalLimit;
 import com.spotify.heroic.grammar.QueryParser;
+import com.spotify.heroic.querylogging.QueryLogger;
+import com.spotify.heroic.querylogging.QueryLoggerFactory;
 import com.spotify.heroic.statistics.ApiReporter;
 import eu.toolchain.async.AsyncFramework;
 import org.junit.Before;
@@ -41,9 +45,14 @@ public class CoreQueryManagerTest {
     public void setup() {
         ApiReporter apiReporter = mock(ApiReporter.class);
         long smallQueryThreshold = 0;
+
+        QueryLogger queryLogger = mock(QueryLogger.class);
+        QueryLoggerFactory queryLoggerFactory = mock(QueryLoggerFactory.class);
+        when(queryLoggerFactory.create(any())).thenReturn(queryLogger);
+
         manager =
             new CoreQueryManager(Features.empty(), async, cluster, parser, queryCache, aggregations,
-                OptionalLimit.empty(), smallQueryThreshold, apiReporter);
+                OptionalLimit.empty(), smallQueryThreshold, apiReporter, queryLoggerFactory);
     }
 
     @Test

--- a/heroic-core/src/test/java/com/spotify/heroic/QueryTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/QueryTest.java
@@ -7,7 +7,7 @@ import com.spotify.heroic.aggregation.Aggregation;
 import com.spotify.heroic.aggregation.Empty;
 import com.spotify.heroic.aggregation.Group;
 import com.spotify.heroic.common.TypeNameMixin;
-import com.spotify.heroic.http.query.QueryMetrics;
+import com.spotify.heroic.metric.QueryMetrics;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/heroic-core/src/test/java/com/spotify/heroic/http/query/QueryMetricsResponseTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/http/query/QueryMetricsResponseTest.java
@@ -1,5 +1,6 @@
 package com.spotify.heroic.http.query;
 
+import com.spotify.heroic.metric.QueryMetricsResponse;
 import com.spotify.heroic.test.LombokDataTest;
 import org.junit.Test;
 

--- a/heroic-core/src/test/java/com/spotify/heroic/metric/BasicSerializationTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/metric/BasicSerializationTest.java
@@ -1,24 +1,26 @@
 package com.spotify.heroic.metric;
 
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.spotify.heroic.HeroicMappers;
+import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.common.Statistics;
 import com.spotify.heroic.grammar.QueryParser;
 import com.spotify.heroic.test.Resources;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
+import java.util.UUID;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 public class BasicSerializationTest {
     private ObjectMapper mapper = HeroicMappers.json(Mockito.mock(QueryParser.class));
@@ -62,15 +64,51 @@ public class BasicSerializationTest {
         assertSerialization("FullQuery.json", expected, FullQuery.class);
     }
 
-    private <T> void assertSerialization(final String json, final T expected, final Class<T> type)
-        throws IOException {
+    @Test
+    public void testQueryMetricsResponse() throws Exception {
+        final UUID queryId = UUID.fromString("d11d0ad7-cc27-4667-a617-67a481f61c30");
+        final DateRange range = DateRange.create(1484027520000L, 1484038320000L);
+
+        final Set<Series> series = ImmutableSet.of();
+        final MetricCollection metrics = MetricCollection.points(new ArrayList<>());
+        final List<ShardedResultGroup> result = ImmutableList.of(
+            new ShardedResultGroup(ImmutableMap.of(), ImmutableMap.of(), series, metrics, 0L));
+
+        final List<RequestError> errors = new ArrayList<>();
+        final QueryTrace trace = QueryTrace.of(QueryTrace.identifier("test"), 0L);
+        final ResultLimits limits = ResultLimits.of();
+
+        final QueryMetricsResponse toVerify =
+            new QueryMetricsResponse(queryId, range, result, errors, trace, limits);
+
+        assertSerialization("QueryMetricsResponse.json", toVerify);
+    }
+
+    private <T> void assertSerialization(
+        final String expectedFile, final T toVerify
+    ) throws IOException {
         // verify that it is equal to the local file.
-        try (final InputStream in = Resources.openResource(getClass(), json)) {
-            assertEquals(expected, mapper.readValue(in, type));
+        try (final InputStream in = Resources.openResource(getClass(), expectedFile)) {
+            final JsonNode expectedNode = mapper.readTree(in);
+            final JsonNode toVerifyNode = mapper.valueToTree(toVerify);
+            // Serialize both, to avoid false negative when comparing above two, in the case of
+            // one tree using IntNode and the other LongNode for what should be equal trees.
+            final String expectedString = mapper.writeValueAsString(expectedNode);
+            final String toVerifyString = mapper.writeValueAsString(toVerifyNode);
+            assertEquals(expectedString, toVerifyString);
+        }
+    }
+
+    private <T> void assertSerialization(
+        final String expectedFile, final T toVerify, final Class<T> type
+    ) throws IOException {
+        // verify that it is equal to the local file.
+        try (final InputStream in = Resources.openResource(getClass(), expectedFile)) {
+            assertEquals(mapper.readValue(in, type), toVerify);
         }
 
         // roundtrip
-        final String string = mapper.writeValueAsString(expected);
-        assertEquals(expected, mapper.readValue(string, type));
+        final String string = mapper.writeValueAsString(toVerify);
+        assertEquals(mapper.readValue(string, type), toVerify);
     }
 }

--- a/heroic-core/src/test/java/com/spotify/heroic/metric/LocalMetricManagerTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/metric/LocalMetricManagerTest.java
@@ -1,12 +1,17 @@
 package com.spotify.heroic.metric;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.spotify.heroic.common.GroupSet;
 import com.spotify.heroic.common.Groups;
 import com.spotify.heroic.common.OptionalLimit;
 import com.spotify.heroic.metadata.MetadataManager;
+import com.spotify.heroic.querylogging.QueryLogger;
+import com.spotify.heroic.querylogging.QueryLoggerFactory;
 import com.spotify.heroic.statistics.MetricBackendReporter;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
@@ -56,8 +61,13 @@ public class LocalMetricManagerTest {
         final GroupSet<MetricBackend> groupSet =
             GroupSet.build(Collections.singletonList(metricBackend), Optional.empty());
 
+        final QueryLogger queryLogger = mock(QueryLogger.class);
+        final QueryLoggerFactory queryLoggerFactory = mock(QueryLoggerFactory.class);
+        when(queryLoggerFactory.create(any())).thenReturn(queryLogger);
+
         manager = new LocalMetricManager(groupLimit, seriesLimit, aggregationLimit, dataLimit,
-            fetchParallelism, failOnLimits, async, groupSet, metadata, reporter);
+            fetchParallelism, failOnLimits, async, groupSet, metadata, reporter,
+            queryLoggerFactory);
     }
 
     @Test

--- a/heroic-core/src/test/java/com/spotify/heroic/querylogging/Slf4jQueryLoggerTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/querylogging/Slf4jQueryLoggerTest.java
@@ -1,0 +1,120 @@
+package com.spotify.heroic.querylogging;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.spotify.heroic.Query;
+import com.spotify.heroic.common.Statistics;
+import com.spotify.heroic.metric.FullQuery;
+import com.spotify.heroic.metric.QueryMetrics;
+import com.spotify.heroic.metric.QueryMetricsResponse;
+import com.spotify.heroic.metric.QueryTrace;
+import com.spotify.heroic.metric.ResultLimits;
+import java.util.ArrayList;
+import java.util.function.Consumer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class Slf4jQueryLoggerTest {
+    @Mock
+    public Consumer<String> logger;
+
+    private static final JsonNode EMPTY = JsonNodeFactory.instance.nullNode();
+
+    private ObjectMapper mapper;
+    private Slf4jQueryLogger slf4jQueryLogger;
+
+    private QueryContext queryContext;
+
+    @Before
+    public void setup() {
+        mapper = mock(ObjectMapper.class);
+        try {
+            when(mapper.writeValueAsString(any())).thenReturn("");
+            when(mapper.valueToTree(any())).thenReturn(EMPTY);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        final String component = "<component>";
+
+        slf4jQueryLogger = new Slf4jQueryLogger(logger, mapper, component);
+
+        final Slf4jQueryLoggerFactory queryLoggerFactory = mock(Slf4jQueryLoggerFactory.class);
+        when(queryLoggerFactory.create(any())).thenReturn(slf4jQueryLogger);
+
+        queryContext = mock(QueryContext.class);
+    }
+
+    @Test
+    public void testHttpTextQuery() {
+        final HttpContext httpContext = mock(HttpContext.class);
+        slf4jQueryLogger.logHttpQueryText(queryContext, "", httpContext);
+        verify(logger, times(1)).accept(any(String.class));
+    }
+
+    @Test
+    public void testHttpJsonQuery() {
+        final HttpContext httpContext = mock(HttpContext.class);
+        final QueryMetrics queryMetrics = mock(QueryMetrics.class);
+        slf4jQueryLogger.logHttpQueryJson(queryContext, queryMetrics, httpContext);
+        verify(logger, times(1)).accept(any(String.class));
+    }
+
+    @Test
+    public void testQuery() {
+        final Query query = mock(Query.class);
+        slf4jQueryLogger.logQuery(queryContext, query);
+        verify(logger, times(1)).accept(any(String.class));
+    }
+
+    @Test
+    public void testOutgoingRequestsToShards() {
+        final FullQuery.Request request = mock(FullQuery.Request.class);
+        slf4jQueryLogger.logOutgoingRequestToShards(queryContext, request);
+        verify(logger, times(1)).accept(any(String.class));
+    }
+
+    @Test
+    public void testIncomingRequestAtNode() {
+        final FullQuery.Request request = mock(FullQuery.Request.class);
+        slf4jQueryLogger.logIncomingRequestAtNode(queryContext, request);
+        verify(logger, times(1)).accept(any(String.class));
+    }
+
+    @Test
+    public void testOutgoingResponseAtNode() {
+        final FullQuery response =
+            new FullQuery(QueryTrace.of(QueryTrace.identifier("test"), 0L), new ArrayList<>(),
+                new ArrayList<>(), Statistics.empty(), ResultLimits.of());
+        slf4jQueryLogger.logOutgoingResponseAtNode(queryContext, response);
+        verify(logger, times(1)).accept(any(String.class));
+    }
+
+    @Test
+    public void testIncomingResponseFromShard() {
+        final FullQuery response =
+            new FullQuery(QueryTrace.of(QueryTrace.identifier("test"), 0L), new ArrayList<>(),
+                new ArrayList<>(), Statistics.empty(), ResultLimits.of());
+        slf4jQueryLogger.logIncomingResponseFromShard(queryContext, response);
+        verify(logger, times(1)).accept(any(String.class));
+    }
+
+    @Test
+    public void testFinalResponse() {
+        final QueryMetricsResponse queryMetricsResponse = mock(QueryMetricsResponse.class);
+        slf4jQueryLogger.logFinalResponse(queryContext, queryMetricsResponse);
+        verify(logger, times(1)).accept(any(String.class));
+    }
+}

--- a/heroic-core/src/test/resources/com/spotify/heroic/metric/QueryMetricsResponse.json
+++ b/heroic-core/src/test/resources/com/spotify/heroic/metric/QueryMetricsResponse.json
@@ -16,7 +16,7 @@
   "result": [
     {
       "type": "points",
-      "hash": "0",
+      "hash": "2362f9de",
       "shard": {},
       "cadence": 0,
       "values": [],

--- a/heroic-core/src/test/resources/com/spotify/heroic/metric/QueryMetricsResponse.json
+++ b/heroic-core/src/test/resources/com/spotify/heroic/metric/QueryMetricsResponse.json
@@ -1,0 +1,29 @@
+{
+  "queryId": "d11d0ad7-cc27-4667-a617-67a481f61c30",
+  "range": {
+    "start": 1484027520000,
+    "end": 1484038320000
+  },
+  "trace": {
+    "what": {
+      "name": "test"
+    },
+    "elapsed": 0,
+    "children": []
+  },
+  "limits": [],
+  "commonTags": {},
+  "result": [
+    {
+      "type": "points",
+      "hash": "0",
+      "shard": {},
+      "cadence": 0,
+      "values": [],
+      "key": null,
+      "tags": {},
+      "tagCounts": {}
+    }
+  ],
+  "errors": []
+}

--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
@@ -31,6 +31,7 @@ import com.spotify.heroic.metric.RequestError;
 import com.spotify.heroic.metric.ResultLimit;
 import com.spotify.heroic.metric.ResultLimits;
 import com.spotify.heroic.metric.ShardedResultGroup;
+import com.spotify.heroic.querylogging.QueryContext;
 import eu.toolchain.async.AsyncFuture;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,6 +50,8 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
 
     private QueryManager query;
 
+    private QueryContext queryContext;
+
     protected boolean cardinalitySupport = true;
 
     protected void setupSupport() {
@@ -57,6 +60,8 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
     @Before
     public final void setupAbstract() {
         setupSupport();
+
+        queryContext = QueryContext.empty();
 
         query = instances.get(0).inject(CoreComponent::queryManager);
     }
@@ -101,7 +106,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
             .rangeIfAbsent(Optional.of(new QueryDateRange.Absolute(10, 40)));
 
         modifier.accept(builder);
-        return query.useDefaultGroup().query(builder.build()).get();
+        return query.useDefaultGroup().query(builder.build(), queryContext).get();
     }
 
     @Test

--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
@@ -12,6 +12,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -23,6 +27,7 @@ import com.spotify.heroic.dagger.CoreComponent;
 import com.spotify.heroic.ingestion.Ingestion;
 import com.spotify.heroic.ingestion.IngestionComponent;
 import com.spotify.heroic.ingestion.IngestionManager;
+import com.spotify.heroic.metric.FullQuery;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.MetricType;
 import com.spotify.heroic.metric.QueryError;
@@ -32,6 +37,7 @@ import com.spotify.heroic.metric.ResultLimit;
 import com.spotify.heroic.metric.ResultLimits;
 import com.spotify.heroic.metric.ShardedResultGroup;
 import com.spotify.heroic.querylogging.QueryContext;
+import com.spotify.heroic.querylogging.QueryLogger;
 import eu.toolchain.async.AsyncFuture;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,6 +46,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -47,6 +54,9 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
     private final Series s1 = Series.of("key1", ImmutableMap.of("shared", "a", "diff", "a"));
     private final Series s2 = Series.of("key1", ImmutableMap.of("shared", "a", "diff", "b"));
     private final Series s3 = Series.of("key1", ImmutableMap.of("shared", "a", "diff", "c"));
+
+    /* the number of queries run */
+    private int queryCount = 0;
 
     private QueryManager query;
 
@@ -64,6 +74,34 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
         queryContext = QueryContext.empty();
 
         query = instances.get(0).inject(CoreComponent::queryManager);
+    }
+
+    @After
+    public final void verifyLoggers() {
+        final QueryLogger coreQueryManagerLogger = getQueryLogger("CoreQueryManager").orElseThrow(
+            () -> new AssertionError("Should have logger for CoreQueryManager"));
+
+        final QueryLogger localMetricManagerLogger =
+            getQueryLogger("LocalMetricManager").orElseThrow(
+                () -> new AssertionError("Should have logger for LocalMetricManager"));
+
+        /* number of expected log-calls is related to the number of queries performed during the
+         * test */
+        final int apiNodeCount = queryCount;
+        final int dataNodeCount = queryCount * 2;
+
+        verify(coreQueryManagerLogger, times(apiNodeCount)).logQuery(any(QueryContext.class),
+            any(Query.class));
+        verify(coreQueryManagerLogger, times(apiNodeCount)).logOutgoingRequestToShards(
+            any(QueryContext.class), any(FullQuery.Request.class));
+        verify(localMetricManagerLogger, times(dataNodeCount)).logIncomingRequestAtNode(
+            any(QueryContext.class), any(FullQuery.Request.class));
+        verify(localMetricManagerLogger, times(dataNodeCount)).logOutgoingResponseAtNode(
+            any(QueryContext.class), any(FullQuery.class));
+        verify(coreQueryManagerLogger, times(dataNodeCount)).logIncomingResponseFromShard(
+            any(QueryContext.class), any(FullQuery.class));
+
+        verifyNoMoreInteractions(coreQueryManagerLogger, localMetricManagerLogger);
     }
 
     @Override
@@ -100,6 +138,8 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
 
     public QueryResult query(final QueryBuilder builder, final Consumer<QueryBuilder> modifier)
         throws Exception {
+        queryCount += 1;
+
         builder
             .features(Optional.of(FeatureSet.of(Feature.DISTRIBUTED_AGGREGATIONS)))
             .source(Optional.of(MetricType.POINT))

--- a/heroic-dist/src/test/java/com/spotify/heroic/HeroicConfigurationTest.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/HeroicConfigurationTest.java
@@ -65,12 +65,22 @@ public class HeroicConfigurationTest {
 
         final List<String> starters = instance.inject(c -> {
             final CoreLifeCycleRegistry reg = (CoreLifeCycleRegistry) c.lifeCycleRegistry();
-            return reg.starters().stream().map(LifeCycleNamedHook::id).sorted().collect(Collectors.toList());
+            return reg
+                .starters()
+                .stream()
+                .map(LifeCycleNamedHook::id)
+                .sorted()
+                .collect(Collectors.toList());
         });
 
         final List<String> stoppers = instance.inject(c -> {
             final CoreLifeCycleRegistry reg = (CoreLifeCycleRegistry) c.lifeCycleRegistry();
-            return reg.stoppers().stream().map(LifeCycleNamedHook::id).sorted().collect(Collectors.toList());
+            return reg
+                .stoppers()
+                .stream()
+                .map(LifeCycleNamedHook::id)
+                .sorted()
+                .collect(Collectors.toList());
         });
 
         assertEquals(referenceStarters, starters);
@@ -78,12 +88,22 @@ public class HeroicConfigurationTest {
 
         final List<String> internalStarters = instance.inject(c -> {
             final CoreLifeCycleRegistry reg = (CoreLifeCycleRegistry) c.internalLifeCycleRegistry();
-            return reg.starters().stream().map(LifeCycleNamedHook::id).sorted().collect(Collectors.toList());
+            return reg
+                .starters()
+                .stream()
+                .map(LifeCycleNamedHook::id)
+                .sorted()
+                .collect(Collectors.toList());
         });
 
         final List<String> internalStoppers = instance.inject(c -> {
             final CoreLifeCycleRegistry reg = (CoreLifeCycleRegistry) c.internalLifeCycleRegistry();
-            return reg.stoppers().stream().map(LifeCycleNamedHook::id).sorted().collect(Collectors.toList());
+            return reg
+                .stoppers()
+                .stream()
+                .map(LifeCycleNamedHook::id)
+                .sorted()
+                .collect(Collectors.toList());
         });
 
         assertEquals(internalStarters, referenceInternalStarters);
@@ -94,7 +114,11 @@ public class HeroicConfigurationTest {
     public void testNullShellHost() throws Exception {
         // TODO: get this into the shell server module
         final HeroicCoreInstance instance = testConfiguration("heroic-null-shell-host.yml");
-        instance.start().get();
+    }
+
+    @Test
+    public void testQueryLoggingConfiguration() throws Exception {
+        final HeroicCoreInstance instance = testConfiguration("heroic-query-logging.yml");
     }
 
     private HeroicCoreInstance testConfiguration(final String name) throws Exception {

--- a/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcProtocol.java
+++ b/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcProtocol.java
@@ -21,6 +21,9 @@
 
 package com.spotify.heroic.rpc.grpc;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.grpc.MethodDescriptor.generateFullMethodName;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -54,13 +57,6 @@ import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.channel.nio.NioEventLoopGroup;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
-
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -70,9 +66,12 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static io.grpc.MethodDescriptor.generateFullMethodName;
+import javax.inject.Inject;
+import javax.inject.Named;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @ToString(of = {})

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,16 @@
+# Tools for working with Heroic
+
+## querylog
+
+A utility used for configuring an Elasticsearch cluster with the templates necessary to index
+query logs as emitted by Heroic.
+
+#### Usage
+
+```bash
+tools/querylog --host http://<elasticsearch-master>:9200 [--base-index <name>] [--logstash] \
+  --commit
+```
+
+The value provided to the `--base-index` option is what will be used as a prefix to the index
+template.

--- a/tools/querylog
+++ b/tools/querylog
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import requests
+import yaml
+import argparse
+import json
+
+settings = {
+    "index": {
+        "number_of_replicas": 1
+    }
+}
+
+def setup_parser():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        '--host', dest='hosts', help="Elasticsearch host to configure",
+        action='append', default=[])
+
+    parser.add_argument(
+        '--index-base', help="Base index name to configure, i.e. <index-base>-*",
+        default="heroic-querylog")
+
+    parser.add_argument(
+        '--logstash', help="Use logstash (@message) format for index template",
+        action='store_const', const=True, default=False)
+
+    parser.add_argument(
+        '--commit', help=(
+            "The default run will just print what would have been "
+            "configured, adding --commit causes it to be writtend"),
+        action='store_const', const=True, default=False)
+
+    return parser
+
+def main():
+    parser = setup_parser()
+
+    ns = parser.parse_args()
+
+    hosts = ns.hosts
+    index_base = ns.index_base
+
+    mapping_path = os.path.join(
+        os.path.dirname(os.path.abspath(sys.argv[0])),
+        'querylog_mappings.yaml')
+
+    mappings = None
+
+    with open(mapping_path) as f:
+        mappings = yaml.load(f)
+
+    common = mappings.get('_common', {})
+
+    for (type, mapping) in mappings.items():
+        if type.startswith('_'):
+            continue
+
+        mapping = dict(mapping)
+
+        try:
+            properties = mapping['properties']
+        except KeyError:
+            mapping['properties'] = properties = dict()
+
+        properties.update(common)
+
+        if ns.logstash:
+            message = dict()
+            message.update(mapping)
+
+            # initial @message nesting
+            mapping = {
+              "properties": {
+                "@message": message,
+                "@timestamp": {
+                  "type": "date"
+                }
+              }
+            }
+
+        template = {
+            "template": "{}-{}-*".format(index_base, type),
+            "settings": settings,
+            "mappings": {
+                "entry": mapping
+            }
+        }
+
+        if ns.commit:
+            for host in hosts:
+                url = '{}/_template/{}-{}'.format(host, index_base, type)
+                print("PUT", url)
+                response = requests.put(url, json=template)
+                print(response.text)
+        else:
+            print(json.dumps(template))
+
+if __name__ == "__main__":
+    main()

--- a/tools/querylog_mappings.yaml
+++ b/tools/querylog_mappings.yaml
@@ -1,0 +1,149 @@
+# vim: sw=2 tabstop=2
+# These are Elasticsearch template mappings as used by the querylog tool.
+
+_histogram: &histogram
+  properties:
+    min:
+      type: long
+    max:
+      type: long
+    median:
+      type: long
+    p75:
+      type: long
+    p99:
+      type: long
+    mean:
+      type: double
+    sum:
+      type: long
+
+_raw_object: &raw_object
+  type: object
+  enabled: false
+
+_raw_string: &raw_string
+  type: string
+  analyzer: "keyword"
+
+_HttpContext: &http_context
+  properties:
+    remoteAddress:
+      type: ip
+    remoteHost: *raw_string
+    clientAddress: *raw_string
+    userAgent: *raw_string
+    clientId: *raw_string
+
+_date_range: &date_range
+  properties:
+    start:
+      type: date
+    end:
+      type: date
+
+# com.spotify.heroic.metric.RequestError
+_request_error: &request_error
+  properties:
+    type: *raw_string
+    error: *raw_string
+
+# com.spotify.heroic.metric.FullQuery.Request.Summary
+_full_query_request_summary: &full_query_request_summary
+  properties:
+    source: *raw_string
+    filter: *raw_object
+    range: *date_range
+    aggregation: *raw_object
+    options: *raw_object
+
+# com.spotify.heroic.metric.SeriesSetsSummarizer
+_series_sets_summarizer: &series_sets_summarizer
+  properties:
+    uniqueKeys:
+      type: long
+    tagsSize: *histogram
+    seriesSize: *histogram
+
+# com.spotify.heroic.metric.FullQuery.Summary
+_full_query_summary: &full_query_summary
+  properties:
+    trace: *raw_object
+    errors: *request_error
+    # com.spotify.heroic.metric.ResultGroup.MultiSummary
+    groups:
+      properties:
+        keySize: *histogram
+        series: *series_sets_summarizer
+        dataSize: *histogram
+        cadence:
+          type: long
+    statistics: *raw_object
+    limits: *raw_string
+
+_common:
+  type: *raw_string
+  component: *raw_string
+  queryId: *raw_string
+  clientContext:
+    type: object
+    dynamic: true
+
+"http-query-text":
+  properties:
+    # com.spotify.heroic.querylogging.Slf4jQueryLogger.HttpQueryData
+    data:
+      properties:
+        httpContext: *http_context
+        query: *raw_string
+
+"http-query-json":
+  properties:
+    # com.spotify.heroic.querylogging.Slf4jQueryLogger.HttpQueryData
+    data:
+      properties:
+        httpContext: *http_context
+        query: *raw_object
+
+"query":
+  properties:
+    # com.spotify.heroic.Query
+    data:
+      type: object
+      enabled: false
+
+"outgoing-request-to-shards":
+  properties:
+    data: *full_query_request_summary
+
+"incoming-request-at-node":
+  properties:
+    data: *full_query_request_summary
+
+"outgoing-response-at-node":
+  properties:
+    data: *full_query_summary
+
+"incoming-response-from-shard":
+  properties:
+    data: *full_query_summary
+
+"final-response":
+  properties:
+    # com.spotify.heroic.metric.QueryMetricsResponse.Summary
+    data:
+      properties:
+        range: *date_range
+        # com.spotify.heroic.metric.ShardedResultGroup.MultiSummary
+        result:
+          properties:
+            shards: *raw_object
+            keySize: *histogram
+            series: *series_sets_summarizer
+            dataSize: *histogram
+            cadence:
+              type: long
+        statistics: *raw_object
+        errors: *request_error
+        trace: *raw_object
+        limits: *raw_string


### PR DESCRIPTION
This is the first step towards implementing detailed query logging as proposed in #194.

This introduces the basic framework and an opinionated `slf4j` implementation.

This also includes `tools/querylog` which is a utility application that can configure index templates in Elasticsearch, suitable for receiving query logs through Logstash.

This also includes some additions to `docs` related to how queryLogging is used.