### PR TITLE
[core] Correct logging of cluster update (& less verbose)

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/cluster/CoreClusterManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/cluster/CoreClusterManager.java
@@ -443,7 +443,7 @@ public class CoreClusterManager implements ClusterManager, LifeCycles {
 
             updates.forEach(update -> {
                 update.handle(s -> {
-                    if (!s.isAdded()) {
+                    if (s.isAdded()) {
                         log.info("{} [new] {}", id, s.getUri());
                     }
 


### PR DESCRIPTION
Existing nodes that hadn't changed were logged as 'new', and new nodes
weren't logged at all.