### PR TITLE
[Metadata] Pick the correct indexes

### DIFF
--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/AbstractElasticsearchMetadataBackend.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/AbstractElasticsearchMetadataBackend.java
@@ -187,7 +187,7 @@ public abstract class AbstractElasticsearchMetadataBackend extends AbstractElast
             try {
                 builder = c
                     .get()
-                    .search(request.getRange(), type)
+                    .search(type)
                     .setSize(ENTRIES_SCAN_SIZE)
                     .setScroll(ENTRIES_TIMEOUT)
                     .setSearchType(SearchType.SCAN)

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/Connection.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/Connection.java
@@ -112,25 +112,25 @@ public class Connection {
     }
 
     public String[] readIndices(DateRange range) throws NoIndexSelectedException {
-        return index.readIndices(range);
+        return index.readIndices();
     }
 
     public String[] writeIndices(DateRange range) throws NoIndexSelectedException {
-        return index.writeIndices(range);
+        return index.writeIndices();
     }
 
     public SearchRequestBuilder search(DateRange range, String type)
         throws NoIndexSelectedException {
-        return index.search(client, range, type);
+        return index.search(client, type);
     }
 
     public CountRequestBuilder count(DateRange range, String type) throws NoIndexSelectedException {
-        return index.count(client, range, type);
+        return index.count(client, type);
     }
 
     public DeleteByQueryRequestBuilder deleteByQuery(DateRange range, String type)
         throws NoIndexSelectedException {
-        return index.deleteByQuery(client, range, type);
+        return index.deleteByQuery(client, type);
     }
 
     public IndexRequestBuilder index(String index, String type) {

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/Connection.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/Connection.java
@@ -21,7 +21,6 @@
 
 package com.spotify.heroic.elasticsearch;
 
-import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.elasticsearch.index.IndexMapping;
 import com.spotify.heroic.elasticsearch.index.NoIndexSelectedException;
 import eu.toolchain.async.AsyncFramework;
@@ -111,24 +110,24 @@ public class Connection {
         return future;
     }
 
-    public String[] readIndices(DateRange range) throws NoIndexSelectedException {
+    public String[] readIndices() throws NoIndexSelectedException {
         return index.readIndices();
     }
 
-    public String[] writeIndices(DateRange range) throws NoIndexSelectedException {
+    public String[] writeIndices() throws NoIndexSelectedException {
         return index.writeIndices();
     }
 
-    public SearchRequestBuilder search(DateRange range, String type)
+    public SearchRequestBuilder search(String type)
         throws NoIndexSelectedException {
         return index.search(client, type);
     }
 
-    public CountRequestBuilder count(DateRange range, String type) throws NoIndexSelectedException {
+    public CountRequestBuilder count(String type) throws NoIndexSelectedException {
         return index.count(client, type);
     }
 
-    public DeleteByQueryRequestBuilder deleteByQuery(DateRange range, String type)
+    public DeleteByQueryRequestBuilder deleteByQuery(String type)
         throws NoIndexSelectedException {
         return index.deleteByQuery(client, type);
     }

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/IndexMapping.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/IndexMapping.java
@@ -23,7 +23,6 @@ package com.spotify.heroic.elasticsearch.index;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.spotify.heroic.common.DateRange;
 import org.elasticsearch.action.count.CountRequestBuilder;
 import org.elasticsearch.action.deletebyquery.DeleteByQueryRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
@@ -37,16 +36,16 @@ import org.elasticsearch.client.Client;
 public interface IndexMapping {
     String template();
 
-    String[] readIndices(DateRange range) throws NoIndexSelectedException;
+    String[] readIndices() throws NoIndexSelectedException;
 
-    String[] writeIndices(DateRange range) throws NoIndexSelectedException;
+    String[] writeIndices() throws NoIndexSelectedException;
 
-    SearchRequestBuilder search(Client client, DateRange range, String type)
+    SearchRequestBuilder search(Client client, String type)
         throws NoIndexSelectedException;
 
-    DeleteByQueryRequestBuilder deleteByQuery(Client client, DateRange range, String type)
+    DeleteByQueryRequestBuilder deleteByQuery(Client client, String type)
         throws NoIndexSelectedException;
 
-    CountRequestBuilder count(Client client, DateRange range, String type)
+    CountRequestBuilder count(Client client, String type)
         throws NoIndexSelectedException;
 }

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/RotatingIndexMapping.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/RotatingIndexMapping.java
@@ -24,7 +24,6 @@ package com.spotify.heroic.elasticsearch.index;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
-import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Duration;
 import lombok.ToString;
 import org.elasticsearch.action.count.CountRequestBuilder;
@@ -119,7 +118,7 @@ public class RotatingIndexMapping implements IndexMapping {
     }
 
     @Override
-    public String[] readIndices(DateRange range) throws NoIndexSelectedException {
+    public String[] readIndices() throws NoIndexSelectedException {
         return readIndices(System.currentTimeMillis());
     }
 
@@ -128,31 +127,31 @@ public class RotatingIndexMapping implements IndexMapping {
     }
 
     @Override
-    public String[] writeIndices(DateRange range) {
+    public String[] writeIndices() {
         return writeIndices(System.currentTimeMillis());
     }
 
     @Override
     public DeleteByQueryRequestBuilder deleteByQuery(
-        final Client client, final DateRange range, final String type
+        final Client client, final String type
     ) throws NoIndexSelectedException {
         return client
-            .prepareDeleteByQuery(readIndices(range))
+            .prepareDeleteByQuery(readIndices())
             .setIndicesOptions(options())
             .setTypes(type);
     }
 
     @Override
     public SearchRequestBuilder search(
-        final Client client, final DateRange range, final String type
+        final Client client, final String type
     ) throws NoIndexSelectedException {
-        return client.prepareSearch(readIndices(range)).setIndicesOptions(options()).setTypes(type);
+        return client.prepareSearch(readIndices()).setIndicesOptions(options()).setTypes(type);
     }
 
     @Override
-    public CountRequestBuilder count(final Client client, final DateRange range, final String type)
+    public CountRequestBuilder count(final Client client, final String type)
         throws NoIndexSelectedException {
-        return client.prepareCount(readIndices(range)).setIndicesOptions(options()).setTypes(type);
+        return client.prepareCount(readIndices()).setIndicesOptions(options()).setTypes(type);
     }
 
     private IndicesOptions options() {

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/RotatingIndexMapping.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/RotatingIndexMapping.java
@@ -120,7 +120,7 @@ public class RotatingIndexMapping implements IndexMapping {
 
     @Override
     public String[] readIndices(DateRange range) throws NoIndexSelectedException {
-        return readIndices(range.end());
+        return readIndices(System.currentTimeMillis());
     }
 
     protected String[] writeIndices(long now) {
@@ -129,7 +129,7 @@ public class RotatingIndexMapping implements IndexMapping {
 
     @Override
     public String[] writeIndices(DateRange range) {
-        return writeIndices(range.end());
+        return writeIndices(System.currentTimeMillis());
     }
 
     @Override

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/SingleIndexMapping.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/SingleIndexMapping.java
@@ -23,7 +23,6 @@ package com.spotify.heroic.elasticsearch.index;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.spotify.heroic.common.DateRange;
 import lombok.ToString;
 import org.elasticsearch.action.count.CountRequestBuilder;
 import org.elasticsearch.action.deletebyquery.DeleteByQueryRequestBuilder;
@@ -55,32 +54,28 @@ public class SingleIndexMapping implements IndexMapping {
     }
 
     @Override
-    public String[] readIndices(DateRange range) {
+    public String[] readIndices() {
         return indices;
     }
 
     @Override
-    public String[] writeIndices(DateRange range) {
+    public String[] writeIndices() {
         return indices;
     }
 
     @Override
-    public SearchRequestBuilder search(
-        final Client client, final DateRange range, final String type
-    ) {
+    public SearchRequestBuilder search(final Client client, final String type) {
         return client.prepareSearch(index).setTypes(type);
     }
 
     @Override
-    public CountRequestBuilder count(
-        final Client client, final DateRange range, final String type
-    ) {
+    public CountRequestBuilder count(final Client client, final String type) {
         return client.prepareCount(index).setTypes(type);
     }
 
     @Override
     public DeleteByQueryRequestBuilder deleteByQuery(
-        final Client client, DateRange range, final String type
+        final Client client, final String type
     ) {
         return client.prepareDeleteByQuery(index).setTypes(type);
     }

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
@@ -171,13 +171,12 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
     public AsyncFuture<WriteMetadata> write(final WriteMetadata.Request request) {
         return doto(c -> {
             final Series series = request.getSeries();
-            final DateRange range = request.getRange();
             final String id = series.hash();
 
             final String[] indices;
 
             try {
-                indices = c.writeIndices(range);
+                indices = c.writeIndices();
             } catch (NoIndexSelectedException e) {
                 return async.failed(e);
             }
@@ -225,7 +224,7 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
 
             final FilterBuilder f = filter(filter.getFilter());
 
-            final CountRequestBuilder builder = c.count(filter.getRange(), TYPE_METADATA);
+            final CountRequestBuilder builder = c.count(TYPE_METADATA);
             limit.asInteger().ifPresent(builder::setTerminateAfter);
 
             builder.setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), f));
@@ -273,7 +272,7 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
             final FilterBuilder f = filter(request.getFilter());
 
             final DeleteByQueryRequestBuilder builder =
-                c.deleteByQuery(request.getRange(), TYPE_METADATA);
+                c.deleteByQuery(TYPE_METADATA);
 
             builder.setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), f));
 
@@ -287,7 +286,7 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
             final FilterBuilder f = filter(request.getFilter());
 
             final SearchRequestBuilder builder =
-                c.search(request.getRange(), TYPE_METADATA).setSearchType("count");
+                c.search(TYPE_METADATA).setSearchType("count");
 
             builder.setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), f));
 
@@ -339,7 +338,7 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
 
         return doto(c -> {
             final SearchRequestBuilder builder = c
-                .search(range, TYPE_METADATA)
+                .search(TYPE_METADATA)
                 .setScroll(SCROLL_TIME)
                 .setSearchType(SearchType.SCAN);
 
@@ -361,7 +360,7 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
 
         return observer -> connection.doto(c -> {
             final SearchRequestBuilder builder = c
-                .search(range, TYPE_METADATA)
+                .search(TYPE_METADATA)
                 .setScroll(SCROLL_TIME)
                 .setSearchType(SearchType.SCAN);
 

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendV1.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendV1.java
@@ -188,7 +188,7 @@ public class MetadataBackendV1 extends AbstractElasticsearchMetadataBackend
     public AsyncFuture<FindTags> findTags(final FindTags.Request request) {
         return doto(c -> {
             final Callable<SearchRequestBuilder> setup =
-                () -> c.search(request.getRange(), ElasticsearchUtils.TYPE_METADATA);
+                () -> c.search(ElasticsearchUtils.TYPE_METADATA);
 
             final FindTagKeys.Request findTagKeys =
                 new FindTagKeys.Request(request.getFilter(), request.getRange(),
@@ -203,10 +203,9 @@ public class MetadataBackendV1 extends AbstractElasticsearchMetadataBackend
     public AsyncFuture<WriteMetadata> write(final WriteMetadata.Request request) {
         return doto(c -> {
             final Series series = request.getSeries();
-            final DateRange range = request.getRange();
             final String id = series.hash();
 
-            final String[] indices = c.writeIndices(range);
+            final String[] indices = c.writeIndices();
 
             final List<AsyncFuture<WriteMetadata>> futures = new ArrayList<>();
 
@@ -244,7 +243,7 @@ public class MetadataBackendV1 extends AbstractElasticsearchMetadataBackend
             final FilterBuilder f = CTX.filter(request.getFilter());
 
             final CountRequestBuilder builder =
-                c.count(request.getRange(), ElasticsearchUtils.TYPE_METADATA);
+                c.count(ElasticsearchUtils.TYPE_METADATA);
             limit.asInteger().ifPresent(builder::setTerminateAfter);
 
             builder.setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), f));
@@ -275,7 +274,7 @@ public class MetadataBackendV1 extends AbstractElasticsearchMetadataBackend
             final FilterBuilder f = CTX.filter(request.getFilter());
 
             final DeleteByQueryRequestBuilder builder =
-                c.deleteByQuery(request.getRange(), ElasticsearchUtils.TYPE_METADATA);
+                c.deleteByQuery(ElasticsearchUtils.TYPE_METADATA);
 
             builder.setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), f));
 
@@ -288,7 +287,7 @@ public class MetadataBackendV1 extends AbstractElasticsearchMetadataBackend
             final FilterBuilder f = CTX.filter(filter.getFilter());
 
             final SearchRequestBuilder builder = c
-                .search(filter.getRange(), ElasticsearchUtils.TYPE_METADATA)
+                .search(ElasticsearchUtils.TYPE_METADATA)
                 .setSearchType("count");
 
             builder.setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), f));
@@ -327,7 +326,7 @@ public class MetadataBackendV1 extends AbstractElasticsearchMetadataBackend
             final FilterBuilder f = CTX.filter(request.getFilter());
 
             final SearchRequestBuilder builder = c
-                .search(request.getRange(), ElasticsearchUtils.TYPE_METADATA)
+                .search(ElasticsearchUtils.TYPE_METADATA)
                 .setSearchType("count");
 
             builder.setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), f));
@@ -381,7 +380,7 @@ public class MetadataBackendV1 extends AbstractElasticsearchMetadataBackend
             final FilterBuilder f = CTX.filter(filter);
 
             final SearchRequestBuilder builder = c
-                .search(range, ElasticsearchUtils.TYPE_METADATA)
+                .search(ElasticsearchUtils.TYPE_METADATA)
                 .setScroll(SCROLL_TIME)
                 .setSearchType(SearchType.SCAN);
 

--- a/suggest/elasticsearch/src/main/java/com/spotify/heroic/suggest/elasticsearch/SuggestBackendKV.java
+++ b/suggest/elasticsearch/src/main/java/com/spotify/heroic/suggest/elasticsearch/SuggestBackendKV.java
@@ -25,7 +25,6 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.HashCode;
-import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Grouped;
 import com.spotify.heroic.common.Groups;
 import com.spotify.heroic.common.OptionalLimit;
@@ -218,7 +217,7 @@ public class SuggestBackendKV extends AbstractElasticsearchBackend
                 bool.hasClauses() ? filteredQuery(matchAllQuery(), bool) : matchAllQuery();
 
             final SearchRequestBuilder builder = c
-                .search(request.getRange(), TAG_TYPE)
+                .search(TAG_TYPE)
                 .setSearchType(SearchType.COUNT)
                 .setQuery(query)
                 .setTimeout(TIMEOUT);
@@ -292,7 +291,7 @@ public class SuggestBackendKV extends AbstractElasticsearchBackend
             }
 
             final SearchRequestBuilder builder = c
-                .search(request.getRange(), TAG_TYPE)
+                .search(TAG_TYPE)
                 .setSearchType(SearchType.COUNT)
                 .setQuery(query);
 
@@ -328,7 +327,7 @@ public class SuggestBackendKV extends AbstractElasticsearchBackend
             final QueryBuilder root = filteredQuery(matchAllQuery(), filter(request.getFilter()));
 
             final SearchRequestBuilder builder = c
-                .search(request.getRange(), TAG_TYPE)
+                .search(TAG_TYPE)
                 .setSearchType(SearchType.COUNT)
                 .setQuery(root);
 
@@ -425,7 +424,7 @@ public class SuggestBackendKV extends AbstractElasticsearchBackend
             }
 
             final SearchRequestBuilder builder = c
-                .search(request.getRange(), TAG_TYPE)
+                .search(TAG_TYPE)
                 .setSearchType(SearchType.COUNT)
                 .setQuery(query)
                 .setTimeout(TIMEOUT);
@@ -496,7 +495,7 @@ public class SuggestBackendKV extends AbstractElasticsearchBackend
             }
 
             final SearchRequestBuilder builder = c
-                .search(request.getRange(), SERIES_TYPE)
+                .search(SERIES_TYPE)
                 .setSearchType(SearchType.COUNT)
                 .setQuery(query);
 
@@ -534,12 +533,11 @@ public class SuggestBackendKV extends AbstractElasticsearchBackend
     public AsyncFuture<WriteSuggest> write(final WriteSuggest.Request request) {
         return connection.doto((final Connection c) -> {
             final Series s = request.getSeries();
-            final DateRange range = request.getRange();
 
             final String[] indices;
 
             try {
-                indices = c.writeIndices(range);
+                indices = c.writeIndices();
             } catch (NoIndexSelectedException e) {
                 return async.failed(e);
             }


### PR DESCRIPTION
The first commit fixes a bug, which prevents Heroic from loading historical data, when querying with an absolute range in the past.

The two following commits just cleans up the API.