### PR TITLE
[aggregation/simple,component,core] introduce BucketStrategy

### DIFF
--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/DeltaInstance.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/DeltaInstance.java
@@ -20,30 +20,31 @@
  */
 
 package com.spotify.heroic.aggregation.simple;
+
 import com.spotify.heroic.aggregation.AggregationInstance;
+import com.spotify.heroic.aggregation.AggregationOutput;
 import com.spotify.heroic.aggregation.AggregationResult;
 import com.spotify.heroic.aggregation.AggregationSession;
-import com.spotify.heroic.aggregation.AggregationOutput;
+import com.spotify.heroic.aggregation.BucketStrategy;
 import com.spotify.heroic.aggregation.EmptyInstance;
 import com.spotify.heroic.aggregation.RetainQuotaWatcher;
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Series;
+import com.spotify.heroic.metric.Event;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.MetricGroup;
-import com.spotify.heroic.metric.Event;
-import com.spotify.heroic.metric.Payload;
 import com.spotify.heroic.metric.MetricType;
+import com.spotify.heroic.metric.Payload;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-import lombok.Data;
-
-import java.util.List;
 import java.util.ArrayList;
-import java.util.Map;
-import java.util.Iterator;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.Data;
 
 @Data
 public class DeltaInstance implements AggregationInstance {
@@ -89,10 +90,11 @@ public class DeltaInstance implements AggregationInstance {
         return result;
     }
 
-
     @Override
-    public AggregationSession session(DateRange range, RetainQuotaWatcher quotaWatcher) {
-        return new Session(INNER.session(range, quotaWatcher));
+    public AggregationSession session(
+        DateRange range, RetainQuotaWatcher quotaWatcher, BucketStrategy bucketStrategy
+    ) {
+        return new Session(INNER.session(range, quotaWatcher, bucketStrategy));
     }
 
     private class Session implements AggregationSession {

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/FilterAggregation.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/FilterAggregation.java
@@ -26,6 +26,7 @@ import com.spotify.heroic.aggregation.AggregationInstance;
 import com.spotify.heroic.aggregation.AggregationOutput;
 import com.spotify.heroic.aggregation.AggregationResult;
 import com.spotify.heroic.aggregation.AggregationSession;
+import com.spotify.heroic.aggregation.BucketStrategy;
 import com.spotify.heroic.aggregation.EmptyInstance;
 import com.spotify.heroic.aggregation.RetainQuotaWatcher;
 import com.spotify.heroic.common.DateRange;
@@ -35,12 +36,10 @@ import com.spotify.heroic.metric.MetricGroup;
 import com.spotify.heroic.metric.Payload;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import lombok.Data;
 import lombok.NonNull;
 
@@ -83,8 +82,10 @@ public abstract class FilterAggregation implements AggregationInstance {
     }
 
     @Override
-    public AggregationSession session(DateRange range, RetainQuotaWatcher quotaWatcher) {
-        return new Session(filterStrategy, INNER.session(range, quotaWatcher));
+    public AggregationSession session(
+        DateRange range, RetainQuotaWatcher quotaWatcher, BucketStrategy bucketStrategy
+    ) {
+        return new Session(filterStrategy, INNER.session(range, quotaWatcher, bucketStrategy));
     }
 
     private class Session implements AggregationSession {

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/MetricMappingAggregation.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/MetricMappingAggregation.java
@@ -21,11 +21,14 @@
 
 package com.spotify.heroic.aggregation.simple;
 
+import static java.util.stream.Collectors.toList;
+
 import com.spotify.heroic.aggregation.AggregationInstance;
+import com.spotify.heroic.aggregation.AggregationOutput;
 import com.spotify.heroic.aggregation.AggregationResult;
 import com.spotify.heroic.aggregation.AggregationSession;
+import com.spotify.heroic.aggregation.BucketStrategy;
 import com.spotify.heroic.aggregation.EmptyInstance;
-import com.spotify.heroic.aggregation.AggregationOutput;
 import com.spotify.heroic.aggregation.RetainQuotaWatcher;
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Series;
@@ -33,17 +36,13 @@ import com.spotify.heroic.metric.Event;
 import com.spotify.heroic.metric.MetricGroup;
 import com.spotify.heroic.metric.Payload;
 import com.spotify.heroic.metric.Point;
-import lombok.Data;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static java.util.stream.Collectors.toList;
+import lombok.Data;
 
 @Data
 public abstract class MetricMappingAggregation implements AggregationInstance {
-
     private static final EmptyInstance INNER = EmptyInstance.INSTANCE;
     private final MetricMappingStrategy metricMappingStrategy;
 
@@ -58,8 +57,10 @@ public abstract class MetricMappingAggregation implements AggregationInstance {
     }
 
     @Override
-    public AggregationSession session(DateRange range, RetainQuotaWatcher quotaWatcher) {
-        return new Session(INNER.session(range, quotaWatcher));
+    public AggregationSession session(
+        DateRange range, RetainQuotaWatcher quotaWatcher, BucketStrategy bucketStrategy
+    ) {
+        return new Session(INNER.session(range, quotaWatcher, bucketStrategy));
     }
 
     @Override

--- a/heroic-component/src/main/java/com/spotify/heroic/QueryOptions.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/QueryOptions.java
@@ -21,16 +21,20 @@
 
 package com.spotify.heroic;
 
+import com.spotify.heroic.aggregation.BucketStrategy;
 import com.spotify.heroic.common.OptionalLimit;
 import com.spotify.heroic.metric.QueryTrace;
 import com.spotify.heroic.metric.Tracing;
-
 import java.util.Optional;
-
 import lombok.Data;
 
 @Data
 public class QueryOptions {
+    /**
+     * Strategy for how to create buckets when performing a sampling aggregation.
+     */
+    private final Optional<BucketStrategy> bucketStrategy;
+
     /**
      * Indicates if tracing is enabled.
      * <p>
@@ -76,8 +80,9 @@ public class QueryOptions {
     }
 
     public static QueryOptions defaults() {
-        return new QueryOptions(Optional.empty(), Optional.empty(), OptionalLimit.empty(),
-            OptionalLimit.empty(), OptionalLimit.empty(), OptionalLimit.empty(), Optional.empty());
+        return new QueryOptions(Optional.empty(), Optional.empty(), Optional.empty(),
+            OptionalLimit.empty(), OptionalLimit.empty(), OptionalLimit.empty(),
+            OptionalLimit.empty(), Optional.empty());
     }
 
     public static Builder builder() {
@@ -85,6 +90,7 @@ public class QueryOptions {
     }
 
     public static class Builder {
+        private Optional<BucketStrategy> bucketStrategy = Optional.empty();
         private Optional<Tracing> tracing = Optional.empty();
         private Optional<Integer> fetchSize = Optional.empty();
         private OptionalLimit dataLimit = OptionalLimit.empty();
@@ -92,6 +98,11 @@ public class QueryOptions {
         private OptionalLimit groupLimit = OptionalLimit.empty();
         private OptionalLimit seriesLimit = OptionalLimit.empty();
         private Optional<Boolean> failOnLimits = Optional.empty();
+
+        public Builder bucketStrategy(BucketStrategy bucketStrategy) {
+            this.bucketStrategy = Optional.of(bucketStrategy);
+            return this;
+        }
 
         public Builder tracing(Tracing tracing) {
             this.tracing = Optional.of(tracing);
@@ -113,7 +124,6 @@ public class QueryOptions {
             return this;
         }
 
-
         public Builder groupLimit(long groupLimit) {
             this.groupLimit = OptionalLimit.of(groupLimit);
             return this;
@@ -130,8 +140,8 @@ public class QueryOptions {
         }
 
         public QueryOptions build() {
-            return new QueryOptions(tracing, fetchSize, dataLimit, aggregationLimit, groupLimit,
-                seriesLimit, failOnLimits);
+            return new QueryOptions(bucketStrategy, tracing, fetchSize, dataLimit, aggregationLimit,
+                groupLimit, seriesLimit, failOnLimits);
         }
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/AggregationInstance.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/AggregationInstance.java
@@ -22,9 +22,7 @@
 package com.spotify.heroic.aggregation;
 
 import com.google.common.collect.ImmutableSet;
-
 import com.spotify.heroic.common.DateRange;
-
 import java.util.Set;
 
 /**
@@ -61,13 +59,15 @@ public interface AggregationInstance {
      * Traverse the possible aggregations and build the necessary graph out of them.
      */
     default AggregationSession session(DateRange range) {
-        return session(range, RetainQuotaWatcher.NO_QUOTA);
+        return session(range, RetainQuotaWatcher.NO_QUOTA, BucketStrategy.END);
     }
 
     /**
      * Traverse the possible aggregations and build the necessary graph out of them.
      */
-    AggregationSession session(DateRange range, RetainQuotaWatcher quotaWatcher);
+    AggregationSession session(
+        DateRange range, RetainQuotaWatcher quotaWatcher, BucketStrategy bucketStrategy
+    );
 
     /**
      * Get the distributed aggregation that is relevant for this aggregation.

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/BucketStrategy.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/BucketStrategy.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.spotify.heroic.common.DateRange;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+public interface BucketStrategy {
+    long MAX_BUCKET_COUNT = 100000L;
+
+    BucketStrategy END = new End();
+
+    Mapping setup(DateRange range, long size, long extent);
+
+    @JsonCreator
+    static BucketStrategy create(final String strategy) {
+        switch (strategy) {
+            case "end":
+                return END;
+            default:
+                throw new IllegalArgumentException(strategy);
+        }
+    }
+
+    class End implements BucketStrategy {
+        @JsonValue
+        public String value() {
+            return "end";
+        }
+
+        @Override
+        public Mapping setup(final DateRange range, final long size, final long extent) {
+            final long start = range.start() + size;
+            final long count = (range.diff() + size) / size - 1;
+
+            if (count < 1 || count > MAX_BUCKET_COUNT) {
+                throw new IllegalArgumentException(String.format("range %s, size %d", range, size));
+            }
+
+            return new EndMapping(start, range.start(), size, extent, (int) count);
+        }
+
+        @RequiredArgsConstructor
+        private static class EndMapping implements Mapping {
+            private final long start;
+            private final long offset;
+            private final long size;
+            private final long extent;
+            private final int buckets;
+
+            /**
+             * Calculate the start and end index of the buckets that should be seeded for the given
+             * timestamp.
+             *
+             * This guarantees that each timestamp ends up in the range (end - extent, end] for
+             * any given bucket.
+             *
+             * @param timestamp timestamp to map
+             * @return a start end and index
+             */
+            @Override
+            public StartEnd map(final long timestamp) {
+                /* adjust the timestamp to the number of buckets */
+                final long adjusted = timestamp - offset;
+
+                final int start = Math.max((int) ((adjusted - 1) / size), 0);
+                final int end = Math.min((int) ((adjusted + extent - 1) / size), buckets);
+
+                return new StartEnd(start, end);
+            }
+
+            @Override
+            public long start() {
+                return start;
+            }
+
+            @Override
+            public int buckets() {
+                return buckets;
+            }
+        }
+    }
+
+    interface Mapping {
+        StartEnd map(final long timestamp);
+
+        long start();
+
+        int buckets();
+    }
+
+    /**
+     * A start, and an end bucket (exclusive) selected.
+     */
+    @Data
+    class StartEnd {
+        private final int start;
+        private final int end;
+    }
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/ChainInstance.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/ChainInstance.java
@@ -23,7 +23,6 @@ package com.spotify.heroic.aggregation;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.common.Statistics;
@@ -32,13 +31,11 @@ import com.spotify.heroic.metric.MetricGroup;
 import com.spotify.heroic.metric.Payload;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
@@ -138,16 +135,18 @@ public class ChainInstance implements AggregationInstance {
     }
 
     @Override
-    public AggregationSession session(final DateRange range, final RetainQuotaWatcher watcher) {
+    public AggregationSession session(
+        final DateRange range, final RetainQuotaWatcher watcher, final BucketStrategy bucketStrategy
+    ) {
         final Iterator<AggregationInstance> it = chain.iterator();
 
         final AggregationInstance first = it.next();
-        final AggregationSession head = first.session(range, watcher);
+        final AggregationSession head = first.session(range, watcher, bucketStrategy);
 
         final List<AggregationSession> tail = new ArrayList<>();
 
         while (it.hasNext()) {
-            final AggregationSession s = it.next().session(range, watcher);
+            final AggregationSession s = it.next().session(range, watcher, bucketStrategy);
             tail.add(s);
         }
 

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/EmptyInstance.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/EmptyInstance.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
-
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.common.Statistics;
@@ -37,7 +36,6 @@ import com.spotify.heroic.metric.MetricGroup;
 import com.spotify.heroic.metric.Payload;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +44,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
-
 import lombok.Data;
 import lombok.ToString;
 
@@ -61,7 +58,9 @@ public class EmptyInstance implements AggregationInstance {
     }
 
     @Override
-    public AggregationSession session(final DateRange range, final RetainQuotaWatcher watcher) {
+    public AggregationSession session(
+        final DateRange range, final RetainQuotaWatcher watcher, final BucketStrategy bucketStrategy
+    ) {
         return new CollectorSession(watcher);
     }
 

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/GroupingAggregation.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/GroupingAggregation.java
@@ -21,9 +21,10 @@
 
 package com.spotify.heroic.aggregation;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.common.Statistics;
@@ -32,20 +33,16 @@ import com.spotify.heroic.metric.MetricGroup;
 import com.spotify.heroic.metric.Payload;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @Data
 @EqualsAndHashCode(of = {"of", "each"})
@@ -74,8 +71,10 @@ public abstract class GroupingAggregation implements AggregationInstance {
     );
 
     @Override
-    public AggregationSession session(DateRange range, RetainQuotaWatcher quotaWatcher) {
-        return new GroupSession(range, quotaWatcher);
+    public AggregationSession session(
+        DateRange range, RetainQuotaWatcher quotaWatcher, BucketStrategy bucketStrategy
+    ) {
+        return new GroupSession(range, quotaWatcher, bucketStrategy);
     }
 
     public Set<String> requiredTags() {
@@ -116,6 +115,7 @@ public abstract class GroupingAggregation implements AggregationInstance {
 
         private final DateRange range;
         private final RetainQuotaWatcher quotaWatcher;
+        private final BucketStrategy bucketStrategy;
 
         @Override
         public void updatePoints(
@@ -171,7 +171,8 @@ public abstract class GroupingAggregation implements AggregationInstance {
                     return checkSession;
                 }
 
-                final AggregationSession newSession = each.session(range, quotaWatcher);
+                final AggregationSession newSession =
+                    each.session(range, quotaWatcher, bucketStrategy);
                 sessions.put(key, newSession);
                 return newSession;
             }

--- a/heroic-component/src/main/java/com/spotify/heroic/common/Feature.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/Feature.java
@@ -61,7 +61,13 @@ public enum Feature {
      * This will cause data to be fetched and consumed by the aggregation framework in
      * pieces avoiding having to load all data into memory before starting to consume it.
      */
-    SLICED_DATA_FETCH("com.spotify.heroic.sliced_data_fetch");
+    SLICED_DATA_FETCH("com.spotify.heroic.sliced_data_fetch"),
+
+    /**
+     * Use the legacy bucket strategy by default where the resulting value is at the end of the
+     * timestamp of the bucket.
+     */
+    END_BUCKET("com.spotify.heroic.end_bucket_stategy");
 
     private final String id;
 

--- a/heroic-component/src/main/java/com/spotify/heroic/common/Features.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/Features.java
@@ -40,6 +40,7 @@ public class Features {
      */
     public static final Features DEFAULT = Features.create(ImmutableSet.<Feature>builder()
         .add(Feature.SHIFT_RANGE)
+        .add(Feature.END_BUCKET)
         .build());
 
     private final Set<Feature> features;

--- a/heroic-component/src/test/java/com/spotify/heroic/aggregation/BucketStrategyTest.java
+++ b/heroic-component/src/test/java/com/spotify/heroic/aggregation/BucketStrategyTest.java
@@ -1,0 +1,43 @@
+package com.spotify.heroic.aggregation;
+
+import static org.junit.Assert.assertEquals;
+
+import com.spotify.heroic.common.DateRange;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class BucketStrategyTest {
+    @Test
+    public void testEnd() {
+        final BucketStrategy.Mapping mapping =
+            BucketStrategy.END.setup(new DateRange(10, 30), 10, 10);
+
+        final Map<Long, BucketStrategy.StartEnd> fromTo = new HashMap<>();
+
+        // underflow
+        for (long ts = 0L; ts <= 10L; ts++) {
+            fromTo.put(ts, new BucketStrategy.StartEnd(0, 0));
+        }
+
+        // first bucket
+        for (long ts = 11L; ts <= 20L; ts++) {
+            fromTo.put(ts, new BucketStrategy.StartEnd(0, 1));
+        }
+
+        // second bucket
+        for (long ts = 21L; ts <= 30L; ts++) {
+            fromTo.put(ts, new BucketStrategy.StartEnd(1, 2));
+        }
+
+        // overflow
+        for (long ts = 31L; ts <= 40L; ts++) {
+            fromTo.put(ts, new BucketStrategy.StartEnd(2, 2));
+        }
+
+        for (final Map.Entry<Long, BucketStrategy.StartEnd> e : fromTo.entrySet()) {
+            assertEquals("Expected same mapping for timestamp " + e.getKey(), e.getValue(),
+                mapping.map(e.getKey()));
+        }
+    }
+}

--- a/heroic-component/src/test/java/com/spotify/heroic/aggregation/GroupingAggregationTest.java
+++ b/heroic-component/src/test/java/com/spotify/heroic/aggregation/GroupingAggregationTest.java
@@ -1,29 +1,28 @@
 package com.spotify.heroic.aggregation;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.metric.Point;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GroupingAggregationTest {

--- a/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
@@ -28,6 +28,7 @@ import com.spotify.heroic.aggregation.AggregationCombiner;
 import com.spotify.heroic.aggregation.AggregationContext;
 import com.spotify.heroic.aggregation.AggregationFactory;
 import com.spotify.heroic.aggregation.AggregationInstance;
+import com.spotify.heroic.aggregation.BucketStrategy;
 import com.spotify.heroic.aggregation.DistributedAggregationCombiner;
 import com.spotify.heroic.aggregation.Empty;
 import com.spotify.heroic.cache.QueryCache;
@@ -242,10 +243,15 @@ public class CoreQueryManager implements QueryManager {
                     shardWatch.end()));
             }
 
+            final BucketStrategy bucketStrategy =
+                features.withFeature(Feature.END_BUCKET, () -> BucketStrategy.END, () -> {
+                    throw new IllegalArgumentException(Feature.END_BUCKET + ": must be set");
+                });
+
             final AggregationCombiner combiner;
 
             if (isDistributed) {
-                combiner = DistributedAggregationCombiner.create(root, range);
+                combiner = DistributedAggregationCombiner.create(root, range, bucketStrategy);
             } else {
                 combiner = AggregationCombiner.DEFAULT;
             }


### PR DESCRIPTION
This moves the specific implementation for how a bucket strategy is performed into the `BucketStrategy` interface.

This is intended to set us up so that we can eventually switch from the current `(end - extent, end]` (`BucketStrategy.END`) bucket interval, to `[start, start + extent)` (`BucketStrategy.START`).

To maintain backwards compatibility when the alternative implementation is introduced, a new feature (`com.spotify.heroic.end_bucket_strategy`) is introduced and enabled by default.