### PR TITLE
Revert "[core] Explicitly close connection for failed nodes"

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/cluster/CoreClusterManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/cluster/CoreClusterManager.java
@@ -452,10 +452,6 @@ public class CoreClusterManager implements ClusterManager, LifeCycles {
                     ok.add(s);
                 }, error -> {
                     log.error("{} [failed] {}", id, error.getUri(), error.getError());
-                    ClusterNode toRemove = oldClients.get(error.getUri());
-                    if (toRemove != null) {
-                        removals.add(toRemove.close());
-                    }
                 });
             });
 


### PR DESCRIPTION
This reverts commit 58b2f5295fd4dac6539b2bf9586694f4aa717468.

It might be that this change made ongoing rpc calls be cancelled - which isn't retried. Let's try reverting it.