### PR TITLE
[Aggregation] Make sure that aggregation cadence is not lost in distributed reduction.

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/DistributedAggregationCombiner.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/DistributedAggregationCombiner.java
@@ -33,6 +33,20 @@ import java.util.List;
 public class DistributedAggregationCombiner implements AggregationCombiner {
     private final AggregationInstance reducer;
     private final DateRange range;
+    private final long cadence;
+
+    /**
+     * Create a combiner from a global aggregation.
+     *
+     * Notice that the cadence is taken from the root aggregation, since the reducer might
+     * lose it
+     * @param root
+     * @param range
+     * @return
+     */
+    public static DistributedAggregationCombiner create(final AggregationInstance root, final DateRange range ) {
+        return new DistributedAggregationCombiner(root.reducer(), range, root.cadence());
+    }
 
     @Override
     public List<ShardedResultGroup> combine(
@@ -54,7 +68,7 @@ public class DistributedAggregationCombiner implements AggregationCombiner {
 
         for (final AggregationOutput out : result.getResult()) {
             groups.add(new ShardedResultGroup(ImmutableMap.of(), out.getKey(), out.getSeries(),
-                out.getMetrics(), reducer.cadence()));
+                out.getMetrics(), cadence));
         }
 
         return groups.build();

--- a/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
@@ -245,7 +245,7 @@ public class CoreQueryManager implements QueryManager {
             final AggregationCombiner combiner;
 
             if (isDistributed) {
-                combiner = new DistributedAggregationCombiner(root.reducer(), range);
+                combiner = DistributedAggregationCombiner.create(root, range);
             } else {
                 combiner = AggregationCombiner.DEFAULT;
             }


### PR DESCRIPTION
This patch is attempting to make sure that queries containing a delta aggregation still returns a meaningful cadence.