### PR TITLE
Introduce indirection for accessing the system clock

### DIFF
--- a/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/ConsumerThread.java
+++ b/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/ConsumerThread.java
@@ -25,6 +25,7 @@ import com.spotify.heroic.consumer.ConsumerSchema;
 import com.spotify.heroic.consumer.ConsumerSchemaValidationException;
 import com.spotify.heroic.statistics.ConsumerReporter;
 import com.spotify.heroic.statistics.FutureReporter;
+import com.spotify.heroic.time.Clock;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.ResolvableFuture;
@@ -48,6 +49,7 @@ public final class ConsumerThread extends Thread {
     private static final long RETRY_MAX_SLEEP = 40;
 
     private final AsyncFramework async;
+    private final Clock clock;
     private final String name;
     private final ConsumerReporter reporter;
     private final KafkaStream<byte[], byte[]> stream;
@@ -78,15 +80,16 @@ public final class ConsumerThread extends Thread {
     private ConsumerThreadCoordinator coordinator;
 
     public ConsumerThread(
-        final AsyncFramework async, final String name, final ConsumerReporter reporter,
-        final KafkaStream<byte[], byte[]> stream, final ConsumerSchema.Consumer schema,
-        final AtomicInteger active, final AtomicLong errors, final LongAdder consumed,
-        final boolean enablePeriodicCommit, final long periodicCommitInterval,
-        final AtomicLong nextOffsetsCommitTSGlobal
+        final AsyncFramework async, final Clock clock, final String name,
+        final ConsumerReporter reporter, final KafkaStream<byte[], byte[]> stream,
+        final ConsumerSchema.Consumer schema, final AtomicInteger active, final AtomicLong errors,
+        final LongAdder consumed, final boolean enablePeriodicCommit,
+        final long periodicCommitInterval, final AtomicLong nextOffsetsCommitTSGlobal
     ) {
         super(String.format("%s: %s", ConsumerThread.class.getCanonicalName(), name));
 
         this.async = async;
+        this.clock = clock;
         this.name = name;
         this.reporter = reporter;
         this.stream = stream;
@@ -299,7 +302,8 @@ public final class ConsumerThread extends Thread {
             return false;
         }
 
-        final Long currTS = java.lang.System.currentTimeMillis();
+        final Long currTS = clock.currentTimeMillis();
+
         if (nextOffsetsCommitTSThreadLocal > currTS) {
             return false;
         }

--- a/heroic-component/src/main/java/com/spotify/heroic/common/DateRange.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/DateRange.java
@@ -24,6 +24,7 @@ package com.spotify.heroic.common;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.spotify.heroic.time.Clock;
 import eu.toolchain.serializer.AutoSerialize;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -88,7 +89,7 @@ public class DateRange implements Comparable<DateRange> {
             return this;
         }
 
-        return new DateRange(start - start % interval, end - (end  % interval));
+        return new DateRange(start - start % interval, end - (end % interval));
     }
 
     public boolean overlap(DateRange other) {
@@ -173,7 +174,7 @@ public class DateRange implements Comparable<DateRange> {
         return new DateRange(now, now);
     }
 
-    public static DateRange now() {
-        return now(System.currentTimeMillis());
+    public static DateRange now(Clock clock) {
+        return now(clock.currentTimeMillis());
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/dagger/LoadingComponent.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/dagger/LoadingComponent.java
@@ -32,12 +32,12 @@ import com.spotify.heroic.filter.FilterModifier;
 import com.spotify.heroic.lifecycle.LifeCycle;
 import com.spotify.heroic.lifecycle.LifeCycleRegistry;
 import com.spotify.heroic.scheduler.Scheduler;
+import com.spotify.heroic.time.Clock;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.serializer.Serializer;
 import eu.toolchain.serializer.SerializerFramework;
-
-import javax.inject.Named;
 import java.util.concurrent.ExecutorService;
+import javax.inject.Named;
 
 /**
  * The component responsible for the loading phase of heroic.
@@ -77,4 +77,6 @@ public interface LoadingComponent {
 
     @Named("loading")
     LifeCycle loadingLifeCycle();
+
+    Clock clock();
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/time/Clock.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/time/Clock.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.time;
+
+/**
+ * Interface for accessing the current time.
+ */
+public interface Clock {
+    /**
+     * Get the current time in milliseconds.
+     */
+    long currentTimeMillis();
+
+    /**
+     * Get the system clock.
+     */
+    static Clock system() {
+        return System::currentTimeMillis;
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/cluster/NodeRegistry.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/cluster/NodeRegistry.java
@@ -27,9 +27,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.spotify.heroic.common.OptionalLimit;
 import eu.toolchain.async.AsyncFramework;
-import lombok.Data;
-import org.apache.commons.lang3.tuple.Pair;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -38,10 +35,12 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.Data;
+import org.apache.commons.lang3.tuple.Pair;
 
 @Data
 public class NodeRegistry {
-    private static final Random random = new Random(System.currentTimeMillis());
+    private static final Random random = new Random();
 
     private final AsyncFramework async;
     private final List<ClusterNode> entries;

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100.java
@@ -43,16 +43,16 @@ import com.spotify.heroic.ingestion.IngestionGroup;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.statistics.ConsumerReporter;
+import com.spotify.heroic.time.Clock;
 import dagger.Component;
 import eu.toolchain.async.AsyncFuture;
-import lombok.Data;
-import lombok.ToString;
-
-import javax.inject.Inject;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.inject.Inject;
+import lombok.Data;
+import lombok.ToString;
 
 @ToString
 public class Spotify100 implements ConsumerSchema {
@@ -122,11 +122,13 @@ public class Spotify100 implements ConsumerSchema {
 
     @SchemaScope
     public static class Consumer implements ConsumerSchema.Consumer {
+        private final Clock clock;
         private final IngestionGroup ingestion;
         private final ConsumerReporter reporter;
 
         @Inject
-        public Consumer(IngestionGroup ingestion, ConsumerReporter reporter) {
+        public Consumer(Clock clock, IngestionGroup ingestion, ConsumerReporter reporter) {
+            this.clock = clock;
             this.ingestion = ingestion;
             this.reporter = reporter;
         }
@@ -169,7 +171,7 @@ public class Spotify100 implements ConsumerSchema {
             final Point p = new Point(metric.getTime(), metric.getValue());
             final List<Point> points = ImmutableList.of(p);
 
-            reporter.reportMessageDrift(System.currentTimeMillis() - p.getTimestamp());
+            reporter.reportMessageDrift(clock.currentTimeMillis() - p.getTimestamp());
             AsyncFuture<Ingestion> ingestionFuture =
                 ingestion.write(new Ingestion.Request(series, MetricCollection.points(points)));
 

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/Tasks.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/Tasks.java
@@ -73,16 +73,6 @@ import com.spotify.heroic.shell.task.TestPrint;
 import com.spotify.heroic.shell.task.TestReadFile;
 import com.spotify.heroic.shell.task.Write;
 import com.spotify.heroic.shell.task.WritePerformance;
-import lombok.Getter;
-import org.apache.commons.lang3.StringUtils;
-import org.joda.time.Chronology;
-import org.joda.time.DateTime;
-import org.joda.time.chrono.ISOChronology;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeParser;
-import org.joda.time.format.DateTimeParserBucket;
-import org.kohsuke.args4j.Option;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -95,6 +85,15 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.Chronology;
+import org.joda.time.DateTime;
+import org.joda.time.chrono.ISOChronology;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeParser;
+import org.joda.time.format.DateTimeParserBucket;
+import org.kohsuke.args4j.Option;
 
 public final class Tasks {
     static final List<ShellTaskDefinition> available = new ArrayList<>();

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/Fetch.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/Fetch.java
@@ -40,12 +40,10 @@ import com.spotify.heroic.shell.TaskName;
 import com.spotify.heroic.shell.TaskParameters;
 import com.spotify.heroic.shell.TaskUsage;
 import com.spotify.heroic.shell.Tasks;
+import com.spotify.heroic.time.Clock;
 import dagger.Component;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.ToString;
-import org.kohsuke.args4j.Option;
-
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -54,18 +52,23 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
+import lombok.ToString;
+import org.kohsuke.args4j.Option;
 
 @TaskUsage("Fetch a range of data points")
 @TaskName("fetch")
 public class Fetch implements ShellTask {
+    private final Clock clock;
     private final MetricManager metrics;
     private final ObjectMapper mapper;
     private final AsyncFramework async;
 
     @Inject
     public Fetch(
-        MetricManager metrics, @Named("application/json") ObjectMapper mapper, AsyncFramework async
+        Clock clock, MetricManager metrics, @Named("application/json") ObjectMapper mapper,
+        AsyncFramework async
     ) {
+        this.clock = clock;
         this.metrics = metrics;
         this.mapper = mapper;
         this.async = async;
@@ -79,7 +82,7 @@ public class Fetch implements ShellTask {
     @Override
     public AsyncFuture<Void> run(final ShellIO io, final TaskParameters base) throws Exception {
         final Parameters params = (Parameters) base;
-        final long now = System.currentTimeMillis();
+        final long now = clock.currentTimeMillis();
 
         final Series series = Tasks.parseSeries(mapper, params.series);
 

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/LoadGenerated.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/LoadGenerated.java
@@ -40,23 +40,24 @@ import com.spotify.heroic.shell.ShellTask;
 import com.spotify.heroic.shell.TaskName;
 import com.spotify.heroic.shell.TaskParameters;
 import com.spotify.heroic.shell.TaskUsage;
+import com.spotify.heroic.time.Clock;
 import dagger.Component;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.Getter;
-import lombok.ToString;
-import org.kohsuke.args4j.Option;
-
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import javax.inject.Named;
+import lombok.Getter;
+import lombok.ToString;
+import org.kohsuke.args4j.Option;
 
 @TaskUsage("Load generated metrics into backends")
 @TaskName("load-generated")
 public class LoadGenerated implements ShellTask {
+    private final Clock clock;
     private final AsyncFramework async;
     private final IngestionManager ingestion;
     private final GeneratorManager generator;
@@ -65,9 +66,10 @@ public class LoadGenerated implements ShellTask {
 
     @Inject
     public LoadGenerated(
-        AsyncFramework async, IngestionManager ingestion, GeneratorManager generator,
+        Clock clock, AsyncFramework async, IngestionManager ingestion, GeneratorManager generator,
         MetadataGenerator metadataGenerator, @Named("application/json") ObjectMapper mapper
     ) {
+        this.clock = clock;
         this.async = async;
         this.ingestion = ingestion;
         this.generator = generator;
@@ -95,7 +97,7 @@ public class LoadGenerated implements ShellTask {
         for (final Generator generator : generators) {
             final IngestionGroup group = ingestion.useOptionalGroup(params.group);
 
-            final long now = System.currentTimeMillis();
+            final long now = clock.currentTimeMillis();
             final long start = now - params.duration.toMilliseconds();
 
             final DateRange range = new DateRange(Math.max(start, 0), now);

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/MetadataWrite.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/MetadataWrite.java
@@ -33,28 +33,26 @@ import com.spotify.heroic.shell.ShellTask;
 import com.spotify.heroic.shell.TaskName;
 import com.spotify.heroic.shell.TaskParameters;
 import com.spotify.heroic.shell.TaskUsage;
-
+import com.spotify.heroic.time.Clock;
+import dagger.Component;
 import eu.toolchain.async.AsyncFuture;
-
-import org.kohsuke.args4j.Option;
-
 import javax.inject.Inject;
 import javax.inject.Named;
-
-import dagger.Component;
 import lombok.ToString;
+import org.kohsuke.args4j.Option;
 
 @TaskUsage("Write metadata")
 @TaskName("metadata-write")
 public class MetadataWrite implements ShellTask {
-
+    private final Clock clock;
     private final MetadataManager metadataManager;
     private final ObjectMapper json;
 
     @Inject
     public MetadataWrite(
-        MetadataManager metadataManager, @Named("application/json") ObjectMapper json
+        Clock clock, MetadataManager metadataManager, @Named("application/json") ObjectMapper json
     ) {
+        this.clock = clock;
         this.metadataManager = metadataManager;
         this.json = json;
     }
@@ -72,7 +70,7 @@ public class MetadataWrite implements ShellTask {
 
         return metadataManager
             .useGroup(params.group)
-            .write(new WriteMetadata.Request(series, DateRange.now()))
+            .write(new WriteMetadata.Request(series, DateRange.now(clock)))
             .directTransform(v -> null);
     }
 

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/ParseQuery.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/ParseQuery.java
@@ -34,29 +34,32 @@ import com.spotify.heroic.shell.ShellTask;
 import com.spotify.heroic.shell.TaskName;
 import com.spotify.heroic.shell.TaskParameters;
 import com.spotify.heroic.shell.TaskUsage;
+import com.spotify.heroic.time.Clock;
 import dagger.Component;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import org.kohsuke.args4j.Argument;
-import org.kohsuke.args4j.Option;
-
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.Option;
 
 @TaskUsage("Parse a given expression as a query and print their structure")
 @TaskName("parse-query")
 public class ParseQuery implements ShellTask {
+    private final Clock clock;
     private final QueryParser parser;
     private final AsyncFramework async;
     private final ObjectMapper mapper;
 
     @Inject
     public ParseQuery(
-        QueryParser parser, AsyncFramework async, @Named("application/json") ObjectMapper mapper
+        Clock clock, QueryParser parser, AsyncFramework async,
+        @Named("application/json") ObjectMapper mapper
     ) {
+        this.clock = clock;
         this.parser = parser;
         this.async = async;
         this.mapper = mapper;
@@ -79,7 +82,7 @@ public class ParseQuery implements ShellTask {
         List<Expression> statements = parser.parse(Joiner.on(" ").join(params.query));
 
         if (params.eval) {
-            final Expression.Scope scope = new DefaultScope(System.currentTimeMillis());
+            final Expression.Scope scope = new DefaultScope(clock.currentTimeMillis());
             statements = statements.stream().map(s -> s.eval(scope)).collect(Collectors.toList());
         }
 

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/SuggestPerformance.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/SuggestPerformance.java
@@ -40,18 +40,10 @@ import com.spotify.heroic.suggest.MatchOptions;
 import com.spotify.heroic.suggest.SuggestBackend;
 import com.spotify.heroic.suggest.SuggestManager;
 import com.spotify.heroic.suggest.TagSuggest;
+import com.spotify.heroic.time.Clock;
 import dagger.Component;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.Data;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
-import org.kohsuke.args4j.Option;
-
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
@@ -71,11 +63,20 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.GZIPInputStream;
+import javax.inject.Inject;
+import javax.inject.Named;
+import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.kohsuke.args4j.Option;
 
 @TaskUsage("Execute a set of suggest performance tests")
 @TaskName("suggest-performance")
 @Slf4j
 public class SuggestPerformance implements ShellTask {
+    private final Clock clock;
     private final SuggestManager suggest;
     private final QueryParser parser;
     private final ObjectMapper mapper;
@@ -83,9 +84,10 @@ public class SuggestPerformance implements ShellTask {
 
     @Inject
     public SuggestPerformance(
-        SuggestManager suggest, QueryParser parser, @Named("application/json") ObjectMapper mapper,
-        AsyncFramework async
+        Clock clock, SuggestManager suggest, QueryParser parser,
+        @Named("application/json") ObjectMapper mapper, AsyncFramework async
     ) {
+        this.clock = clock;
         this.suggest = suggest;
         this.parser = parser;
         this.mapper = mapper;
@@ -107,7 +109,7 @@ public class SuggestPerformance implements ShellTask {
 
         final List<Callable<TestResult>> tests = new ArrayList<>();
 
-        final DateRange range = DateRange.now();
+        final DateRange range = DateRange.now(clock);
 
         try (final InputStream input = open(io, params.file)) {
             final TestSuite suite = mapper.readValue(input, TestSuite.class);

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/Write.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/Write.java
@@ -40,20 +40,20 @@ import com.spotify.heroic.shell.TaskName;
 import com.spotify.heroic.shell.TaskParameters;
 import com.spotify.heroic.shell.TaskUsage;
 import com.spotify.heroic.shell.Tasks;
+import com.spotify.heroic.time.Clock;
 import dagger.Component;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.Transform;
-import lombok.ToString;
-import org.kohsuke.args4j.Option;
-
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Named;
+import lombok.ToString;
+import org.kohsuke.args4j.Option;
 
 @TaskUsage("Write a single, or a set of events")
 @TaskName("write")
@@ -62,15 +62,17 @@ public class Write implements ShellTask {
         new TypeReference<Map<String, String>>() {
         };
 
+    private final Clock clock;
     private final IngestionManager ingestion;
     private final AsyncFramework async;
     private final ObjectMapper json;
 
     @Inject
     public Write(
-        IngestionManager ingestion, AsyncFramework async,
+        Clock clock, IngestionManager ingestion, AsyncFramework async,
         @Named("application/json") ObjectMapper json
     ) {
+        this.clock = clock;
         this.ingestion = ingestion;
         this.async = async;
         this.json = json;
@@ -95,7 +97,7 @@ public class Write implements ShellTask {
 
         final IngestionGroup g = ingestion.useGroup(params.group);
 
-        final long now = System.currentTimeMillis();
+        final long now = clock.currentTimeMillis();
 
         final List<Point> points = parsePoints(params.points, now);
         final List<Event> events = parseEvents(params.events, now);

--- a/heroic-core/src/test/java/com/spotify/heroic/CoreQueryManagerTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/CoreQueryManagerTest.java
@@ -15,6 +15,7 @@ import com.spotify.heroic.grammar.QueryParser;
 import com.spotify.heroic.querylogging.QueryLogger;
 import com.spotify.heroic.querylogging.QueryLoggerFactory;
 import com.spotify.heroic.statistics.ApiReporter;
+import com.spotify.heroic.time.Clock;
 import eu.toolchain.async.AsyncFramework;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,9 +51,9 @@ public class CoreQueryManagerTest {
         QueryLoggerFactory queryLoggerFactory = mock(QueryLoggerFactory.class);
         when(queryLoggerFactory.create(any())).thenReturn(queryLogger);
 
-        manager =
-            new CoreQueryManager(Features.empty(), async, cluster, parser, queryCache, aggregations,
-                OptionalLimit.empty(), smallQueryThreshold, apiReporter, queryLoggerFactory);
+        manager = new CoreQueryManager(Features.empty(), async, Clock.system(), cluster, parser,
+            queryCache, aggregations, OptionalLimit.empty(), smallQueryThreshold, apiReporter,
+            queryLoggerFactory);
     }
 
     @Test

--- a/heroic-loading/src/main/java/com/spotify/heroic/dagger/LoadingModule.java
+++ b/heroic-loading/src/main/java/com/spotify/heroic/dagger/LoadingModule.java
@@ -203,6 +203,6 @@ public class LoadingModule {
     @Provides
     @LoadingScope
     Clock clock() {
-        return System::currentTimeMillis;
+        return Clock.system();
     }
 }

--- a/heroic-loading/src/main/java/com/spotify/heroic/dagger/LoadingModule.java
+++ b/heroic-loading/src/main/java/com/spotify/heroic/dagger/LoadingModule.java
@@ -40,6 +40,7 @@ import com.spotify.heroic.lifecycle.LifeCycle;
 import com.spotify.heroic.lifecycle.LifeCycleRegistry;
 import com.spotify.heroic.scheduler.DefaultScheduler;
 import com.spotify.heroic.scheduler.Scheduler;
+import com.spotify.heroic.time.Clock;
 import dagger.Module;
 import dagger.Provides;
 import eu.toolchain.async.AsyncFramework;
@@ -197,5 +198,11 @@ public class LoadingModule {
         if (!terminated) {
             throw new RuntimeException("executor did not shut down in time");
         }
+    }
+
+    @Provides
+    @LoadingScope
+    Clock clock() {
+        return System::currentTimeMillis;
     }
 }


### PR DESCRIPTION
hardcoded `System.currentTimeMillis()` calls (and the like) are hard to test.

This introduces an interface `com.spotify.heroic.time.Clock` that should be dependency injected instead of making use of the static methods.

Most call sites are also fixed in a separate commit, except a few harder ones. 