### PR TITLE
[dist] enable jcl-over-slf4j

### DIFF
--- a/heroic-dist/pom.xml
+++ b/heroic-dist/pom.xml
@@ -44,6 +44,10 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+    </dependency>
 
     <!-- core -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -699,6 +699,11 @@
         <version>${slf4j.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
         <version>${log4j.version}</version>


### PR DESCRIPTION
This enables logging for any component that uses `org.apache.common.logging` for logging.