### PR TITLE
[heroic] Transactional Kafka consumer

### DIFF
--- a/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/Connection.java
+++ b/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/Connection.java
@@ -21,13 +21,101 @@
 
 package com.spotify.heroic.consumer.kafka;
 
+import com.spotify.heroic.statistics.ConsumerReporter;
+import com.spotify.heroic.statistics.HeroicTimer;
+import eu.toolchain.async.AsyncFramework;
+import eu.toolchain.async.AsyncFuture;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import kafka.javaapi.consumer.ConsumerConnector;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 
-import java.util.List;
-
+@Slf4j
 @Data
-public class Connection {
+public class Connection implements ConsumerThreadCoordinator {
+    private final AsyncFramework async;
+    private final ConsumerReporter reporter;
+
     private final ConsumerConnector connector;
     private final List<ConsumerThread> threads;
+
+    private final AtomicReference<Boolean> pleaseCommitConsumerOffsets = new AtomicReference<>();
+
+    private HeroicTimer.Context wholeOperationTimer;
+    private HeroicTimer.Context writeCompletionTimer;
+
+    public AsyncFuture<Void> pause() {
+        final List<AsyncFuture<Void>> perThread = new ArrayList<>();
+        for (final ConsumerThread t : threads) {
+            perThread.add(t.pauseConsumption());
+        }
+        return async.collectAndDiscard(perThread);
+    }
+
+    public AsyncFuture<Void> resume() {
+        final List<AsyncFuture<Void>> perThread = new ArrayList<>();
+        for (final ConsumerThread t : threads) {
+            perThread.add(t.resumeConsumption());
+        }
+        return async.collectAndDiscard(perThread);
+    }
+
+    public void prepareToCommitConsumerOffsets() {
+        synchronized (pleaseCommitConsumerOffsets) {
+            log.info("Consumer offsets commit: Preparing");
+            wholeOperationTimer = reporter.reportConsumerCommitOperation();
+            writeCompletionTimer = reporter.reportConsumerCommitPhase1();
+            pleaseCommitConsumerOffsets.set(true);
+            pause();
+        }
+    }
+
+    public boolean isPreparingToCommitConsumerOffsets() {
+        return !(pleaseCommitConsumerOffsets.get() == null ||
+            !pleaseCommitConsumerOffsets.get().booleanValue());
+    }
+
+    public void commitConsumerOffsets() {
+        if (pleaseCommitConsumerOffsets.get() == null) {
+            return;
+        }
+        // Verify that all threads have 0 outstanding consumption requests
+        for (final ConsumerThread t : threads) {
+            if (t.getNumOutstandingRequests() > 0) {
+                return;
+            }
+        }
+
+        synchronized (pleaseCommitConsumerOffsets) {
+            final Boolean valueRef = pleaseCommitConsumerOffsets.get();
+            if (valueRef == null || !valueRef.booleanValue()) {
+                // pleaseCommitConsumerOffsets changed value while we tried to take the lock
+                return;
+            }
+
+            writeCompletionTimer.stop();
+            writeCompletionTimer = null;
+            log.info("Consumer offsets commit: All writes complete");
+
+            /* 1) We've asked threads to pause. The ones that are relevant (actively processing
+             * work) will at this point be paused.
+             * 2) There's no more outstanding writes
+             * == This is a good time to commit offsets. */
+
+            final HeroicTimer.Context offsetsCommitTimer = reporter.reportConsumerCommitPhase2();
+
+            // Commit
+            connector.commitOffsets();
+
+            offsetsCommitTimer.stop();
+            log.info("Consumer offsets commit: Done committing");
+
+            resume();
+            pleaseCommitConsumerOffsets.set(null);
+            wholeOperationTimer.stop();
+            wholeOperationTimer = null;
+        }
+    }
 }

--- a/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/ConsumerThread.java
+++ b/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/ConsumerThread.java
@@ -24,23 +24,28 @@ package com.spotify.heroic.consumer.kafka;
 import com.spotify.heroic.consumer.ConsumerSchema;
 import com.spotify.heroic.consumer.ConsumerSchemaValidationException;
 import com.spotify.heroic.statistics.ConsumerReporter;
+import com.spotify.heroic.statistics.FutureReporter;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.ResolvableFuture;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
+import kafka.consumer.ConsumerTimeoutException;
 import kafka.consumer.KafkaStream;
 import kafka.message.MessageAndMetadata;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public final class ConsumerThread extends Thread {
-    private static final long INITIAL_SLEEP = 5;
-    private static final long MAX_SLEEP = 40;
+    private static final long RETRY_INITIAL_SLEEP = 5;
+    private static final long RETRY_MAX_SLEEP = 40;
 
     private final AsyncFramework async;
     private final String name;
@@ -50,6 +55,7 @@ public final class ConsumerThread extends Thread {
     private final AtomicInteger active;
     private final AtomicLong errors;
     private final LongAdder consumed;
+    private long threadLocalSequenceNumber = 0;
     // use a latch as a signal so that we can block on it instead of Thread#sleep (or similar) which
     // would be a pain to
     // interrupt.
@@ -59,10 +65,24 @@ public final class ConsumerThread extends Thread {
 
     private volatile AtomicReference<CountDownLatch> shouldPause = new AtomicReference<>();
 
+    private final boolean enablePeriodicCommit;
+
+    private final Map<Long, Boolean> outstandingConsumptionRequests;
+    private final long periodicCommitInterval;
+    // Timestamp specifying when the next consumer commit should happen
+    private final AtomicLong nextOffsetsCommitTSGlobal;
+    // Thread-local copy of the above timestamp
+    private long nextOffsetsCommitTSThreadLocal;
+
+    @Setter
+    private ConsumerThreadCoordinator coordinator;
+
     public ConsumerThread(
         final AsyncFramework async, final String name, final ConsumerReporter reporter,
         final KafkaStream<byte[], byte[]> stream, final ConsumerSchema.Consumer schema,
-        final AtomicInteger active, final AtomicLong errors, final LongAdder consumed
+        final AtomicInteger active, final AtomicLong errors, final LongAdder consumed,
+        final boolean enablePeriodicCommit, final long periodicCommitInterval,
+        final AtomicLong nextOffsetsCommitTSGlobal
     ) {
         super(String.format("%s: %s", ConsumerThread.class.getCanonicalName(), name));
 
@@ -74,6 +94,13 @@ public final class ConsumerThread extends Thread {
         this.active = active;
         this.errors = errors;
         this.consumed = consumed;
+        this.enablePeriodicCommit = enablePeriodicCommit;
+        this.outstandingConsumptionRequests = new ConcurrentHashMap<Long, Boolean>();
+
+        this.periodicCommitInterval = periodicCommitInterval;
+        this.nextOffsetsCommitTSGlobal = nextOffsetsCommitTSGlobal;
+        this.nextOffsetsCommitTSThreadLocal = this.nextOffsetsCommitTSGlobal.get();
+        this.coordinator = null;
 
         this.hasStopped = async.future();
     }
@@ -133,6 +160,10 @@ public final class ConsumerThread extends Thread {
         return this.shouldPause.get() != null;
     }
 
+    public long getNumOutstandingRequests() {
+        return outstandingConsumptionRequests.size();
+    }
+
     public AsyncFuture<Void> shutdown() {
         shouldStop.countDown();
 
@@ -146,15 +177,33 @@ public final class ConsumerThread extends Thread {
     }
 
     private void guardedRun() throws Exception {
-        for (final MessageAndMetadata<byte[], byte[]> m : stream) {
-            parkPaused();
+        while (true) {
+            try {
+                for (final MessageAndMetadata<byte[], byte[]> m : stream) {
+                    if (shouldStop.getCount() == 0) {
+                        break;
+                    }
 
-            if (shouldStop.getCount() == 0) {
+                    final byte[] body = m.message();
+                    consumeOneWithRetry(body);
+
+                    parkPaused();
+                    if (shouldStop.getCount() == 0) {
+                        break;
+                    }
+                }
                 break;
+            } catch (ConsumerTimeoutException cte) {
+                log.info("ConsumerTimeoutException while waiting for data from Kafka. Will retry.");
+                if (shouldStop.getCount() == 0) {
+                    break;
+                }
+                parkPaused();
+                if (shouldStop.getCount() == 0) {
+                    break;
+                }
+                continue;
             }
-
-            final byte[] body = m.message();
-            consumeOneWithRetry(body);
         }
     }
 
@@ -167,8 +216,8 @@ public final class ConsumerThread extends Thread {
 
         log.info("Pausing");
 
-        /* block on stop signal while shouldPause, re-check since multiple calls to {#link #pause()}
-         * might swap it */
+        /* block on stop signal while shouldPause, re-check since multiple calls to
+         * {#link #pauseConsumption()} might swap it */
         while (p != null && shouldStop.getCount() > 0) {
             p.await();
             p = shouldPause.get();
@@ -178,14 +227,14 @@ public final class ConsumerThread extends Thread {
     }
 
     private void consumeOneWithRetry(final byte[] body) throws InterruptedException {
-        long sleep = INITIAL_SLEEP;
+        long sleep = RETRY_INITIAL_SLEEP;
 
         while (shouldStop.getCount() > 0) {
             final boolean retry = consumeOne(body);
 
             if (retry) {
                 handleRetry(sleep);
-                sleep = Math.min(sleep * 2, MAX_SLEEP);
+                sleep = Math.min(sleep * 2, RETRY_MAX_SLEEP);
                 continue;
             }
 
@@ -195,9 +244,37 @@ public final class ConsumerThread extends Thread {
 
     private boolean consumeOne(final byte[] body) {
         try {
-            schema.consume(body);
+            /* We have read something. This is a good time to check if we should prepare to commit.
+             * Why is it a good time? Because if we pause now, then send off one more consumption
+             * request, then we know that there will be _at least one_ write being finished sometime
+             * soon so we can use onFinished() to do the commit. */
+            maybePrepareToCommitConsumerOffsets();
+
+            final FutureReporter.Context consumptionContext = reporter.reportConsumption();
+
+            // Actually consume
+            final AsyncFuture<Void> future = schema.consume(body);
+
+            if (enablePeriodicCommit) {
+                final Long sequenceNumber = ++threadLocalSequenceNumber;
+
+                outstandingConsumptionRequests.put(sequenceNumber, true);
+
+                future.onFinished(() -> {
+                    outstandingConsumptionRequests.remove(sequenceNumber);
+
+                    if (outstandingConsumptionRequests.size() == 0) {
+                        // If applicable, commit consumer offsets
+                        coordinator.commitConsumerOffsets();
+                    }
+                });
+            }
+
+            future.onDone(consumptionContext);
+
             reporter.reportMessageSize(body.length);
             consumed.increment();
+
             return false;
         } catch (final ConsumerSchemaValidationException e) {
             /* these messages should be ignored */
@@ -211,7 +288,45 @@ public final class ConsumerThread extends Thread {
         }
     }
 
-    private void handleRetry(long sleep) throws InterruptedException {
+    /* There's a timestamp, nextOffsetsCommitTSGlobal, saying when we should commit consumer offsets
+     * the next time. This method looks at a thread local cached copy of that timestamp, to make
+     * this check as fast as possible. When the cached copy says that we should commit, we check the
+     * actual nextOffsetsCommitTSGlobal to see if the value has changed (if some other thread has
+     * already done a commit).
+     */
+    private boolean maybePrepareToCommitConsumerOffsets() {
+        if (!enablePeriodicCommit) {
+            return false;
+        }
+
+        final Long currTS = java.lang.System.currentTimeMillis();
+        if (nextOffsetsCommitTSThreadLocal > currTS) {
+            return false;
+        }
+        /* Thread local cached copy of nextOffsetsCommitTSGlobal says that it's time. Double check
+         * with the actual nextOffsetsCommitTSGlobal. */
+
+        synchronized (nextOffsetsCommitTSGlobal) {
+            // We now have exclusive access to nextOffsetsCommitTSGlobal
+            final Long nextOffsetsCommitTSGlobalValue = nextOffsetsCommitTSGlobal.get();
+            nextOffsetsCommitTSThreadLocal = nextOffsetsCommitTSGlobalValue;
+
+            if (nextOffsetsCommitTSGlobalValue > currTS) {
+                return false;
+            }
+
+            final Long nextTS = currTS + periodicCommitInterval;
+            nextOffsetsCommitTSGlobal.set(nextTS);
+            nextOffsetsCommitTSThreadLocal = nextTS;
+
+            /* This will ask all threads to pause and will set us up for committing when all writes
+             * are done. */
+            coordinator.prepareToCommitConsumerOffsets();
+            return true;
+        }
+    }
+
+    private void handleRetry(final long sleep) throws InterruptedException {
         log.info("{}: Retrying in {} second(s)", name, sleep);
 
         /* decrementing the number of active active consumers indicates an error to the consumer

--- a/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/ConsumerThreadCoordinator.java
+++ b/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/ConsumerThreadCoordinator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Spotify AB.
+ * Copyright (c) 2017 Spotify AB.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,28 +19,12 @@
  * under the License.
  */
 
-package com.spotify.heroic.statistics;
+package com.spotify.heroic.consumer.kafka;
 
-public interface ConsumerReporter {
-    void reportMessageSize(int size);
+public interface ConsumerThreadCoordinator {
+    void prepareToCommitConsumerOffsets();
 
-    void reportMessageError();
+    boolean isPreparingToCommitConsumerOffsets();
 
-    void reportConsumerSchemaError();
-
-    void reportConsumerThreadsWanted(final long count);
-
-    void reportConsumerThreadsIncrement();
-
-    void reportConsumerThreadsDecrement();
-
-    void reportMessageDrift(final long ms);
-
-    FutureReporter.Context reportConsumption();
-
-    HeroicTimer.Context reportConsumerCommitOperation();
-
-    HeroicTimer.Context reportConsumerCommitPhase1();
-
-    HeroicTimer.Context reportConsumerCommitPhase2();
+    void commitConsumerOffsets();
 }

--- a/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/KafkaConsumer.java
+++ b/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/KafkaConsumer.java
@@ -117,8 +117,7 @@ public class KafkaConsumer implements Consumer, LifeCycles {
         try {
             final Connection c = b.get();
             final int threads = c.getThreads().size();
-            final int paused =
-                c.getThreads().stream().mapToInt(t -> t.isPausing() ? 1 : 0).sum();
+            final int paused = c.getThreads().stream().mapToInt(t -> t.isPausing() ? 1 : 0).sum();
             return String.format(
                 "KafkaConsumer(configured, topics=%s, config=%s, threads=%d, " + "paused=%d)",
                 topics, config, threads, paused);

--- a/heroic-component/src/main/java/com/spotify/heroic/consumer/ConsumerSchema.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/consumer/ConsumerSchema.java
@@ -27,13 +27,14 @@ import com.spotify.heroic.lifecycle.LifeCycle;
 import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
+import eu.toolchain.async.AsyncFuture;
 import lombok.RequiredArgsConstructor;
 
 public interface ConsumerSchema {
     Exposed setup(Depends depends);
 
     interface Consumer {
-        void consume(byte[] message) throws ConsumerSchemaException;
+        AsyncFuture<Void> consume(byte[] message) throws ConsumerSchemaException;
     }
 
     @ConsumerSchemaScope

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopConsumerReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopConsumerReporter.java
@@ -22,6 +22,8 @@
 package com.spotify.heroic.statistics.noop;
 
 import com.spotify.heroic.statistics.ConsumerReporter;
+import com.spotify.heroic.statistics.FutureReporter;
+import com.spotify.heroic.statistics.HeroicTimer;
 
 public class NoopConsumerReporter implements ConsumerReporter {
     private NoopConsumerReporter() {
@@ -55,9 +57,42 @@ public class NoopConsumerReporter implements ConsumerReporter {
     public void reportMessageDrift(final long ms) {
     }
 
+    @Override
+    public FutureReporter.Context reportConsumption() {
+        return NoopFutureReporterContext.get();
+    }
+
+    @Override
+    public HeroicTimer.Context reportConsumerCommitOperation() {
+        return new NoopTimerContext();
+    }
+
+    @Override
+    public HeroicTimer.Context reportConsumerCommitPhase1() {
+        return new NoopTimerContext();
+    }
+
+    @Override
+    public HeroicTimer.Context reportConsumerCommitPhase2() {
+        return new NoopTimerContext();
+    }
+
     private static final NoopConsumerReporter instance = new NoopConsumerReporter();
 
     public static NoopConsumerReporter get() {
         return instance;
+    }
+
+    public class NoopTimerContext implements HeroicTimer.Context {
+
+        @Override
+        public long stop() {
+            return 0;
+        }
+
+        @Override
+        public void finished() throws Exception {
+            stop();
+        }
     }
 }

--- a/heroic-core/src/main/java/com/spotify/heroic/ingestion/CoreIngestionGroup.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/ingestion/CoreIngestionGroup.java
@@ -37,8 +37,6 @@ import com.spotify.heroic.suggest.SuggestBackend;
 import com.spotify.heroic.suggest.WriteSuggest;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.RequiredArgsConstructor;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -46,6 +44,7 @@ import java.util.Optional;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class CoreIngestionGroup implements IngestionGroup {

--- a/heroic-core/src/test/java/com/spotify/heroic/ingestion/CoreIngestionGroupTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/ingestion/CoreIngestionGroupTest.java
@@ -10,6 +10,7 @@ import com.spotify.heroic.statistics.IngestionManagerReporter;
 import com.spotify.heroic.suggest.SuggestBackend;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
+import eu.toolchain.async.FutureDone;
 import eu.toolchain.async.FutureFinished;
 import org.junit.Before;
 import org.junit.Test;
@@ -81,6 +82,10 @@ public class CoreIngestionGroupTest {
             ((FutureFinished) invocation.getArguments()[0]).finished();
             return expected;
         }).when(expected).onFinished(any(FutureFinished.class));
+
+        doAnswer(invocation -> {
+            return expected;
+        }).when(expected).onDone(any(FutureDone.class));
 
         doReturn(other).when(other).onFinished(any(FutureFinished.class));
 

--- a/heroic-dist/src/test/java/com/spotify/heroic/HeroicConfigurationTest.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/HeroicConfigurationTest.java
@@ -1,16 +1,15 @@
 package com.spotify.heroic;
 
+import static org.junit.Assert.assertEquals;
+
 import com.google.common.collect.ImmutableList;
 import com.spotify.heroic.lifecycle.CoreLifeCycleRegistry;
 import com.spotify.heroic.lifecycle.LifeCycleNamedHook;
-import org.junit.Test;
-
 import java.io.InputStream;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class HeroicConfigurationTest {
     @Test
@@ -24,6 +23,7 @@ public class HeroicConfigurationTest {
         final List<String> referenceStarters = ImmutableList.of(
             "com.spotify.heroic.analytics.bigtable.BigtableMetricAnalytics",
             "com.spotify.heroic.cluster.CoreClusterManager",
+            "com.spotify.heroic.consumer.kafka.KafkaConsumer",
             "com.spotify.heroic.http.HttpServer",
             "com.spotify.heroic.metadata.elasticsearch.MetadataBackendKV",
             "com.spotify.heroic.metric.bigtable.BigtableBackend",
@@ -38,6 +38,7 @@ public class HeroicConfigurationTest {
         final List<String> referenceStoppers = ImmutableList.of(
             "com.spotify.heroic.analytics.bigtable.BigtableMetricAnalytics",
             "com.spotify.heroic.cluster.CoreClusterManager",
+            "com.spotify.heroic.consumer.kafka.KafkaConsumer",
             "com.spotify.heroic.http.HttpServer",
             "com.spotify.heroic.metadata.elasticsearch.MetadataBackendKV",
             "com.spotify.heroic.metric.bigtable.BigtableBackend",
@@ -119,6 +120,17 @@ public class HeroicConfigurationTest {
     @Test
     public void testQueryLoggingConfiguration() throws Exception {
         final HeroicCoreInstance instance = testConfiguration("heroic-query-logging.yml");
+    }
+
+    @Test
+    public void testKafkaConfiguration() throws Exception {
+        final HeroicCoreInstance instance = testConfiguration("heroic-kafka.yml");
+        instance.inject(coreComponent -> {
+            assertEquals(coreComponent.consumers().size(), 1);
+            assertEquals(coreComponent.consumers().iterator().next().getClass(),
+                com.spotify.heroic.consumer.kafka.KafkaConsumer.class);
+            return null;
+        });
     }
 
     private HeroicCoreInstance testConfiguration(final String name) throws Exception {

--- a/heroic-dist/src/test/resources/heroic-all.yml
+++ b/heroic-dist/src/test/resources/heroic-all.yml
@@ -31,3 +31,9 @@ generator:
     type: random
   metrics:
     - type: sine
+
+consumers:
+  - type: kafka
+    schema: com.spotify.heroic.consumer.schemas.Spotify100
+    topics:
+      - testtopic1

--- a/heroic-dist/src/test/resources/heroic-kafka.yml
+++ b/heroic-dist/src/test/resources/heroic-kafka.yml
@@ -1,0 +1,10 @@
+consumers:
+  - type: kafka
+    schema: com.spotify.heroic.consumer.schemas.Spotify100
+    transactional: true
+    topics:
+      - testtopic1
+
+metrics:
+  backends:
+    - type: memory

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticConsumerReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticConsumerReporter.java
@@ -24,6 +24,8 @@ package com.spotify.heroic.statistics.semantic;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.spotify.heroic.statistics.ConsumerReporter;
+import com.spotify.heroic.statistics.FutureReporter;
+import com.spotify.heroic.statistics.HeroicTimer;
 import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricRegistry;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +45,11 @@ public class SemanticConsumerReporter implements ConsumerReporter {
     private final SemanticRatioGauge consumerThreadsLiveRatio;
     private final Histogram messageSize;
     private final Histogram messageDrift;
+    private final SemanticFutureReporter consumer;
+
+    private final SemanticHeroicTimerGauge consumerCommitWholeOperationTimer;
+    private final SemanticHeroicTimerGauge consumerCommitPhase1Timer;
+    private final SemanticHeroicTimerGauge consumerCommitPhase2Timer;
 
     public SemanticConsumerReporter(SemanticMetricRegistry registry, String id) {
         this.registry = registry;
@@ -59,6 +66,19 @@ public class SemanticConsumerReporter implements ConsumerReporter {
         messageSize = registry.histogram(base.tagged("what", "message-size", "unit", Units.BYTE));
         messageDrift =
             registry.histogram(base.tagged("what", "message-drift", "unit", Units.MILLISECOND));
+
+        consumer = new SemanticFutureReporter(registry,
+            base.tagged("what", "consumer", "unit", Units.WRITE));
+
+        consumerCommitWholeOperationTimer =
+            registry.register(base.tagged("what", "consumer-commit-latency"),
+                new SemanticHeroicTimerGauge());
+        consumerCommitPhase1Timer =
+            registry.register(base.tagged("what", "consumer-commit-phase1-latency"),
+                new SemanticHeroicTimerGauge());
+        consumerCommitPhase2Timer =
+            registry.register(base.tagged("what", "consumer-commit-phase2-latency"),
+                new SemanticHeroicTimerGauge());
     }
 
     @Override
@@ -95,5 +115,25 @@ public class SemanticConsumerReporter implements ConsumerReporter {
     @Override
     public void reportMessageDrift(final long ms) {
         messageDrift.update(ms);
+    }
+
+    @Override
+    public FutureReporter.Context reportConsumption() {
+        return consumer.setup();
+    }
+
+    @Override
+    public HeroicTimer.Context reportConsumerCommitOperation() {
+        return consumerCommitWholeOperationTimer.time();
+    }
+
+    @Override
+    public HeroicTimer.Context reportConsumerCommitPhase1() {
+        return consumerCommitPhase1Timer.time();
+    }
+
+    @Override
+    public HeroicTimer.Context reportConsumerCommitPhase2() {
+        return consumerCommitPhase2Timer.time();
     }
 }

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticHeroicTimerGauge.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticHeroicTimerGauge.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.statistics.semantic;
+
+import com.codahale.metrics.Gauge;
+import com.google.common.base.Stopwatch;
+import com.spotify.heroic.statistics.HeroicTimer;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString(of = {})
+@RequiredArgsConstructor
+public class SemanticHeroicTimerGauge implements HeroicTimer, Gauge<Long> {
+
+    private final AtomicLong value = new AtomicLong(0);
+
+    @Override
+    public Context time() {
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        return new Context() {
+            @Override
+            public long stop() {
+                final long elapsed = stopwatch.elapsed(TimeUnit.NANOSECONDS);
+                value.set(elapsed);
+                return elapsed;
+            }
+
+            @Override
+            public void finished() throws Exception {
+                stop();
+            }
+        };
+    }
+
+    @Override
+    public Long getValue() {
+        return value.get();
+    }
+}

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SimpleGauge.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SimpleGauge.java
@@ -19,28 +19,25 @@
  * under the License.
  */
 
-package com.spotify.heroic.statistics;
+package com.spotify.heroic.statistics.semantic;
 
-public interface ConsumerReporter {
-    void reportMessageSize(int size);
+import com.codahale.metrics.Gauge;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
-    void reportMessageError();
+@ToString(of = {})
+@RequiredArgsConstructor
+public class SimpleGauge implements Gauge<Long> {
 
-    void reportConsumerSchemaError();
+    private final AtomicLong value = new AtomicLong(0);
 
-    void reportConsumerThreadsWanted(final long count);
+    public void setValue(final long value) {
+        this.value.set(value);
+    }
 
-    void reportConsumerThreadsIncrement();
-
-    void reportConsumerThreadsDecrement();
-
-    void reportMessageDrift(final long ms);
-
-    FutureReporter.Context reportConsumption();
-
-    HeroicTimer.Context reportConsumerCommitOperation();
-
-    HeroicTimer.Context reportConsumerCommitPhase1();
-
-    HeroicTimer.Context reportConsumerCommitPhase2();
+    @Override
+    public Long getValue() {
+        return value.get();
+    }
 }


### PR DESCRIPTION
Ensure safe Kafka consumption by disabling Kafka auto-commit and instead
explicitly commiting for data that we know has been completely written
to backend.

More specifically, we periodically pause consumption, wait for all
outstanding backend write requests to complete, then commit Kafka
offsets.