### PR TITLE
Introduce FakeBigtableConnection and more test coverage

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/async/AsyncObservable.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/async/AsyncObservable.java
@@ -21,10 +21,8 @@
 
 package com.spotify.heroic.async;
 
-import com.spotify.heroic.analytics.SeriesHit;
 import com.spotify.heroic.common.Throwing;
 import eu.toolchain.async.AsyncFuture;
-
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
@@ -140,7 +138,7 @@ public interface AsyncObservable<T> {
     /**
      * Create an observable that will always be immediately failed with the given throwable.
      */
-    static <T> AsyncObservable<SeriesHit> failed(final Throwable e) {
+    static <T> AsyncObservable<T> failed(final Throwable e) {
         return observer -> observer.fail(e);
     }
 }

--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
@@ -143,7 +143,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
         builder
             .features(Optional.of(FeatureSet.of(Feature.DISTRIBUTED_AGGREGATIONS)))
             .source(Optional.of(MetricType.POINT))
-            .rangeIfAbsent(Optional.of(new QueryDateRange.Absolute(10, 40)));
+            .rangeIfAbsent(Optional.of(new QueryDateRange.Absolute(0, 40)));
 
         modifier.accept(builder);
         return query.useDefaultGroup().query(builder.build(), queryContext).get();
@@ -275,7 +275,9 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
         final List<Long> cadences = getCadences(result);
 
         assertEquals(ImmutableList.of(10L), cadences);
-        assertEquals(ImmutableSet.of(points().p(10, 1D).p(20, 1D).p(30, 1D).p(40, 0D).build()), m);
+        assertEquals(
+            ImmutableSet.of(points().p(0, 0.0D).p(10, 1D).p(20, 1D).p(30, 1D).p(40, 0D).build()),
+            m);
     }
 
     @Test
@@ -289,7 +291,9 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
         final List<Long> cadences = getCadences(result);
 
         assertEquals(ImmutableList.of(10L), cadences);
-        assertEquals(ImmutableSet.of(points().p(10, 2D).p(20, 1D).p(30, 1D).p(40, 0D).build()), m);
+        assertEquals(
+            ImmutableSet.of(points().p(0, 0.0D).p(10, 2D).p(20, 1D).p(30, 1D).p(40, 0D).build()),
+            m);
     }
 
     @Test

--- a/heroic-test-it/src/main/java/com/spotify/heroic/test/AbstractMetricBackendIT.java
+++ b/heroic-test-it/src/main/java/com/spotify/heroic/test/AbstractMetricBackendIT.java
@@ -21,6 +21,11 @@
 
 package com.spotify.heroic.test;
 
+import static com.spotify.heroic.test.Data.events;
+import static com.spotify.heroic.test.Data.points;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -37,31 +42,31 @@ import com.spotify.heroic.metric.MetricBackend;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.MetricManagerModule;
 import com.spotify.heroic.metric.MetricModule;
-import com.spotify.heroic.metric.MetricType;
 import com.spotify.heroic.metric.WriteMetric;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.junit.runners.model.Statement;
 
