### PR TITLE
[component, core] Add httpContext to all query log types

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryContext.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryContext.java
@@ -22,23 +22,27 @@
 package com.spotify.heroic.querylogging;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.Data;
 
 @Data
 public class QueryContext {
-    private static final JsonNode EMPTY = JsonNodeFactory.instance.nullNode();
-
     private final UUID queryId;
-    private final JsonNode clientContext;
+    private final Optional<JsonNode> clientContext;
+    private final Optional<HttpContext> httpContext;
 
     public static QueryContext empty() {
         return create(Optional.empty());
     }
 
     public static QueryContext create(final Optional<JsonNode> clientContext) {
-        return new QueryContext(UUID.randomUUID(), clientContext.orElse(EMPTY));
+        return new QueryContext(UUID.randomUUID(), clientContext, Optional.empty());
+    }
+
+    public static QueryContext create(
+        final Optional<JsonNode> clientContext, final HttpContext httpContext
+    ) {
+        return new QueryContext(UUID.randomUUID(), clientContext, Optional.of(httpContext));
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryLogger.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryLogger.java
@@ -28,9 +28,9 @@ import com.spotify.heroic.metric.QueryMetricsResponse;
 
 public interface QueryLogger {
 
-    void logHttpQueryText(QueryContext context, String queryString, HttpContext httpContext);
+    void logHttpQueryText(QueryContext context, String queryString);
 
-    void logHttpQueryJson(QueryContext context, QueryMetrics query, HttpContext httpContext);
+    void logHttpQueryJson(QueryContext context, QueryMetrics query);
 
     void logQuery(QueryContext context, Query query);
 

--- a/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryResource.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryResource.java
@@ -83,8 +83,8 @@ public class QueryResource {
         @Context final HttpServletRequest servletReq, final String query
     ) {
         final HttpContext httpContext = CoreHttpContextFactory.create(servletReq);
-        final QueryContext queryContext = QueryContext.empty();
-        queryLogger.logHttpQueryText(queryContext, query, httpContext);
+        final QueryContext queryContext = QueryContext.create(Optional.empty(), httpContext);
+        queryLogger.logHttpQueryText(queryContext, query);
 
         final Query q = this.query.newQueryFromString(query).build();
 
@@ -102,8 +102,9 @@ public class QueryResource {
         @Context final HttpServletRequest servletReq, final QueryMetrics query
     ) {
         final HttpContext httpContext = CoreHttpContextFactory.create(servletReq);
-        final QueryContext queryContext = QueryContext.create(query.getClientContext());
-        queryLogger.logHttpQueryJson(queryContext, query, httpContext);
+        final QueryContext queryContext =
+            QueryContext.create(query.getClientContext(), httpContext);
+        queryLogger.logHttpQueryJson(queryContext, query);
 
         final Query q = query.toQueryBuilder(this.query::newQueryFromString).build();
 
@@ -134,8 +135,9 @@ public class QueryResource {
                     .rangeIfAbsent(query.getRange())
                     .build();
 
-                final QueryContext queryContext = QueryContext.create(qm.getClientContext());
-                queryLogger.logHttpQueryJson(queryContext, qm, httpContext);
+                final QueryContext queryContext =
+                    QueryContext.create(qm.getClientContext(), httpContext);
+                queryLogger.logHttpQueryJson(queryContext, qm);
 
                 futures.add(g
                     .query(q, queryContext)

--- a/heroic-core/src/main/java/com/spotify/heroic/querylogging/noop/NoopQueryLogger.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/querylogging/noop/NoopQueryLogger.java
@@ -36,13 +36,13 @@ import lombok.extern.slf4j.Slf4j;
 public class NoopQueryLogger implements QueryLogger {
     @Override
     public void logHttpQueryText(
-        final QueryContext context, final String query, final HttpContext httpContext
+        final QueryContext context, final String query
     ) {
     }
 
     @Override
     public void logHttpQueryJson(
-        final QueryContext context, final QueryMetrics query, final HttpContext httpContext
+        final QueryContext context, final QueryMetrics query
     ) {
     }
 

--- a/heroic-core/src/test/java/com/spotify/heroic/querylogging/Slf4jQueryLoggerTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/querylogging/Slf4jQueryLoggerTest.java
@@ -59,16 +59,14 @@ public class Slf4jQueryLoggerTest {
 
     @Test
     public void testHttpTextQuery() {
-        final HttpContext httpContext = mock(HttpContext.class);
-        slf4jQueryLogger.logHttpQueryText(queryContext, "", httpContext);
+        slf4jQueryLogger.logHttpQueryText(queryContext, "");
         verify(logger, times(1)).accept(any(String.class));
     }
 
     @Test
     public void testHttpJsonQuery() {
-        final HttpContext httpContext = mock(HttpContext.class);
         final QueryMetrics queryMetrics = mock(QueryMetrics.class);
-        slf4jQueryLogger.logHttpQueryJson(queryContext, queryMetrics, httpContext);
+        slf4jQueryLogger.logHttpQueryJson(queryContext, queryMetrics);
         verify(logger, times(1)).accept(any(String.class));
     }
 

--- a/tools/querylog_mappings.yaml
+++ b/tools/querylog_mappings.yaml
@@ -88,22 +88,17 @@ _common:
   clientContext:
     type: object
     dynamic: true
+  httpContext: *http_context
 
 "http-query-text":
   properties:
-    # com.spotify.heroic.querylogging.Slf4jQueryLogger.HttpQueryData
-    data:
-      properties:
-        httpContext: *http_context
-        query: *raw_string
+    # String
+    data: *raw_string
 
 "http-query-json":
   properties:
-    # com.spotify.heroic.querylogging.Slf4jQueryLogger.HttpQueryData
-    data:
-      properties:
-        httpContext: *http_context
-        query: *raw_object
+    # com.spotify.heroic.metric.QueryMetrics
+    data: *raw_object
 
 "query":
   properties:


### PR DESCRIPTION
httpContext contains information about the http connection from where the query
originated from. It was previously only logged for the 'http-query-*' query
types. It's now added to all types so that the information is always available
for filtering in kibana.