### PR TITLE
[consumer/kafka] Disable Kafka consumer timeout

### DIFF
--- a/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/KafkaConsumerModule.java
+++ b/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/KafkaConsumerModule.java
@@ -266,10 +266,6 @@ public class KafkaConsumerModule implements ConsumerModule {
 
                 private KafkaConnection createKafkaConnection() {
                     final Properties properties = new Properties();
-
-                    // Defaults
-                    properties.put("consumer.timeout.ms", "1000");
-
                     properties.putAll(config);
 
                     if (transactional) {


### PR DESCRIPTION
The Kafka consumer timeout is actually not needed, just adds complexity. So simplify by disabling the timeout and removing the code that handles the timeout.