### PR TITLE
[component, core, statistics] Add query metrics

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/ApiReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/ApiReporter.java
@@ -22,5 +22,17 @@
 package com.spotify.heroic.statistics;
 
 public interface ApiReporter {
+    /**
+     * Report on a full query, on an API node level
+     */
+    FutureReporter.Context reportQuery();
+
+    /**
+     * Report latency of a full query, including gathering data from shards and doing aggregation,
+     * but only for queries that are deemed "small".
+     * The threshold for what is deemed "small" may be configurable and may change.
+     *
+     * @param duration Duration of query, in ms
+     */
     void reportSmallQueryLatency(long duration);
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopApiReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopApiReporter.java
@@ -22,12 +22,18 @@
 package com.spotify.heroic.statistics.noop;
 
 import com.spotify.heroic.statistics.ApiReporter;
+import com.spotify.heroic.statistics.FutureReporter;
 
 public class NoopApiReporter implements ApiReporter {
     private static final NoopApiReporter INSTANCE = new NoopApiReporter();
 
     public static NoopApiReporter get() {
         return INSTANCE;
+    }
+
+    @Override
+    public FutureReporter.Context reportQuery() {
+        return NoopFutureReporterContext.get();
     }
 
     @Override


### PR DESCRIPTION
Adds a set of new metrics, measuring a full query on the API node level. this
differs from query-metrics-* in that those metrics are on the data node level
while this is on the API node level.
* query-latency
* query-failure-rate
* query-resolve-rate
* query-cancel-rate
* query-pending