-import java.util.Optional;
-
-import lombok.extern.slf4j.Slf4j;
-
-import static org.junit.Assert.assertEquals;
-
 @Slf4j
 public abstract class AbstractMetricBackendIT {
-    protected abstract Optional<MetricModule> setupModule();
-
     protected final Series s1 = Series.of("s1", ImmutableMap.of("id", "s1"));
-    protected final Series s2 = Series.of("s2", ImmutableMap.of("id", "s2"));
+    public static final Map<String, String> EVENT = ImmutableMap.of();
 
     protected MetricBackend backend;
 
+    protected boolean eventSupport = false;
+    protected Optional<Integer> maxBatchSize = Optional.empty();
+
     @Rule
     public TestRule setupBackend = (base, description) -> new Statement() {
-
         @Override
         public void evaluate() throws Throwable {
             Optional<MetricModule> module = setupModule();
@@ -93,21 +98,193 @@ public abstract class AbstractMetricBackendIT {
                 base.evaluate();
                 core.shutdown().get();
             } else {
-                log.info("Omitting "  + description + " since module is not configured");
+                log.info("Omitting " + description + " since module is not configured");
             }
         }
     };
 
+    @Before
+    public void setup() {
+        setupSupport();
+    }
+
+    protected abstract Optional<MetricModule> setupModule();
+
+    protected Optional<Long> period() {
+        return Optional.empty();
+    }
+
+    /**
+     * Setup backend-specific support.
+     */
+    protected void setupSupport() {
+    }
+
     @Test
-    public void testWrite() throws Exception {
-        // write and read data back
-        final MetricCollection points = Data.points().p(100000L, 42D).build();
-        backend.write(new WriteMetric.Request(s1, points)).get();
+    public void testInterval() throws Exception {
+        newCase()
+            .input(99L, 100L, 101L, 199L, 200L, 201L)
+            .expect(101L, 199L, 200L)
+            .forEach((input, expected) -> {
+                verifyReadWrite(input, expected, new DateRange(100L, 200L));
+            });
+    }
+
+    /**
+     * Some backends have optimized code for writing a single sample.
+     */
+    @Test
+    public void testOne() throws Exception {
+        newCase().input(100L).expect(100L).forEach((input, expected) -> {
+            verifyReadWrite(input, expected, new DateRange(99L, 100L));
+        });
+    }
+
+    /**
+     * Some backends have limits on how many metrics should be written in a single request.
+     *
+     * This test case creates a dense pool of metrics after a given max batch size to make sure that
+     * they can be written and read out.
+     */
+    @Test
+    public void testMaxBatchSize() throws Exception {
+        assumeTrue("max batch size", maxBatchSize.isPresent());
+        final int maxBatchSize = this.maxBatchSize.get();
+
+        newCase().denseStart(100).dense(maxBatchSize * 4).forEach((input, expected) -> {
+            verifyReadWrite(input, expected, new DateRange(99L, 100L + (maxBatchSize * 4)));
+        });
+    }
+
+    /**
+     * This test is run if the specific test overrides the {@link #period()} method and returns a
+     * value (not {@link java.util.Optional#empty()}.
+     * <p>
+     * This value will be considered the period of the metric backend, which indicates at what
+     * distance the backend will split samples up into distinct storage parts. These would typically
+     * make up edge cases that this test case attempts to read and write.
+     */
+    @Test
+    public void testPeriod() throws Exception {
+        final Optional<Long> maybePeriod = period();
+        assumeTrue("period is present", maybePeriod.isPresent());
+
+        final long count = 5;
+        final long period = maybePeriod.get();
+
+        final Points points = points();
+
+        // seed data just at the edges of the period
+        for (int i = 1; i < count; i++) {
+            points.p(i * period, 1.0D);
+            points.p((i + 1) * period - 1, 1.0D);
+        }
+
+        final MetricCollection written = points.build();
+
+        verifyReadWrite(written, written, new DateRange(period - 1, (period + 1) * count));
+    }
+
+    private void verifyReadWrite(
+        final MetricCollection input, final MetricCollection expected, final DateRange range
+    ) throws Exception {
+        backend.write(new WriteMetric.Request(s1, input)).get();
+
         FetchData data = backend
-            .fetch(new FetchData.Request(MetricType.POINT, s1, new DateRange(10000L, 200000L),
+            .fetch(new FetchData.Request(expected.getType(), s1, range,
                 QueryOptions.builder().build()), FetchQuotaWatcher.NO_QUOTA)
             .get();
 
-        assertEquals(ImmutableSet.of(points), ImmutableSet.copyOf(data.getGroups()));
+        assertEquals(ImmutableSet.of(expected), ImmutableSet.copyOf(data.getGroups()));
+    }
+
+    private TestCase newCase() {
+        return new TestCase();
+    }
+
+    @lombok.Data
+    private class TestCase {
+        private Optional<Integer> denseStart = Optional.empty();
+        private Optional<Integer> dense = Optional.empty();
+        private final List<Long> input = new ArrayList<>();
+        private final List<Long> expected = new ArrayList<>();
+
+        TestCase denseStart(final int denseStart) {
+            this.denseStart = Optional.of(denseStart);
+            return this;
+        }
+
+        TestCase dense(final int dense) {
+            this.dense = Optional.of(dense);
+            return this;
+        }
+
+        TestCase input(final long... inputs) {
+            for (final long input : inputs) {
+                this.input.add(input);
+            }
+
+            return this;
+        }
+
+        TestCase expect(final long... expected) {
+            for (final long expect : expected) {
+                this.expected.add(expect);
+            }
+
+            return this;
+        }
+
+        void forEach(final ThrowingBiConsumer<MetricCollection, MetricCollection> consumer)
+            throws Exception {
+            // test for events, if supported
+            if (eventSupport) {
+                final Events input = events();
+                final Events expected = events();
+
+                inputStream().forEach(t -> input.e(t, EVENT));
+                expectedStream().forEach(t -> expected.e(t, EVENT));
+
+                consumer.accept(input.build(), expected.build());
+            }
+
+            // test for points
+            {
+                final Points input = points();
+                final Points expected = points();
+
+                inputStream().forEach(t -> input.p(t, 42D));
+                expectedStream().forEach(t -> expected.p(t, 42D));
+
+                consumer.accept(input.build(), expected.build());
+            }
+        }
+
+        private Stream<Long> inputStream() {
+            return Stream.concat(this.input.stream(), this.denseStream());
+        }
+
+        private Stream<Long> expectedStream() {
+            return Stream.concat(this.expected.stream(), this.denseStream());
+        }
+
+        private Stream<Long> denseStream() {
+            return dense.map(d -> {
+                final Stream.Builder<Long> builder = Stream.builder();
+
+                final int start = denseStart.orElse(0);
+
+                for (int t = 0; t < d; t++) {
+                    builder.add((long) (t + start));
+                }
+
+                return builder.build();
+            }).orElseGet(Stream::empty);
+        }
+    }
+
+    @FunctionalInterface
+    interface ThrowingBiConsumer<A, B> {
+        void accept(final A a, final B b) throws Exception;
     }
 }

--- a/heroic-test-it/src/main/java/com/spotify/heroic/test/Events.java
+++ b/heroic-test-it/src/main/java/com/spotify/heroic/test/Events.java
@@ -21,12 +21,20 @@
 
 package com.spotify.heroic.test;
 
-public class Data {
-    public static Points points() {
-        return new Points();
+import com.google.common.collect.ImmutableList;
+import com.spotify.heroic.metric.Event;
+import com.spotify.heroic.metric.MetricCollection;
+import java.util.Map;
+
+public class Events {
+    private final ImmutableList.Builder<Event> events = ImmutableList.builder();
+
+    public Events e(final long t, final Map<String, String> payload) {
+        events.add(new Event(t, payload));
+        return this;
     }
 
-    public static Events events() {
-        return new Events();
+    public MetricCollection build() {
+        return MetricCollection.events(events.build());
     }
 }

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableMetricModule.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableMetricModule.java
@@ -21,6 +21,9 @@
 
 package com.spotify.heroic.metric.bigtable;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.heroic.ExtraParameters;
@@ -31,8 +34,10 @@ import com.spotify.heroic.dagger.PrimaryComponent;
 import com.spotify.heroic.lifecycle.LifeCycle;
 import com.spotify.heroic.lifecycle.LifeCycleManager;
 import com.spotify.heroic.metric.MetricModule;
+import com.spotify.heroic.metric.bigtable.api.FakeBigtableConnection;
 import com.spotify.heroic.metric.bigtable.credentials.ComputeEngineCredentialsBuilder;
 import dagger.Component;
+import dagger.Lazy;
 import dagger.Module;
 import dagger.Provides;
 import eu.toolchain.async.AsyncFramework;
@@ -40,14 +45,10 @@ import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.Managed;
 import eu.toolchain.async.ManagedSetup;
 import eu.toolchain.serializer.Serializer;
-import lombok.Data;
-
-import javax.inject.Named;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
-
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
+import javax.inject.Named;
+import lombok.Data;
 
 @Data
 @ModuleId("bigtable")
@@ -62,6 +63,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
     public static final boolean DEFAULT_CONFIGURE = false;
     public static final boolean DEFAULT_DISABLE_BULK_MUTATIONS = false;
     public static final int DEFAULT_FLUSH_INTERVAL_SECONDS = 2;
+    public static final boolean DEFAULT_FAKE = false;
 
     private final Optional<String> id;
     private final Groups groups;
@@ -73,6 +75,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
     private final boolean disableBulkMutations;
     private final int flushIntervalSeconds;
     private final Optional<Integer> batchSize;
+    private final boolean fake;
 
     @JsonCreator
     public BigtableMetricModule(
@@ -84,7 +87,8 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         @JsonProperty("configure") Optional<Boolean> configure,
         @JsonProperty("disableBulkMutations") Optional<Boolean> disableBulkMutations,
         @JsonProperty("flushIntervalSeconds") Optional<Integer> flushIntervalSeconds,
-        @JsonProperty("batchSize") Optional<Integer> batchSize
+        @JsonProperty("batchSize") Optional<Integer> batchSize,
+        @JsonProperty("fake") Optional<Boolean> fake
     ) {
         this.id = id;
         this.groups = groups.orElseGet(Groups::empty).or(DEFAULT_GROUP);
@@ -96,6 +100,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         this.disableBulkMutations = disableBulkMutations.orElse(DEFAULT_DISABLE_BULK_MUTATIONS);
         this.flushIntervalSeconds = flushIntervalSeconds.orElse(DEFAULT_FLUSH_INTERVAL_SECONDS);
         this.batchSize = batchSize;
+        this.fake = fake.orElse(DEFAULT_FAKE);
     }
 
     @Override
@@ -123,8 +128,24 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         @Provides
         @BigtableScope
         public Managed<BigtableConnection> connection(
-            final AsyncFramework async, final ExecutorService executorService
+            final AsyncFramework async, final ExecutorService executorService,
+            final Lazy<FakeBigtableConnection> fakeBigtableConnection
         ) {
+            if (fake) {
+                return async.managed(new ManagedSetup<BigtableConnection>() {
+                    @Override
+                    public AsyncFuture<BigtableConnection> construct() throws Exception {
+                        return async.resolved(fakeBigtableConnection.get());
+                    }
+
+                    @Override
+                    public AsyncFuture<Void> destruct(final BigtableConnection value)
+                        throws Exception {
+                        return value.close();
+                    }
+                });
+            }
+
             return async.managed(new ManagedSetup<BigtableConnection>() {
                 @Override
                 public AsyncFuture<BigtableConnection> construct() throws Exception {
@@ -198,6 +219,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         private Optional<Boolean> disableBulkMutations = empty();
         private Optional<Integer> flushIntervalSeconds = empty();
         private Optional<Integer> batchSize = empty();
+        private Optional<Boolean> fake = empty();
 
         public Builder id(String id) {
             this.id = of(id);
@@ -250,9 +272,14 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
             return this;
         }
 
+        public Builder fake(final boolean fake) {
+            this.fake = of(fake);
+            return this;
+        }
+
         public BigtableMetricModule build() {
             return new BigtableMetricModule(id, groups, project, instance, table, credentials,
-                configure, disableBulkMutations, flushIntervalSeconds, batchSize);
+                configure, disableBulkMutations, flushIntervalSeconds, batchSize, fake);
         }
     }
 }

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/FakeBigtableConnection.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/FakeBigtableConnection.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.metric.bigtable.api;
+
+import com.google.bigtable.v2.Mutation;
+import com.google.cloud.bigtable.grpc.scanner.FlatRow;
+import com.google.protobuf.ByteString;
+import com.spotify.heroic.async.AsyncObservable;
+import com.spotify.heroic.metric.bigtable.BigtableConnection;
+import eu.toolchain.async.AsyncFramework;
+import eu.toolchain.async.AsyncFuture;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.inject.Inject;
+import lombok.Data;
+import org.apache.commons.lang3.tuple.Pair;
+
+public class FakeBigtableConnection implements BigtableConnection {
+    private static final String CLUSTER_URI = "fake";
+
+    private final AsyncFramework async;
+
+    private final ConcurrentMap<String, TableStorage> tables = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Pair<Table, String>, ColumnFamily> columnFamilies =
+        new ConcurrentHashMap<>();
+
+    @Inject
+    public FakeBigtableConnection(final AsyncFramework async) {
+        this.async = async;
+    }
+
+    @Override
+    public BigtableTableAdminClient tableAdminClient() {
+        return new AdminClient();
+    }
+
+    @Override
+    public BigtableDataClient dataClient() {
+        return new DataClient();
+    }
+
+    @Override
+    public AsyncFuture<Void> close() {
+        return async.resolved();
+    }
+
+    class AdminClient implements BigtableTableAdminClient {
+        private final Object lock = new Object();
+
+        @Override
+        public Optional<Table> getTable(
+            final String tableId
+        ) {
+            final TableStorage storage = tables.get(tableId);
+
+            if (storage == null) {
+                return Optional.empty();
+            }
+
+            return Optional.of(storage.getTable());
+        }
+
+        @Override
+        public Table createTable(final String name) {
+            synchronized (lock) {
+                TableStorage storage = tables.get(name);
+
+                if (storage == null) {
+                    final Table table = new Table(CLUSTER_URI, name);
+                    storage = new TableStorage(table);
+                    tables.put(name, storage);
+                }
+
+                return storage.getTable();
+            }
+        }
+
+        @Override
+        public ColumnFamily createColumnFamily(
+            final Table table, final String name
+        ) {
+            synchronized (lock) {
+                final TableStorage storage = tables.get(table.getName());
+
+                if (storage == null) {
+                    throw new IllegalArgumentException("no such table: " + name);
+                }
+
+                final Pair<Table, String> key = Pair.of(storage.getTable(), name);
+
+                ColumnFamily columnFamily = columnFamilies.get(key);
+
+                if (columnFamily == null) {
+                    columnFamily = new ColumnFamily(table.getClusterUri(), table.getName(), name);
+                    columnFamilies.put(key, columnFamily);
+                }
+
+                return columnFamily;
+            }
+        }
+    }
+
+    class DataClient implements BigtableDataClient {
+        @Override
+        public AsyncFuture<Void> mutateRow(
+            final String tableName, final ByteString rowKey, final Mutations mutations
+        ) {
+            final TableStorage storage = tables.get(tableName);
+
+            if (storage == null) {
+                return async.failed(new IllegalStateException("No such table: " + tableName));
+            }
+
+            return storage.mutateRow(rowKey, mutations);
+        }
+
+        @Override
+        public AsyncFuture<List<FlatRow>> readRows(
+            final String tableName, final ReadRowsRequest request
+        ) {
+            final TableStorage storage = tables.get(tableName);
+
+            if (storage == null) {
+                return async.failed(new IllegalStateException("No such table: " + tableName));
+            }
+
+            return storage.readRows(request);
+        }
+
+        @Override
+        public AsyncObservable<Row> readRowsObserved(
+            final String tableName, final ReadRowsRequest request
+        ) {
+            return AsyncObservable.failed(new RuntimeException("not supported"));
+        }
+
+        @Override
+        public AsyncFuture<Row> readModifyWriteRow(
+            final String tableName, final ByteString rowKey, final ReadModifyWriteRules rules
+        ) {
+            return async.failed(new RuntimeException("not supported"));
+        }
+    }
+
+    @Data
+    class TableStorage {
+        private final Table table;
+
+        private final ConcurrentMap<Pair<ByteString, ColumnFamily>, RowStorage> rows =
+            new ConcurrentHashMap<>();
+
+        private final Object lock = new Object();
+
+        public AsyncFuture<Void> mutateRow(final ByteString rowKey, final Mutations mutations) {
+            return async.call(() -> {
+                mutations.getMutations().forEach(mutation -> {
+                    switch (mutation.getMutationCase()) {
+                        case SET_CELL:
+                            final Mutation.SetCell setCell = mutation.getSetCell();
+                            final ColumnFamily columnFamily =
+                                columnFamilies.get(Pair.of(table, setCell.getFamilyName()));
+
+                            if (columnFamily == null) {
+                                throw new IllegalArgumentException(
+                                    "no such column family: " + setCell.getFamilyName());
+                            }
+
+                            RowStorage rowStorage;
+
+                            synchronized (lock) {
+                                final Pair<ByteString, ColumnFamily> key =
+                                    Pair.of(rowKey, columnFamily);
+
+                                rowStorage = rows.get(key);
+
+                                if (rowStorage == null) {
+                                    rowStorage = new RowStorage(columnFamily);
+                                    rows.put(key, rowStorage);
+                                }
+                            }
+
+                            rowStorage.runSetCell(setCell);
+                            break;
+                        default:
+                            throw new IllegalArgumentException(
+                                "Unsupported mutation: " + mutation.getMutationCase());
+                    }
+                });
+
+                return null;
+            });
+        }
+
+        public AsyncFuture<List<FlatRow>> readRows(final ReadRowsRequest request) {
+            final Function<String, Boolean> matchesColumnFamily =
+                request.getFilter().<Function<String, Boolean>>map(
+                    filter -> filter::matchesColumnFamily).orElse(familyName -> true);
+
+            final Function<ByteString, Boolean> matchesColumn =
+                request.getFilter().<Function<ByteString, Boolean>>map(
+                    filter -> filter::matchesColumn).orElse(column -> true);
+
+            final Function<ByteString, Boolean> matchesRowKey =
+                request.getRowKey().<Function<ByteString, Boolean>>map(
+                    rowKey -> rowKey::equals).orElse(key -> true);
+
+            return async.call(() -> rows.entrySet().stream().flatMap(entry -> {
+                final Pair<ByteString, ColumnFamily> key = entry.getKey();
+
+                if (!matchesRowKey.apply(key.getLeft())) {
+                    return Stream.empty();
+                }
+
+                if (!matchesColumnFamily.apply(key.getRight().getName())) {
+                    return Stream.empty();
+                }
+
+                return Stream.of(entry
+                    .getValue()
+                    .readRows(key.getLeft(), key.getRight(), request, matchesColumn));
+            }).collect(Collectors.toList()));
+        }
+    }
+
+    @Data
+    class RowStorage {
+        private final ColumnFamily columnFamily;
+        private final ConcurrentMap<ByteString, ByteString> storage =
+            new ConcurrentSkipListMap<>(RowFilter::compareByteStrings);
+
+        void runSetCell(final Mutation.SetCell setCell) {
+            // TODO: take timestamp into account
+            storage.put(setCell.getColumnQualifier(), setCell.getValue());
+        }
+
+        FlatRow readRows(
+            final ByteString rowKey, final ColumnFamily columnFamily, final ReadRowsRequest request,
+            final Function<ByteString, Boolean> matchesColumn
+        ) {
+            final FlatRow.Builder builder = FlatRow.newBuilder().withRowKey(rowKey);
+
+            storage
+                .entrySet()
+                .stream()
+                .filter(e -> {
+                    final boolean matches = matchesColumn.apply(e.getKey());
+                    final Optional<RowFilter> filter = request.getFilter();
+                    return matches;
+                })
+                .map(column -> FlatRow.Cell
+                    .newBuilder()
+                    .withFamily(columnFamily.getName())
+                    .withQualifier(column.getKey())
+                    .withValue(column.getValue())
+                    .build())
+                .forEach(builder::addCell);
+
+            return builder.build();
+        }
+    }
+}

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/Mutations.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/Mutations.java
@@ -23,11 +23,10 @@ package com.spotify.heroic.metric.bigtable.api;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class Mutations {

--- a/metric/bigtable/src/test/java/com/spotify/heroic/metric/bigtable/BigtableBackendIT.java
+++ b/metric/bigtable/src/test/java/com/spotify/heroic/metric/bigtable/BigtableBackendIT.java
@@ -4,7 +4,6 @@ import com.spotify.heroic.metric.MetricModule;
 import com.spotify.heroic.metric.bigtable.credentials.JsonCredentialsBuilder;
 import com.spotify.heroic.test.AbstractMetricBackendIT;
 import com.spotify.heroic.test.TestProperties;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -14,10 +13,25 @@ public class BigtableBackendIT extends AbstractMetricBackendIT {
     private final TestProperties properties = TestProperties.ofPrefix("it.bigtable");
 
     @Override
-    public Optional<MetricModule> setupModule() {
-        return properties.getOptionalString("remote").map(v -> {
-            final String table = "heroic_it_" + UUID.randomUUID();
+    protected Optional<Long> period() {
+        /* BigtableBackend currently does not implement period edge cases correctly,
+         * See: https://github.com/spotify/heroic/pull/208 */
+        return Optional.empty();
+    }
 
+    @Override
+    protected void setupSupport() {
+        super.setupSupport();
+
+        this.eventSupport = true;
+        this.maxBatchSize = Optional.of(BigtableBackend.MAX_BATCH_SIZE);
+    }
+
+    @Override
+    public Optional<MetricModule> setupModule() {
+        final String table = "heroic_it_" + UUID.randomUUID();
+
+        final Optional<MetricModule> remote = properties.getOptionalString("remote").map(v -> {
             final String project = properties.getRequiredString("project");
             final String instance = properties.getRequiredString("instance");
             final Path credentials = Paths.get(properties.getRequiredString("credentials"));
@@ -31,5 +45,19 @@ public class BigtableBackendIT extends AbstractMetricBackendIT {
                 .credentials(JsonCredentialsBuilder.builder().path(credentials).build())
                 .build();
         });
+
+        if (remote.isPresent()) {
+            return remote;
+        }
+
+        final BigtableMetricModule module = BigtableMetricModule
+            .builder()
+            .configure(true)
+            .project("fake")
+            .table(table)
+            .fake(true)
+            .build();
+
+        return Optional.of(module);
     }
 }

--- a/metric/bigtable/src/test/java/com/spotify/heroic/metric/bigtable/api/RowFilterTest.java
+++ b/metric/bigtable/src/test/java/com/spotify/heroic/metric/bigtable/api/RowFilterTest.java
@@ -1,0 +1,54 @@
+package com.spotify.heroic.metric.bigtable.api;
+
+import static com.spotify.heroic.metric.bigtable.api.RowFilter.compareByteStrings;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.protobuf.ByteString;
+import org.junit.Test;
+
+public class RowFilterTest {
+    final ByteString s = ByteString.copyFrom(new byte[]{0, 0});
+    final ByteString a = ByteString.copyFrom(new byte[]{0, 0, 0, 0});
+    final ByteString b = ByteString.copyFrom(new byte[]{0, 0, 0, 1});
+    final ByteString c = ByteString.copyFrom(new byte[]{0, 0, 0, 2});
+    final ByteString d = ByteString.copyFrom(new byte[]{0, 0, 0, Byte.MIN_VALUE});
+
+    @Test
+    public void testColumnRange() {
+        final RowFilter.ColumnRange sqo =
+            RowFilter.newColumnRangeBuilder("family").startQualifierOpen(a).build();
+
+        assertFalse(sqo.matchesColumn(a));
+        assertTrue(sqo.matchesColumn(b));
+
+        final RowFilter.ColumnRange sqc =
+            RowFilter.newColumnRangeBuilder("family").startQualifierClosed(a).build();
+
+        assertTrue(sqc.matchesColumn(a));
+        assertTrue(sqc.matchesColumn(b));
+
+        final RowFilter.ColumnRange eqo =
+            RowFilter.newColumnRangeBuilder("family").endQualifierOpen(b).build();
+
+        assertTrue(eqo.matchesColumn(a));
+        assertFalse(eqo.matchesColumn(b));
+
+        final RowFilter.ColumnRange eqc =
+            RowFilter.newColumnRangeBuilder("family").endQualifierClosed(b).build();
+
+        assertTrue(eqc.matchesColumn(a));
+        assertTrue(eqc.matchesColumn(b));
+    }
+
+    @Test
+    public void testCompareByteStrings() {
+        assertEquals(-1, compareByteStrings(s, a));
+        assertEquals(1, compareByteStrings(a, s));
+        assertEquals(-1, compareByteStrings(a, b));
+        assertEquals(0, compareByteStrings(b, b));
+        assertEquals(1, compareByteStrings(c, b));
+        assertEquals(-1, compareByteStrings(c, d));
+    }
+}

--- a/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryBackend.java
+++ b/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryBackend.java
@@ -41,17 +41,16 @@ import com.spotify.heroic.metric.QueryTrace;
 import com.spotify.heroic.metric.WriteMetric;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.Data;
-import lombok.ToString;
-
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
+import javax.inject.Inject;
+import javax.inject.Named;
+import lombok.Data;
+import lombok.ToString;
 
 /**
  * MetricBackend for Heroic cassandra datastore.
@@ -168,7 +167,8 @@ public class MemoryBackend extends AbstractMetricBackend {
         }
 
         synchronized (tree) {
-            final Iterable<Metric> metrics = tree.subMap(range.getStart(), range.getEnd()).values();
+            final Iterable<Metric> metrics =
+                tree.subMap(range.getStart(), false, range.getEnd(), true).values();
             final List<Metric> data = ImmutableList.copyOf(metrics);
             watcher.readData(data.size());
             return ImmutableList.of(MetricCollection.build(key.getSource(), data));

--- a/metric/memory/src/test/java/com/spotify/heroic/metric/memory/MemoryBackendIT.java
+++ b/metric/memory/src/test/java/com/spotify/heroic/metric/memory/MemoryBackendIT.java
@@ -7,6 +7,13 @@ import java.util.Optional;
 
 public class MemoryBackendIT extends AbstractMetricBackendIT {
     @Override
+    protected void setupSupport() {
+        super.setupSupport();
+
+        this.eventSupport = true;
+    }
+
+    @Override
     protected Optional<MetricModule> setupModule() {
         return Optional.of(MemoryMetricModule.builder().build());
     }


### PR DESCRIPTION
This introduces a FakeBigtableConnection which can be used to include the majority of the code under `BigtableBackend` under `AbstractMetricBackendIT`.

With this, these tests can be run without operating an external Bigtable cluster, making it suitable for inclusion in the test suites that are automatically run on every PR.