### PR TITLE
[core] Explicitly close connection for failed nodes

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/cluster/CoreClusterManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/cluster/CoreClusterManager.java
@@ -452,6 +452,10 @@ public class CoreClusterManager implements ClusterManager, LifeCycles {
                     ok.add(s);
                 }, error -> {
                     log.error("{} [failed] {}", id, error.getUri(), error.getError());
+                    ClusterNode toRemove = oldClients.get(error.getUri());
+                    if (toRemove != null) {
+                        removals.add(toRemove.close());
+                    }
                 });
             });
 


### PR DESCRIPTION
When the cluster manager refreshes the cluster regularly, it will notice
if a node is down and remove it from the list of active nodes. This
works well. However, this commit ensures that the channel (containing
the actual tcp/ip connection) is also really closed. This fixes a
resource leak where sockets would not be closed.