### PR TITLE
[core,rpc/grpc] close channel if initial metadata refresh fails

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/cluster/CoreClusterManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/cluster/CoreClusterManager.java
@@ -372,7 +372,7 @@ public class CoreClusterManager implements ClusterManager, LifeCycles {
                  * otherwise, re-use the existing node */
                 updated.add(node.fetchMetadata().lazyTransform(m -> {
                     if (!node.metadata().equals(m)) {
-                            /* add to removedNodes list to make sure it is being closed */
+                        /* add to removedNodes list to make sure it is being closed */
                         removedNodes.add(new RemovedNode(uri, node));
                         return createClusterNode(id, uri);
                     }


### PR DESCRIPTION
This causes the client side to accumulate established connections if metadata refresh fails on the remote side for any reason.

The channels are probably not closed through gc because they are associated with persistent event loop groups when created.

This has been tested by intentionally breaking the metadata handle on the remote end.