### PR TITLE
Read data from MetricBackend continuously

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/common/Feature.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/Feature.java
@@ -53,7 +53,15 @@ public enum Feature {
      * This will assert that there are data outside of the range queried for, which is a useful
      * feature when using a dashboarding system.
      */
-    SHIFT_RANGE("com.spotify.heroic.shift_range");
+    SHIFT_RANGE("com.spotify.heroic.shift_range"),
+
+    /**
+     * Enable feature to cause data to be fetched in slices.
+     * <p>
+     * This will cause data to be fetched and consumed by the aggregation framework in
+     * pieces avoiding having to load all data into memory before starting to consume it.
+     */
+    SLICED_DATA_FETCH("com.spotify.heroic.sliced_data_fetch");
 
     private final String id;
 

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/FetchData.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/FetchData.java
@@ -27,46 +27,69 @@ import com.spotify.heroic.QueryOptions;
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Series;
 import eu.toolchain.async.Collector;
-import lombok.Data;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import lombok.Data;
 
 @Data
 public class FetchData {
-    private final QueryTrace trace;
-    private final List<RequestError> errors;
+    private final Result result;
     private final List<Long> times;
     private final List<MetricCollection> groups;
 
-    public static FetchData error(final QueryTrace trace, final RequestError error) {
-        return new FetchData(trace, ImmutableList.of(error), ImmutableList.of(),
-            ImmutableList.of());
+    public static Result errorResult(final QueryTrace trace, final RequestError error) {
+        return new Result(trace, ImmutableList.of(error));
     }
 
+    public static Result result(final QueryTrace trace) {
+        return new Result(trace, ImmutableList.of());
+    }
+
+    @Deprecated
+    public static FetchData error(final QueryTrace trace, final RequestError error) {
+        return new FetchData(errorResult(trace, error), ImmutableList.of(), ImmutableList.of());
+    }
+
+    @Deprecated
     public static FetchData of(
         final QueryTrace trace, final List<Long> times, final List<MetricCollection> groups
     ) {
-        return new FetchData(trace, ImmutableList.of(), times, groups);
+        return new FetchData(new Result(trace, ImmutableList.of()), times, groups);
     }
 
-    public static Collector<FetchData, FetchData> collect(
+    public static Collector<Result, Result> collectResult(
         final QueryTrace.Identifier what
     ) {
         final QueryTrace.NamedWatch w = QueryTrace.watch(what);
 
         return results -> {
-            final ImmutableList.Builder<Long> times = ImmutableList.builder();
-            final Map<MetricType, ImmutableList.Builder<Metric>> fetchGroups = new HashMap<>();
             final ImmutableList.Builder<QueryTrace> traces = ImmutableList.builder();
             final ImmutableList.Builder<RequestError> errors = ImmutableList.builder();
 
-            for (final FetchData fetch : results) {
+            for (final Result result : results) {
+                traces.add(result.trace);
+                errors.addAll(result.errors);
+            }
+            return new Result(w.end(traces.build()), errors.build());
+        };
+    }
+
+    @Deprecated
+    public static Collector<FetchData, FetchData> collect(
+        final QueryTrace.Identifier what
+    ) {
+        final Collector<Result, Result> resultCollector = collectResult(what);
+
+        return fetchDataCollection -> {
+            final ImmutableList.Builder<Long> times = ImmutableList.builder();
+            final Map<MetricType, ImmutableList.Builder<Metric>> fetchGroups = new HashMap<>();
+            final ImmutableList.Builder<Result> results = ImmutableList.builder();
+
+            for (final FetchData fetch : fetchDataCollection) {
                 times.addAll(fetch.times);
-                traces.add(fetch.trace);
-                errors.addAll(fetch.errors);
+                results.add(fetch.result);
 
                 for (final MetricCollection g : fetch.groups) {
                     ImmutableList.Builder<Metric> data = fetchGroups.get(g.getType());
@@ -87,7 +110,7 @@ public class FetchData {
                     Ordering.from(Metric.comparator()).immutableSortedCopy(e.getValue().build())))
                 .collect(Collectors.toList());
 
-            return new FetchData(w.end(traces.build()), errors.build(), times.build(), groups);
+            return new FetchData(resultCollector.collect(results.build()), times.build(), groups);
         };
     }
 
@@ -97,5 +120,11 @@ public class FetchData {
         private final Series series;
         private final DateRange range;
         private final QueryOptions options;
+    }
+
+    @Data
+    public static class Result {
+        private final QueryTrace trace;
+        private final List<RequestError> errors;
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/FullQuery.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/FullQuery.java
@@ -27,6 +27,7 @@ import com.spotify.heroic.QueryOptions;
 import com.spotify.heroic.aggregation.AggregationInstance;
 import com.spotify.heroic.cluster.ClusterShard;
 import com.spotify.heroic.common.DateRange;
+import com.spotify.heroic.common.Features;
 import com.spotify.heroic.common.Statistics;
 import com.spotify.heroic.filter.Filter;
 import com.spotify.heroic.querylogging.QueryContext;
@@ -116,6 +117,7 @@ public final class FullQuery {
         private final AggregationInstance aggregation;
         private final QueryOptions options;
         private final QueryContext context;
+        private final Features features;
 
         public Summary summarize() {
             return new Summary(source, filter, range, aggregation, options);

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/MetricBackend.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/MetricBackend.java
@@ -27,9 +27,11 @@ import com.spotify.heroic.common.Collected;
 import com.spotify.heroic.common.Grouped;
 import com.spotify.heroic.common.Initializing;
 import com.spotify.heroic.common.Statistics;
+
 import eu.toolchain.async.AsyncFuture;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 public interface MetricBackend extends Initializing, Grouped, Collected {
     Statistics getStatistics();
@@ -59,7 +61,21 @@ public interface MetricBackend extends Initializing, Grouped, Collected {
      * @param watcher The watcher implementation to use when fetching metrics.
      * @return A future containing the fetched data wrapped in a {@link FetchData} structure.
      */
+    @Deprecated
     AsyncFuture<FetchData> fetch(FetchData.Request request, FetchQuotaWatcher watcher);
+
+    /**
+     * Query for data points that is part of the specified list of rows and range.
+     *
+     * @param request Fetch request to use.
+     * @param watcher The watcher implementation to use when fetching metrics.
+     * @param metricsConsumer The consumer that receives the fetched data
+     * @return A future containing the fetch result.
+     */
+    AsyncFuture<FetchData.Result> fetch(
+        FetchData.Request request, FetchQuotaWatcher watcher,
+        Consumer<MetricCollection> metricsConsumer
+    );
 
     /**
      * List all series directly from the database.

--- a/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
@@ -252,7 +252,7 @@ public class CoreQueryManager implements QueryManager {
 
             final FullQuery.Request request =
                 new FullQuery.Request(source, filter, range, aggregationInstance, options,
-                    queryContext);
+                    queryContext, features);
 
             queryLogger.logOutgoingRequestToShards(queryContext, request);
 

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -32,6 +32,7 @@ import com.spotify.heroic.aggregation.AggregationSession;
 import com.spotify.heroic.aggregation.RetainQuotaWatcher;
 import com.spotify.heroic.async.AsyncObservable;
 import com.spotify.heroic.common.DateRange;
+import com.spotify.heroic.common.Feature;
 import com.spotify.heroic.common.GroupSet;
 import com.spotify.heroic.common.Groups;
 import com.spotify.heroic.common.OptionalLimit;
@@ -52,12 +53,6 @@ import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.LazyTransform;
 import eu.toolchain.async.StreamCollector;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.NotImplementedException;
-import org.apache.commons.lang3.tuple.Pair;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -68,6 +63,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.inject.Inject;
 import javax.inject.Named;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.NotImplementedException;
 
 @Slf4j
 @ToString(of = {})
@@ -167,6 +166,8 @@ public class LocalMetricManager implements MetricManager {
 
             queryLogger.logIncomingRequestAtNode(queryContext, request);
 
+            final boolean slicedFetch = request.getFeatures().hasFeature(Feature.SLICED_DATA_FETCH);
+
             final QuotaWatcher watcher = new QuotaWatcher(
                 options.getDataLimit().orElse(dataLimit).asLong().orElse(Long.MAX_VALUE), options
                 .getAggregationLimit()
@@ -217,20 +218,6 @@ public class LocalMetricManager implements MetricManager {
                         Statistics.empty(), ResultLimits.of(ResultLimit.AGGREGATION)));
                 }
 
-                final List<Callable<AsyncFuture<Pair<Series, FetchData>>>> fetches =
-                    new ArrayList<>();
-
-                /* setup fetches */
-                accept(b -> {
-                    for (final Series s : result.getSeries()) {
-                        /* Setup fetches from metric backend
-                         * The result is a stream of Pair<Series, FetchData> */
-                        fetches.add(() -> b
-                            .fetch(new FetchData.Request(source, s, range, options), watcher)
-                            .directTransform(d -> Pair.of(s, d)));
-                    }
-                });
-
                 /* setup collector */
 
                 final ResultCollector collector;
@@ -244,8 +231,8 @@ public class LocalMetricManager implements MetricManager {
                                 new ConcurrentLinkedQueue<>();
 
                             @Override
-                            public void resolved(Pair<Series, FetchData> result) throws Exception {
-                                traces.add(result.getRight().getTrace());
+                            public void resolved(final FetchData.Result result) throws Exception {
+                                traces.add(result.getTrace());
                                 super.resolved(result);
                             }
 
@@ -265,6 +252,28 @@ public class LocalMetricManager implements MetricManager {
                             }
                         };
                 }
+
+                final List<Callable<AsyncFuture<FetchData.Result>>> fetches = new ArrayList<>();
+
+                /* setup fetches */
+                accept(b -> {
+                    for (final Series s : result.getSeries()) {
+                        if (slicedFetch) {
+                            fetches.add(
+                                () -> b.fetch(new FetchData.Request(source, s, range, options),
+                                    watcher, mc -> collector.acceptMetricsCollection(s, mc)));
+                        } else {
+                            fetches.add(() -> b
+                                .fetch(new FetchData.Request(source, s, range, options), watcher)
+                                .directTransform(d -> {
+                                    d.getGroups().forEach(group -> {
+                                        collector.acceptMetricsCollection(s, group);
+                                    });
+                                    return d.getResult();
+                                }));
+                        }
+                    }
+                });
 
                 return async.eventuallyCollect(fetches, collector, fetchParallelism);
             };
@@ -300,8 +309,13 @@ public class LocalMetricManager implements MetricManager {
         }
 
         @Override
-        public AsyncFuture<FetchData> fetch(final FetchData.Request request) {
-            return fetch(request, FetchQuotaWatcher.NO_QUOTA);
+        public AsyncFuture<FetchData.Result> fetch(
+            final FetchData.Request request, final FetchQuotaWatcher watcher,
+            final Consumer<MetricCollection> metricsConsumer
+        ) {
+            final List<AsyncFuture<FetchData.Result>> callbacks =
+                map(b -> b.fetch(request, watcher, metricsConsumer));
+            return async.collect(callbacks, FetchData.collectResult(FETCH));
         }
 
         @Override
@@ -400,7 +414,7 @@ public class LocalMetricManager implements MetricManager {
 
     @RequiredArgsConstructor
     private abstract static class ResultCollector
-        implements StreamCollector<Pair<Series, FetchData>, FullQuery> {
+        implements StreamCollector<FetchData.Result, FullQuery> {
         final ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
         final ConcurrentLinkedQueue<RequestError> requestErrors = new ConcurrentLinkedQueue<>();
 
@@ -413,19 +427,13 @@ public class LocalMetricManager implements MetricManager {
         final boolean failOnLimits;
 
         @Override
-        public void resolved(final Pair<Series, FetchData> result) throws Exception {
-            final FetchData f = result.getRight();
-            requestErrors.addAll(f.getErrors());
-            try {
-                for (final MetricCollection g : f.getGroups()) {
-                    g.updateAggregation(session, result.getLeft().getTags(),
-                        ImmutableSet.of(result.getLeft()));
-                    dataInMemoryReporter.reportDataNoLongerNeeded(g.size());
-                }
-            } catch (QuotaViolationException e) {
-                // Seems resolved() should not throw exception
-                log.debug("Aggregation quota violated", e);
-            }
+        public void resolved(final FetchData.Result result) throws Exception {
+            requestErrors.addAll(result.getErrors());
+        }
+
+        void acceptMetricsCollection(final Series series, MetricCollection g) {
+            g.updateAggregation(session, series.getTags(), ImmutableSet.of(series));
+            dataInMemoryReporter.reportDataNoLongerNeeded(g.size());
         }
 
         @Override

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/Fetch.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/Fetch.java
@@ -27,6 +27,7 @@ import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.dagger.CoreComponent;
 import com.spotify.heroic.metric.FetchData;
+import com.spotify.heroic.metric.FetchQuotaWatcher;
 import com.spotify.heroic.metric.Metric;
 import com.spotify.heroic.metric.MetricBackendGroup;
 import com.spotify.heroic.metric.MetricCollection;
@@ -44,12 +45,14 @@ import com.spotify.heroic.time.Clock;
 import dagger.Component;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
+import eu.toolchain.async.LazyTransform;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import javax.inject.Inject;
 import javax.inject.Named;
 import lombok.ToString;
@@ -91,7 +94,6 @@ public class Fetch implements ShellTask {
             params.end.map(t -> Tasks.parseInstant(t, now)).orElseGet(() -> defaultEnd(start));
 
         final DateRange range = new DateRange(start, end);
-        final int limit = Math.max(1, params.limit);
 
         final DateFormat flip = new SimpleDateFormat("yyyy-MM-dd HH:mm");
         final DateFormat point = new SimpleDateFormat("HH:mm:ss.SSS");
@@ -99,47 +101,51 @@ public class Fetch implements ShellTask {
         final MetricBackendGroup readGroup = metrics.useOptionalGroup(params.group);
         final MetricType source = MetricType.fromIdentifier(params.source).orElse(MetricType.POINT);
 
-        final QueryOptions options =
-            QueryOptions.builder().tracing(Tracing.fromBoolean(params.tracing)).build();
+        final QueryOptions.Builder optionsBuilder =
+            QueryOptions.builder().tracing(Tracing.fromBoolean(params.tracing));
+        final QueryOptions options = optionsBuilder.build();
 
-        return readGroup
-            .fetch(new FetchData.Request(source, series, range, options))
-            .lazyTransform(result -> {
-                outer:
-                for (final MetricCollection g : result.getGroups()) {
-                    int i = 0;
+        final Consumer<MetricCollection> printMetricsCollection = g -> {
+            Calendar current = null;
+            Calendar last = null;
 
-                    Calendar current = null;
-                    Calendar last = null;
+            for (final Metric d : g.getData()) {
+                current = Calendar.getInstance();
+                current.setTime(new Date(d.getTimestamp()));
 
-                    for (final Metric d : g.getData()) {
-                        current = Calendar.getInstance();
-                        current.setTime(new Date(d.getTimestamp()));
-
-                        if (flipped(last, current)) {
-                            io.out().println(flip.format(current.getTime()));
-                        }
-
-                        io
-                            .out()
-                            .println(
-                                String.format("  %s: %s", point.format(new Date(d.getTimestamp())),
-                                    d));
-
-                        if (i++ >= limit) {
-                            break outer;
-                        }
-
-                        last = current;
-                    }
+                if (flipped(last, current)) {
+                    io.out().println(flip.format(current.getTime()));
                 }
+                String fs = String.format("  %s: %s", point.format(new Date(d.getTimestamp())), d);
+                io.out().println(fs);
 
-                io.out().println("TRACE:");
-                result.getTrace().formatTrace(io.out());
-                io.out().flush();
+                last = current;
+            }
+        };
 
-                return async.resolved();
-            });
+        final LazyTransform<FetchData.Result, Void> handleResult = result -> {
+
+            io.out().println("TRACE:");
+            result.getTrace().formatTrace(io.out());
+            io.out().flush();
+
+            return async.resolved();
+        };
+
+        if (params.slicedDataFetch) {
+            return readGroup
+                .fetch(new FetchData.Request(source, series, range, options),
+                    FetchQuotaWatcher.NO_QUOTA, printMetricsCollection)
+                .lazyTransform(handleResult);
+        } else {
+            return readGroup
+                .fetch(new FetchData.Request(source, series, range, options),
+                    FetchQuotaWatcher.NO_QUOTA)
+                .lazyTransform(resultData -> {
+                    resultData.getGroups().forEach(printMetricsCollection);
+                    return handleResult.transform(resultData.getResult());
+                });
+        }
     }
 
     private boolean flipped(Calendar last, Calendar current) {
@@ -185,16 +191,15 @@ public class Fetch implements ShellTask {
         @Option(name = "--end", usage = "End date", metaVar = "<datetime>")
         private Optional<String> end = Optional.empty();
 
-        @Option(name = "--limit", usage = "Maximum number of datapoints to fetch",
-            metaVar = "<int>")
-        private int limit = 1000;
-
         @Option(name = "-g", aliases = {"--group"}, usage = "Backend group to use",
             metaVar = "<group>")
         private Optional<String> group = Optional.empty();
 
         @Option(name = "--tracing", usage = "Enable extensive tracing")
         private boolean tracing = false;
+
+        @Option(name = "--sliced-data-fetch", usage = "Enable sliced data fetch")
+        private boolean slicedDataFetch = false;
     }
 
     public static Fetch setup(final CoreComponent core) {

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/Query.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/Query.java
@@ -23,15 +23,18 @@ package com.spotify.heroic.shell.task;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.spotify.heroic.querylogging.QueryContext;
+import com.spotify.heroic.QueryBuilder;
 import com.spotify.heroic.QueryDateRange;
 import com.spotify.heroic.QueryManager;
 import com.spotify.heroic.QueryOptions;
+import com.spotify.heroic.common.Feature;
+import com.spotify.heroic.common.FeatureSet;
 import com.spotify.heroic.dagger.CoreComponent;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.RequestError;
 import com.spotify.heroic.metric.ShardedResultGroup;
 import com.spotify.heroic.metric.Tracing;
+import com.spotify.heroic.querylogging.QueryContext;
 import com.spotify.heroic.shell.AbstractShellTaskParams;
 import com.spotify.heroic.shell.ShellIO;
 import com.spotify.heroic.shell.ShellTask;
@@ -40,10 +43,6 @@ import com.spotify.heroic.shell.TaskParameters;
 import com.spotify.heroic.shell.TaskUsage;
 import dagger.Component;
 import eu.toolchain.async.AsyncFuture;
-import lombok.ToString;
-import org.kohsuke.args4j.Argument;
-import org.kohsuke.args4j.Option;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -51,6 +50,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
+import lombok.ToString;
+import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.Option;
 
 @TaskUsage("Execute a query")
 @TaskName("query")
@@ -86,18 +88,19 @@ public class Query implements ShellTask {
         params.groupLimit.ifPresent(optionsBuilder::groupLimit);
         params.seriesLimit.ifPresent(optionsBuilder::seriesLimit);
 
-        final QueryOptions options = optionsBuilder.build();
+        final Optional<QueryOptions> options = Optional.of(optionsBuilder.build());
 
         final Optional<QueryDateRange> range =
             Optional.of(new QueryDateRange.Relative(TimeUnit.DAYS, 1));
 
+        QueryBuilder queryBuilder =
+            query.newQueryFromString(queryString).options(options).rangeIfAbsent(range);
+        if (params.slicedDataFetch) {
+            queryBuilder.features(Optional.of(FeatureSet.of(Feature.SLICED_DATA_FETCH)));
+        }
         return query
             .useGroup(params.group)
-            .query(query
-                .newQueryFromString(queryString)
-                .options(Optional.of(options))
-                .rangeIfAbsent(range)
-                .build(), queryContext)
+            .query(queryBuilder.build(), queryContext)
             .directTransform(result -> {
                 for (final RequestError e : result.getErrors()) {
                     io.out().println(String.format("ERR: %s", e.toString()));
@@ -135,6 +138,10 @@ public class Query implements ShellTask {
 
         @Option(name = "--tracing", usage = "Enable extensive tracing")
         private boolean tracing = false;
+
+        @Option(name = "--sliced-data-fetch", usage = "Enable sliced data fetch")
+        private boolean slicedDataFetch = false;
+
 
         @Option(name = "--data-limit", usage = "Enable data limiting")
         private Optional<Long> dataLimit = Optional.empty();

--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
@@ -327,7 +327,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
         for (final RequestError e : result.getErrors()) {
             assertTrue((e instanceof QueryError));
             final QueryError q = (QueryError) e;
-            assertThat(q.getError(), containsString("Query exceeded quota"));
+            assertThat(q.getError(), containsString("Some fetches failed (1) or were cancelled (0)"));
         }
 
         assertEquals(ResultLimits.of(ResultLimit.AGGREGATION), result.getLimits());

--- a/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsMetricBackend.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsMetricBackend.java
@@ -35,11 +35,11 @@ import com.spotify.heroic.metric.MetricBackend;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.WriteMetric;
 import eu.toolchain.async.AsyncFuture;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
-
 import java.time.LocalDate;
 import java.util.List;
+import java.util.function.Consumer;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
 @ToString
 @RequiredArgsConstructor
@@ -78,6 +78,15 @@ class BigtableAnalyticsMetricBackend implements MetricBackend {
     ) {
         analytics.reportFetchSeries(LocalDate.now(), request.getSeries());
         return backend.fetch(request, watcher);
+    }
+
+    @Override
+    public AsyncFuture<FetchData.Result> fetch(
+        final FetchData.Request request, final FetchQuotaWatcher watcher,
+        final Consumer<MetricCollection> metricsConsumer
+    ) {
+        analytics.reportFetchSeries(LocalDate.now(), request.getSeries());
+        return backend.fetch(request, watcher, metricsConsumer);
     }
 
     @Override

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/ReadRowRangeRequest.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/ReadRowRangeRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Spotify AB.
+ * Copyright (c) 2016 Spotify AB.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,14 +19,16 @@
  * under the License.
  */
 
-package com.spotify.heroic.metric;
+package com.spotify.heroic.metric.bigtable.api;
 
-import eu.toolchain.async.AsyncFuture;
+import com.google.protobuf.ByteString;
 
-public interface MetricBackendGroup extends MetricBackend {
-    /**
-     * Perform a local query for metrics.
-     */
-    AsyncFuture<FullQuery> query(FullQuery.Request request);
+import lombok.Data;
 
+@Data
+public final class ReadRowRangeRequest {
+    private final ByteString rowKey;
+    private final String columnFamily;
+    private final ByteString startQualifierOpen;
+    private final ByteString endQualifierClosed;
 }

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxBackend.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxBackend.java
@@ -29,6 +29,7 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.utils.Bytes;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.spotify.heroic.QueryOptions;
 import com.spotify.heroic.async.AsyncObservable;
 import com.spotify.heroic.async.AsyncObserver;
@@ -62,13 +63,6 @@ import eu.toolchain.async.Managed;
 import eu.toolchain.async.ResolvableFuture;
 import eu.toolchain.async.StreamCollector;
 import eu.toolchain.async.Transform;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
-
-import javax.inject.Inject;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
@@ -84,6 +78,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import javax.inject.Inject;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * MetricBackend for Heroic cassandra datastore.
@@ -149,10 +149,46 @@ public class DatastaxBackend extends AbstractMetricBackend implements LifeCycles
                 c.schema.ranges(request.getSeries(), request.getRange());
 
             if (request.getType() == MetricType.POINT) {
-                return fetchDataPoints(w, limit, request.getOptions(), prepared, c);
+                final List<AsyncFuture<FetchData>> fetches =
+                    fetchDataPoints(w, limit, request.getOptions(), prepared, c);
+                return async.collect(fetches, FetchData.collect(FETCH));
             }
 
             return async.resolved(FetchData.error(w.end(FETCH),
+                QueryError.fromMessage("unsupported source: " + request.getType())));
+        });
+    }
+
+    @Override
+    public AsyncFuture<FetchData.Result> fetch(
+        final FetchData.Request request, final FetchQuotaWatcher watcher,
+        final Consumer<MetricCollection> metricsConsumer
+    ) {
+        if (!watcher.mayReadData()) {
+            throw new IllegalArgumentException("query violated data limit");
+        }
+
+        final int limit = watcher.getReadDataQuota();
+
+        return connection.doto(c -> {
+            final QueryTrace.Watch w = QueryTrace.watch();
+
+            final List<PreparedFetch> prepared =
+                c.schema.ranges(request.getSeries(), request.getRange());
+
+            if (request.getType() == MetricType.POINT) {
+                final List<AsyncFuture<FetchData>> fetches =
+                    fetchDataPoints(w, limit, request.getOptions(), prepared, c);
+
+                final List<AsyncFuture<FetchData.Result>> results =
+                    Lists.transform(fetches, fetch -> fetch.directTransform(fetchData -> {
+                        fetchData.getGroups().forEach(metricsConsumer::accept);
+                        return fetchData.getResult();
+                    }));
+                return async.collect(results, FetchData.collectResult(FETCH));
+            }
+
+            return async.resolved(FetchData.errorResult(w.end(FETCH),
                 QueryError.fromMessage("unsupported source: " + request.getType())));
         });
     }
@@ -480,7 +516,7 @@ public class DatastaxBackend extends AbstractMetricBackend implements LifeCycles
             .directTransform(t -> QueryTrace.of(what, elapsed, ImmutableList.copyOf(t)));
     }
 
-    private AsyncFuture<FetchData> fetchDataPoints(
+    private List<AsyncFuture<FetchData>> fetchDataPoints(
         final QueryTrace.Watch w, final int limit, final QueryOptions options,
         final List<PreparedFetch> prepared, final Connection c
     ) throws Exception {
@@ -516,7 +552,7 @@ public class DatastaxBackend extends AbstractMetricBackend implements LifeCycles
             fetches.add(future);
         }
 
-        return async.collect(fetches, FetchData.collect(FETCH));
+        return fetches;
     }
 
     @RequiredArgsConstructor

--- a/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryBackend.java
+++ b/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryBackend.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
+import java.util.function.Consumer;
 import javax.inject.Inject;
 import javax.inject.Named;
 import lombok.Data;
@@ -118,8 +119,20 @@ public class MemoryBackend extends AbstractMetricBackend {
     public AsyncFuture<FetchData> fetch(FetchData.Request request, FetchQuotaWatcher watcher) {
         final QueryTrace.NamedWatch w = QueryTrace.watch(FETCH);
         final MemoryKey key = new MemoryKey(request.getType(), request.getSeries());
-        final List<MetricCollection> groups = doFetch(key, request.getRange(), watcher);
-        return async.resolved(FetchData.of(w.end(), ImmutableList.of(), groups));
+        final MetricCollection metrics = doFetch(key, request.getRange(), watcher);
+        return async.resolved(FetchData.of(w.end(), ImmutableList.of(), ImmutableList.of(metrics)));
+    }
+
+    @Override
+    public AsyncFuture<FetchData.Result> fetch(
+        FetchData.Request request, FetchQuotaWatcher watcher,
+        Consumer<MetricCollection> metricsConsumer
+    ) {
+        final QueryTrace.NamedWatch w = QueryTrace.watch(FETCH);
+        final MemoryKey key = new MemoryKey(request.getType(), request.getSeries());
+        final MetricCollection metrics = doFetch(key, request.getRange(), watcher);
+        metricsConsumer.accept(metrics);
+        return async.resolved(FetchData.result(w.end()));
     }
 
     @Override
@@ -157,13 +170,13 @@ public class MemoryBackend extends AbstractMetricBackend {
         }
     }
 
-    private List<MetricCollection> doFetch(
+    private MetricCollection doFetch(
         final MemoryKey key, final DateRange range, final FetchQuotaWatcher watcher
     ) {
         final NavigableMap<Long, Metric> tree = storage.get(key);
 
         if (tree == null) {
-            return ImmutableList.of(MetricCollection.build(key.getSource(), ImmutableList.of()));
+            return MetricCollection.build(key.getSource(), ImmutableList.of());
         }
 
         synchronized (tree) {
@@ -171,7 +184,7 @@ public class MemoryBackend extends AbstractMetricBackend {
                 tree.subMap(range.getStart(), false, range.getEnd(), true).values();
             final List<Metric> data = ImmutableList.copyOf(metrics);
             watcher.readData(data.size());
-            return ImmutableList.of(MetricCollection.build(key.getSource(), data));
+            return MetricCollection.build(key.getSource(), data);
         }
     }
 

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
@@ -40,9 +40,13 @@ import com.spotify.heroic.statistics.FutureReporter;
 import com.spotify.heroic.statistics.MetricBackendReporter;
 import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricRegistry;
+
 import eu.toolchain.async.AsyncFuture;
+
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
@@ -162,6 +166,14 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
             final FetchData.Request request, final FetchQuotaWatcher watcher
         ) {
             return delegate.fetch(request, watcher).onDone(fetch.setup());
+        }
+
+        @Override
+        public AsyncFuture<FetchData.Result> fetch(
+            final FetchData.Request request, final FetchQuotaWatcher watcher,
+            final Consumer<MetricCollection> metricsConsumer
+        ) {
+            return delegate.fetch(request, watcher, metricsConsumer).onDone(fetch.setup());
         }
 
         @Override


### PR DESCRIPTION
When reading data from MetricBackend, allow different series to be consumed continuously (in a streaming fashion) which in many cases reduces the amount of memory that must be retained.

When this is merged, there are two more possible pending changes queued up, based on this:
* jo-ri#2: Allow a single row to be read in chunks
* jo-ri#3: Use the protobuf client

(Originally all three steps were in PR #181)