### PR TITLE
Read limited number of cells in each FlatRow from Bigtable

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/metric/MetricCollection.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/MetricCollection.java
@@ -28,13 +28,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
 import com.spotify.heroic.aggregation.AggregationSession;
 import com.spotify.heroic.common.Series;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -160,28 +158,6 @@ public abstract class MetricCollection {
         final Function<List<? extends Metric>, MetricCollection> adapter =
             checkNotNull(adapters.get(key), "adapter does not exist for type");
         return adapter.apply(metrics);
-    }
-
-    public static MetricCollection mergeSorted(
-        final List<MetricCollection> values
-    ) {
-        if (values.isEmpty()) {
-            return empty();
-        }
-
-        MetricType type = values.iterator().next().getType();
-        values.stream().forEach(mc -> {
-            if (mc.getType() != type) {
-                throw new RuntimeException("Can't mix metric types when merging");
-            }
-        });
-
-        // Flatten
-        final List<Metric> data =
-            values.stream().flatMap(mc -> mc.getData().stream()).collect(Collectors.toList());
-        // Sort
-        Collections.sort(data, Metric.comparator);
-        return build(type, data);
     }
 
     public static MetricCollection mergeSorted(

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/MetricCollection.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/MetricCollection.java
@@ -28,11 +28,13 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
 import com.spotify.heroic.aggregation.AggregationSession;
 import com.spotify.heroic.common.Series;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -158,6 +160,28 @@ public abstract class MetricCollection {
         final Function<List<? extends Metric>, MetricCollection> adapter =
             checkNotNull(adapters.get(key), "adapter does not exist for type");
         return adapter.apply(metrics);
+    }
+
+    public static MetricCollection mergeSorted(
+        final List<MetricCollection> values
+    ) {
+        if (values.isEmpty()) {
+            return empty();
+        }
+
+        MetricType type = values.iterator().next().getType();
+        values.stream().forEach(mc -> {
+            if (mc.getType() != type) {
+                throw new RuntimeException("Can't mix metric types when merging");
+            }
+        });
+
+        // Flatten
+        final List<Metric> data =
+            values.stream().flatMap(mc -> mc.getData().stream()).collect(Collectors.toList());
+        // Sort
+        Collections.sort(data, Metric.comparator);
+        return build(type, data);
     }
 
     public static MetricCollection mergeSorted(

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/Fetch.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/Fetch.java
@@ -103,6 +103,8 @@ public class Fetch implements ShellTask {
 
         final QueryOptions.Builder optionsBuilder =
             QueryOptions.builder().tracing(Tracing.fromBoolean(params.tracing));
+        params.fetchSize.ifPresent(optionsBuilder::fetchSize);
+
         final QueryOptions options = optionsBuilder.build();
 
         final Consumer<MetricCollection> printMetricsCollection = g -> {
@@ -200,6 +202,10 @@ public class Fetch implements ShellTask {
 
         @Option(name = "--sliced-data-fetch", usage = "Enable sliced data fetch")
         private boolean slicedDataFetch = false;
+
+        @Option(name = "--fetch-size", usage = "Set the number of entries to fetch for every slice")
+        private Optional<Integer> fetchSize = Optional.empty();
+
     }
 
     public static Fetch setup(final CoreComponent core) {

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/Query.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/Query.java
@@ -88,6 +88,7 @@ public class Query implements ShellTask {
         params.dataLimit.ifPresent(optionsBuilder::dataLimit);
         params.groupLimit.ifPresent(optionsBuilder::groupLimit);
         params.seriesLimit.ifPresent(optionsBuilder::seriesLimit);
+        params.fetchSize.ifPresent(optionsBuilder::fetchSize);
 
         final Optional<QueryOptions> options = Optional.of(optionsBuilder.build());
 
@@ -153,6 +154,9 @@ public class Query implements ShellTask {
 
         @Option(name = "--sliced-data-fetch", usage = "Enable sliced data fetch")
         private boolean slicedDataFetch = false;
+
+        @Option(name = "--fetch-size", usage = "Set the number of entries to fetch for every slice")
+        private Optional<Integer> fetchSize = Optional.empty();
 
         @Option(name = "--data-limit", usage = "Enable data limiting")
         private Optional<Long> dataLimit = Optional.empty();

--- a/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsModule.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsModule.java
@@ -89,7 +89,7 @@ public class BigtableAnalyticsModule implements AnalyticsModule {
                 return async.call(
                     new BigtableConnectionBuilder(project, cluster, credentials, async,
                         DEFAULT_DISABLE_BULK_MUTATIONS, DEFAULT_FLUSH_INTERVAL_SECONDS,
-                        Optional.empty()));
+                        Optional.empty(), Optional.empty()));
             }
 
             @Override

--- a/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsModule.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsModule.java
@@ -59,6 +59,7 @@ public class BigtableAnalyticsModule implements AnalyticsModule {
     public static final int DEFAULT_MAX_PENDING_REPORTS = 1000;
     public static final boolean DEFAULT_DISABLE_BULK_MUTATIONS = false;
     public static final int DEFAULT_FLUSH_INTERVAL_SECONDS = 2;
+    public static final int DEFAULT_FETCH_SIZE = 500000;
 
     private final String project;
     private final String cluster;
@@ -89,7 +90,7 @@ public class BigtableAnalyticsModule implements AnalyticsModule {
                 return async.call(
                     new BigtableConnectionBuilder(project, cluster, credentials, async,
                         DEFAULT_DISABLE_BULK_MUTATIONS, DEFAULT_FLUSH_INTERVAL_SECONDS,
-                        Optional.empty(), Optional.empty()));
+                        Optional.empty(), DEFAULT_FETCH_SIZE));
             }
 
             @Override

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnectionBuilder.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnectionBuilder.java
@@ -56,6 +56,7 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
     private final boolean disableBulkMutations;
     private final int flushIntervalSeconds;
     private final Optional<Integer> batchSize;
+    private final Optional<Integer> defaultFetchSize;
 
     @Override
     public BigtableConnection call() throws Exception {
@@ -90,7 +91,8 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
             new BigtableMutatorImpl(async, session, disableBulkMutations, flushIntervalSeconds);
 
         final BigtableDataClient client =
-            new BigtableDataClientImpl(async, session, mutator, project, instance);
+            new BigtableDataClientImpl(async, session, mutator, project, instance,
+                defaultFetchSize);
 
         return new GrpcBigtableConnection(async, project, instance, session, mutator, adminClient,
             client);

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnectionBuilder.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnectionBuilder.java
@@ -56,7 +56,7 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
     private final boolean disableBulkMutations;
     private final int flushIntervalSeconds;
     private final Optional<Integer> batchSize;
-    private final Optional<Integer> defaultFetchSize;
+    private final int fetchSize;
 
     @Override
     public BigtableConnection call() throws Exception {
@@ -91,8 +91,7 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
             new BigtableMutatorImpl(async, session, disableBulkMutations, flushIntervalSeconds);
 
         final BigtableDataClient client =
-            new BigtableDataClientImpl(async, session, mutator, project, instance,
-                defaultFetchSize);
+            new BigtableDataClientImpl(async, session, mutator, project, instance, fetchSize);
 
         return new GrpcBigtableConnection(async, project, instance, session, mutator, adminClient,
             client);

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableMetricModule.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableMetricModule.java
@@ -75,6 +75,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
     private final int flushIntervalSeconds;
     private final Optional<Integer> batchSize;
     private final boolean fake;
+    private final Optional<Integer> defaultFetchSize;
 
     @JsonCreator
     public BigtableMetricModule(
@@ -87,7 +88,8 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         @JsonProperty("disableBulkMutations") Optional<Boolean> disableBulkMutations,
         @JsonProperty("flushIntervalSeconds") Optional<Integer> flushIntervalSeconds,
         @JsonProperty("batchSize") Optional<Integer> batchSize,
-        @JsonProperty("fake") Optional<Boolean> fake
+        @JsonProperty("fake") Optional<Boolean> fake,
+        @JsonProperty("defaultFetchSize") Optional<Integer> defaultFetchSize
     ) {
         this.id = id;
         this.groups = groups.orElseGet(Groups::empty).or(DEFAULT_GROUP);
@@ -100,6 +102,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         this.flushIntervalSeconds = flushIntervalSeconds.orElse(DEFAULT_FLUSH_INTERVAL_SECONDS);
         this.batchSize = batchSize;
         this.fake = fake.orElse(DEFAULT_FAKE);
+        this.defaultFetchSize = defaultFetchSize;
     }
 
     @Override
@@ -149,7 +152,8 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
                 public AsyncFuture<BigtableConnection> construct() throws Exception {
                     return async.call(
                         new BigtableConnectionBuilder(project, instance, credentials, async,
-                            disableBulkMutations, flushIntervalSeconds, batchSize));
+                            disableBulkMutations, flushIntervalSeconds, batchSize,
+                            defaultFetchSize));
                 }
 
                 @Override
@@ -217,6 +221,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         private Optional<Integer> flushIntervalSeconds = empty();
         private Optional<Integer> batchSize = empty();
         private Optional<Boolean> fake = empty();
+        private Optional<Integer> defaultFetchSize = empty();
 
         public Builder id(String id) {
             this.id = of(id);
@@ -263,6 +268,11 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
             return this;
         }
 
+        public Builder defaultFetchSize(int defaultFetchSize) {
+            this.defaultFetchSize = of(defaultFetchSize);
+            return this;
+        }
+
         public Builder table(final String table) {
             this.table = of(table);
             return this;
@@ -275,7 +285,8 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
 
         public BigtableMetricModule build() {
             return new BigtableMetricModule(id, groups, project, instance, table, credentials,
-                configure, disableBulkMutations, flushIntervalSeconds, batchSize, fake);
+                configure, disableBulkMutations, flushIntervalSeconds, batchSize, fake,
+                defaultFetchSize);
         }
     }
 }

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableMetricModule.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableMetricModule.java
@@ -63,6 +63,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
     public static final boolean DEFAULT_DISABLE_BULK_MUTATIONS = false;
     public static final int DEFAULT_FLUSH_INTERVAL_SECONDS = 2;
     public static final boolean DEFAULT_FAKE = false;
+    public static final int DEFAULT_FETCH_SIZE = 500000;
 
     private final Optional<String> id;
     private final Groups groups;
@@ -75,7 +76,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
     private final int flushIntervalSeconds;
     private final Optional<Integer> batchSize;
     private final boolean fake;
-    private final Optional<Integer> defaultFetchSize;
+    private final int fetchSize;
 
     @JsonCreator
     public BigtableMetricModule(
@@ -89,7 +90,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         @JsonProperty("flushIntervalSeconds") Optional<Integer> flushIntervalSeconds,
         @JsonProperty("batchSize") Optional<Integer> batchSize,
         @JsonProperty("fake") Optional<Boolean> fake,
-        @JsonProperty("defaultFetchSize") Optional<Integer> defaultFetchSize
+        @JsonProperty("fetchSize") Optional<Integer> fetchSize
     ) {
         this.id = id;
         this.groups = groups.orElseGet(Groups::empty).or(DEFAULT_GROUP);
@@ -102,7 +103,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         this.flushIntervalSeconds = flushIntervalSeconds.orElse(DEFAULT_FLUSH_INTERVAL_SECONDS);
         this.batchSize = batchSize;
         this.fake = fake.orElse(DEFAULT_FAKE);
-        this.defaultFetchSize = defaultFetchSize;
+        this.fetchSize = fetchSize.orElse(DEFAULT_FETCH_SIZE);
     }
 
     @Override
@@ -152,8 +153,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
                 public AsyncFuture<BigtableConnection> construct() throws Exception {
                     return async.call(
                         new BigtableConnectionBuilder(project, instance, credentials, async,
-                            disableBulkMutations, flushIntervalSeconds, batchSize,
-                            defaultFetchSize));
+                            disableBulkMutations, flushIntervalSeconds, batchSize, fetchSize));
                 }
 
                 @Override
