### PR TITLE
[all] A shard with no discovered nodes is an error

### DIFF
--- a/discovery/simple/src/main/java/com/spotify/heroic/cluster/discovery/simple/StaticListDiscovery.java
+++ b/discovery/simple/src/main/java/com/spotify/heroic/cluster/discovery/simple/StaticListDiscovery.java
@@ -24,12 +24,11 @@ package com.spotify.heroic.cluster.discovery.simple;
 import com.spotify.heroic.cluster.ClusterDiscovery;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.ToString;
-
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.net.URI;
 import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Named;
+import lombok.ToString;
 
 @ToString
 public class StaticListDiscovery implements ClusterDiscovery {
@@ -37,7 +36,9 @@ public class StaticListDiscovery implements ClusterDiscovery {
     private final List<URI> nodes;
 
     @Inject
-    public StaticListDiscovery(AsyncFramework async, @Named("nodes") List<URI> nodes) {
+    public StaticListDiscovery(
+        AsyncFramework async, @Named("nodes") List<URI> nodes
+    ) {
         this.async = async;
         this.nodes = nodes;
     }

--- a/discovery/simple/src/main/java/com/spotify/heroic/cluster/discovery/simple/StaticListDiscoveryModule.java
+++ b/discovery/simple/src/main/java/com/spotify/heroic/cluster/discovery/simple/StaticListDiscoveryModule.java
@@ -30,19 +30,20 @@ import com.spotify.heroic.dagger.PrimaryComponent;
 import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
-import lombok.Data;
-
-import javax.inject.Named;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import javax.inject.Named;
+import lombok.Data;
 
 @Data
 public class StaticListDiscoveryModule implements ClusterDiscoveryModule {
     private final List<URI> nodes;
 
     @JsonCreator
-    public StaticListDiscoveryModule(@JsonProperty("nodes") List<URI> nodes) {
+    public StaticListDiscoveryModule(
+        @JsonProperty("nodes") List<URI> nodes
+    ) {
         this.nodes = Optional.ofNullable(nodes).orElseGet(ImmutableList::of);
     }
 

--- a/heroic-all/src/main/java/com/spotify/heroic/profile/ClusterProfile.java
+++ b/heroic-all/src/main/java/com/spotify/heroic/profile/ClusterProfile.java
@@ -21,6 +21,8 @@
 
 package com.spotify.heroic.profile;
 
+import static com.spotify.heroic.ParameterSpecification.parameter;
+
 import com.google.common.collect.ImmutableList;
 import com.spotify.heroic.ExtraParameters;
 import com.spotify.heroic.HeroicConfig;
@@ -29,13 +31,10 @@ import com.spotify.heroic.cluster.ClusterManagerModule;
 import com.spotify.heroic.cluster.discovery.simple.SrvRecordDiscoveryModule;
 import com.spotify.heroic.cluster.discovery.simple.StaticListDiscoveryModule;
 import com.spotify.heroic.rpc.grpc.GrpcRpcProtocolModule;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Optional;
-
-import static com.spotify.heroic.ParameterSpecification.parameter;
 
 public class ClusterProfile extends HeroicProfileBase {
     public static final String DEFAULT_PROTOCOL = "grpc";

--- a/heroic-component/src/main/java/com/spotify/heroic/cluster/ClusterDiscovery.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/cluster/ClusterDiscovery.java
@@ -22,7 +22,6 @@
 package com.spotify.heroic.cluster;
 
 import eu.toolchain.async.AsyncFuture;
-
 import java.net.URI;
 import java.util.List;
 

--- a/heroic-core/src/main/java/com/spotify/heroic/cluster/ClusterManagerModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/cluster/ClusterManagerModule.java
@@ -21,6 +21,10 @@
 
 package com.spotify.heroic.cluster;
 
+import static com.spotify.heroic.common.Optionals.pickOptional;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -35,12 +39,6 @@ import com.spotify.heroic.metric.MetricComponent;
 import com.spotify.heroic.suggest.SuggestComponent;
 import dagger.Module;
 import dagger.Provides;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import org.apache.commons.lang3.tuple.Pair;
-
-import javax.inject.Named;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -48,10 +46,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-
-import static com.spotify.heroic.common.Optionals.pickOptional;
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
+import javax.inject.Named;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * @author udoprog

--- a/heroic-core/src/main/java/com/spotify/heroic/cluster/NodeRegistry.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/cluster/NodeRegistry.java
@@ -81,12 +81,12 @@ public class NodeRegistry {
     ) {
         final List<Pair<Map<String, String>, List<ClusterNode>>> result = Lists.newArrayList();
 
-        final Multimap<Map<String, String>, ClusterNode> shards = buildShards(entries);
+        final Multimap<Map<String, String>, ClusterNode> shardToNode = buildShards(entries);
 
-        final Set<Entry<Map<String, String>, Collection<ClusterNode>>> entries =
-            shards.asMap().entrySet();
+        final Set<Entry<Map<String, String>, Collection<ClusterNode>>> shardToNodeEntries =
+            shardToNode.asMap().entrySet();
 
-        for (final Entry<Map<String, String>, Collection<ClusterNode>> e : entries) {
+        for (final Entry<Map<String, String>, Collection<ClusterNode>> e : shardToNodeEntries) {
             result.add(Pair.of(e.getKey(), pickN(e.getValue(), n)));
         }
 

--- a/heroic-core/src/test/java/com/spotify/heroic/cluster/CoreClusterManagerTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/cluster/CoreClusterManagerTest.java
@@ -1,23 +1,23 @@
 package com.spotify.heroic.cluster;
 
-import com.spotify.heroic.HeroicConfiguration;
-import com.spotify.heroic.HeroicContext;
-import com.spotify.heroic.scheduler.Scheduler;
-import eu.toolchain.async.AsyncFramework;
-import eu.toolchain.async.AsyncFuture;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import java.util.Map;
-
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.ImmutableSet;
+import com.spotify.heroic.HeroicConfiguration;
+import com.spotify.heroic.HeroicContext;
+import com.spotify.heroic.scheduler.Scheduler;
+import eu.toolchain.async.AsyncFramework;
+import eu.toolchain.async.AsyncFuture;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CoreClusterManagerTest {
@@ -55,7 +55,7 @@ public class CoreClusterManagerTest {
         final boolean useLocal = true;
 
         manager = spy(new CoreClusterManager(async, discovery, localMetadata, protocols, scheduler,
-            useLocal, options, local, context));
+            useLocal, options, local, context, ImmutableSet.of()));
     }
 
     @Test

--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractLocalClusterIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractLocalClusterIT.java
@@ -1,5 +1,7 @@
 package com.spotify.heroic;
 
+import static org.junit.Assert.assertEquals;
+
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -17,10 +19,6 @@ import com.spotify.heroic.rpc.jvm.JvmRpcContext;
 import com.spotify.heroic.rpc.jvm.JvmRpcProtocolModule;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.TinyAsync;
-import org.junit.After;
-import org.junit.Before;
-import org.mockito.Mockito;
-
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -31,8 +29,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
+import org.junit.After;
+import org.junit.Before;
+import org.mockito.Mockito;
 
 public abstract class AbstractLocalClusterIT {
     protected final ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -216,9 +215,7 @@ public abstract class AbstractLocalClusterIT {
                     .tags(ImmutableMap.of("shard", uri.getHost()))
                     .protocols(ImmutableList.of(protocol))
                     .discovery(discovery)))
-            .configFragment(HeroicConfig
-                .builder()
-                .queryLogging(mockQueryLoggingModule))
+            .configFragment(HeroicConfig.builder().queryLogging(mockQueryLoggingModule))
             .profile(new MemoryProfile())
             .modules(HeroicModules.ALL_MODULES)
             .build()


### PR DESCRIPTION
This requires configuration - reusing the already existing 'topology'
configuration variable. Use it to specify which shards that are
expected to exist / be represented by nodes in the cluster. If Heroic
at some point has zero known nodes for any of these shards that will
be treated as a shard error and shown in query responses in the form
of entries in the 'errors' hash.
The list of expected shards is optional, but can be specified as so:

```
    cluster:
      tags:
        site: site2
        part: a
      discovery:
        type: ...
      topology:
        - site: site1
        - site: site2
          part: a
        - site: site2
          part: b
        - site: site3
```