@@ -221,7 +221,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         private Optional<Integer> flushIntervalSeconds = empty();
         private Optional<Integer> batchSize = empty();
         private Optional<Boolean> fake = empty();
-        private Optional<Integer> defaultFetchSize = empty();
+        private Optional<Integer> fetchSize = empty();
 
         public Builder id(String id) {
             this.id = of(id);
@@ -268,8 +268,8 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
             return this;
         }
 
-        public Builder defaultFetchSize(int defaultFetchSize) {
-            this.defaultFetchSize = of(defaultFetchSize);
+        public Builder fetchSize(int fetchSize) {
+            this.fetchSize = of(fetchSize);
             return this;
         }
 
@@ -285,8 +285,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
 
         public BigtableMetricModule build() {
             return new BigtableMetricModule(id, groups, project, instance, table, credentials,
-                configure, disableBulkMutations, flushIntervalSeconds, batchSize, fake,
-                defaultFetchSize);
+                configure, disableBulkMutations, flushIntervalSeconds, batchSize, fake, fetchSize);
         }
     }
 }

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableDataClient.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableDataClient.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 import java.util.function.Function;
 
 public interface BigtableDataClient {
-
     interface CellConsumer {
         <T> void consume(
             List<? extends T> data, Function<T, ByteString> qualifier, Function<T, ByteString> value

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableDataClient.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableDataClient.java
@@ -56,12 +56,12 @@ public interface BigtableDataClient {
      *
      * @param tableName Table to read rows from.
      * @param request Request to use when reading rows.
-     * @param fetchSize The number of cells to fetch for every batch.
+     * @param fetchSizeOverride The number of cells to fetch for every batch, optional
      * @param cellConsumer The consumer of fetched data.
      * @return A future that will be resolved when all cells have been passed to the cellConsumer.
      */
     AsyncFuture<Void> readRowRange(
-        String tableName, ReadRowRangeRequest request, Optional<Integer> fetchSize,
+        String tableName, ReadRowRangeRequest request, Optional<Integer> fetchSizeOverride,
         CellConsumer cellConsumer
     );
 

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableDataClientImpl.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableDataClientImpl.java
@@ -48,7 +48,6 @@ import lombok.ToString;
 @RequiredArgsConstructor
 @ToString
 public class BigtableDataClientImpl implements BigtableDataClient {
-
     private final AsyncFramework async;
     private final com.google.cloud.bigtable.grpc.BigtableSession session;
     private final BigtableMutator mutator;
@@ -100,7 +99,6 @@ public class BigtableDataClientImpl implements BigtableDataClient {
     ) {
         return Futures.transform(session.getDataClient().readFlatRowsAsync(request),
             new Function<List<FlatRow>, Object>() {
-
                 @Override
                 public Object apply(final List<FlatRow> flatRows) {
                     flatRows

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableDataClientImpl.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableDataClientImpl.java
@@ -52,19 +52,19 @@ public class BigtableDataClientImpl implements BigtableDataClient {
     private final AsyncFramework async;
     private final com.google.cloud.bigtable.grpc.BigtableSession session;
     private final BigtableMutator mutator;
-    private final Optional<Integer> defaultFetchSize;
+    private final int fetchSize;
     private final LimitedCellsRequestEmitter rangeReader;
     private final String clusterUri;
 
     public BigtableDataClientImpl(
         final AsyncFramework async, final com.google.cloud.bigtable.grpc.BigtableSession session,
         final BigtableMutator mutator, final String project,
-        final String cluster, final Optional<Integer> defaultFetchSize
+        final String cluster, final int fetchSize
     ) {
         this.async = async;
         this.session = session;
         this.mutator = mutator;
-        this.defaultFetchSize = defaultFetchSize;
+        this.fetchSize = fetchSize;
         this.rangeReader = new LimitedCellsRequestEmitter(this::issueReadRowsRequest, async);
         this.clusterUri = String.format("projects/%s/instances/%s", project, cluster);
     }
@@ -88,10 +88,10 @@ public class BigtableDataClientImpl implements BigtableDataClient {
     @Override
     public AsyncFuture<Void> readRowRange(
         final String tableName, final ReadRowRangeRequest request,
-        final Optional<Integer> fetchSize, final CellConsumer cellConsumer
+        final Optional<Integer> fetchSizeOverride, final CellConsumer cellConsumer
     ) {
         final String tableUri = Table.toURI(clusterUri, tableName);
-        final Optional<Integer> fetchSizeOrDefault = fetchSize.isPresent() ? fetchSize : defaultFetchSize;
+        final int fetchSizeOrDefault = fetchSizeOverride.orElse(this.fetchSize);
         return rangeReader.readRow(tableUri, request, fetchSizeOrDefault, cellConsumer);
     }
 

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/FakeBigtableConnection.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/FakeBigtableConnection.java
@@ -28,7 +28,6 @@ import com.spotify.heroic.async.AsyncObservable;
 import com.spotify.heroic.metric.bigtable.BigtableConnection;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import eu.toolchain.async.FutureResolved;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/LimitedCellsRequestEmitter.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/LimitedCellsRequestEmitter.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.metric.bigtable.api;
+
+import com.google.bigtable.v2.ColumnRange;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.RowFilter;
+import com.google.bigtable.v2.RowSet;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.protobuf.ByteString;
+
+import com.spotify.heroic.metric.bigtable.api.BigtableDataClient.CellConsumer;
+
+import eu.toolchain.async.AsyncFramework;
+import eu.toolchain.async.AsyncFuture;
+import eu.toolchain.async.ResolvableFuture;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+class LimitedCellsRequestEmitter {
+
+    private static final int DEFAULT_FETCH_SIZE = 500000;
+
+    private final BiFunction<ReadRowsRequest, CellConsumer, ListenableFuture<?>> requestIssuer;
+    private final AsyncFramework async;
+
+    @RequiredArgsConstructor
+    private class RequestHandler implements CellConsumer, FutureCallback<Object> {
+        private final String tableUri;
+        private final ReadRowRangeRequest rowRequest;
+        private final int fetchSize;
+        private final ResolvableFuture<?> future;
+        private final CellConsumer cellConsumer;
+        // Number of input cells consumed
+        private int consumedCells;
+        private ByteString lastQualifierRef;
+
+        @Override
+        public <T> void consume(
+            final List<? extends T> cells, final Function<T, ByteString> qualifier,
+            final Function<T, ByteString> value
+        ) {
+            if (cells.isEmpty()) {
+                log.warn("Got empty cell chunk list");
+                return;
+            }
+            cellConsumer.consume(cells, qualifier, value);
+            consumedCells += cells.size();
+            lastQualifierRef = qualifier.apply(cells.get(cells.size() - 1));
+        }
+
+        @Override
+        public void onSuccess(final Object object) {
+            if (consumedCells < fetchSize || lastQualifierRef == null ||
+                rowRequest.getEndQualifierClosed().equals(lastQualifierRef)) {
+                log.debug("Read rows completed");
+                future.resolve(null);
+            } else {
+                log.debug("Send new read rows request");
+                final RequestHandler requestHandler =
+                    new RequestHandler(tableUri, rowRequest, fetchSize, future, cellConsumer);
+                issueRequest(requestHandler, lastQualifierRef);
+            }
+        }
+
+        @Override
+        public void onFailure(final Throwable throwable) {
+            future.fail(throwable);
+        }
+
+        private ReadRowsRequest buildRequest(final ByteString startQualifierOpen) {
+            final RowSet.Builder rowSetBuilder = RowSet.newBuilder();
+            rowSetBuilder.addRowKeys(rowRequest.getRowKey());
+
+            final ReadRowsRequest.Builder requestBuilder = ReadRowsRequest.newBuilder();
+            requestBuilder.setTableName(tableUri);
+            requestBuilder.setRows(rowSetBuilder.build());
+
+            final RowFilter.Chain.Builder chain = RowFilter.Chain.newBuilder();
+
+            final ColumnRange.Builder columnRange = ColumnRange
+                .newBuilder()
+                .setFamilyName(rowRequest.getColumnFamily())
+                .setStartQualifierOpen(startQualifierOpen)
+                .setEndQualifierClosed(rowRequest.getEndQualifierClosed());
+
+            chain.addFilters(RowFilter.newBuilder().setColumnRangeFilter(columnRange.build()));
+            chain.addFilters(RowFilter.newBuilder().setCellsPerColumnLimitFilter(1));
+            chain.addFilters(RowFilter.newBuilder().setCellsPerRowLimitFilter(fetchSize));
+
+            requestBuilder.setFilter(RowFilter.newBuilder().setChain(chain.build()).build());
+            return requestBuilder.build();
+        }
+    }
+
+    public AsyncFuture<Void> readRow(
+        final String tableUri, final ReadRowRangeRequest request, final Optional<Integer> optionalFetchSize,
+        final CellConsumer consumer
+    ) {
+        final ResolvableFuture<Void> future = async.future();
+        final int fetchSize = optionalFetchSize.orElse(DEFAULT_FETCH_SIZE);
+        final RequestHandler requestHandler =
+            new RequestHandler(tableUri, request, fetchSize, future, consumer);
+        issueRequest(requestHandler, request.getStartQualifierOpen());
+        return future;
+    }
+
+    private void issueRequest(final RequestHandler requestHandler, final ByteString startQualifierOpen) {
+        final ReadRowsRequest request = requestHandler.buildRequest(startQualifierOpen);
+        final ListenableFuture<?> future = requestIssuer.apply(request, requestHandler);
+        Futures.addCallback(future, requestHandler);
+    }
+}

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/LimitedCellsRequestEmitter.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/LimitedCellsRequestEmitter.java
@@ -42,7 +42,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 class LimitedCellsRequestEmitter {
-
     private final BiFunction<ReadRowsRequest, CellConsumer, ListenableFuture<?>> requestIssuer;
     private final AsyncFramework async;
 


### PR DESCRIPTION
Make the memory usage of BT reads more deterministic by limiting the max number of cells that is read in each FlatRow request/response.

This used to be jo-ri#2 while waiting for #206. Now rebased on Master, where #206 is merged.