### PR TITLE
Recover from RPC cancellation

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/cluster/ClusterShard.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/cluster/ClusterShard.java
@@ -23,6 +23,7 @@ package com.spotify.heroic.cluster;
 
 import com.spotify.heroic.metric.QueryTrace;
 import com.spotify.heroic.metric.RuntimeNodeException;
+import com.spotify.heroic.statistics.QueryReporter;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.RetryException;
@@ -47,6 +48,7 @@ public class ClusterShard {
 
     private final Map<String, String> shard;
     private final List<ClusterNode.Group> groups;
+    private final QueryReporter reporter;
 
     public <T> AsyncFuture<T> apply(
         Function<ClusterNode.Group, AsyncFuture<T>> function,
@@ -77,11 +79,12 @@ public class ClusterShard {
             .retryUntilResolved(() -> {
                 final ClusterNode.Group next = it.next();
                 return function.apply(next).catchFailed(throwable -> {
+                    reporter.reportClusterNodeRpcError();
                     /* Actually never return;s, instead throws a new exception with added info.
                      * The point is to get Node identifying information into the exception */
                     throw new RuntimeNodeException(next.toString(), throwable.getMessage(),
                         throwable);
-                });
+                }).onCancelled(() -> reporter.reportClusterNodeRpcCancellation());
             }, iteratorPolicy)
             .directTransform(retryResult -> handleRetryTraceFn.apply(retryResult.getResult(),
                 queryTracesFromRetries(retryResult.getErrors(), retryResult.getBackoffTimings())));

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/RuntimeNodeException.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/RuntimeNodeException.java
@@ -27,6 +27,10 @@ import lombok.Data;
 public class RuntimeNodeException extends RuntimeException {
     private final String uri;
 
+    public RuntimeNodeException(final String uri, final String message) {
+        this(uri, message, null);
+    }
+
     public RuntimeNodeException(final String uri, final String message, Throwable cause) {
         super(message, cause);
         this.uri = uri;

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/HeroicReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/HeroicReporter.java
@@ -37,7 +37,7 @@ public interface HeroicReporter {
 
     MetricBackendReporter newMetricBackend();
 
-    ApiReporter newApiReporter();
+    QueryReporter newQueryReporter();
 
     void registerShards(Set<Map<String, String>> knownShards);
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/QueryReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/QueryReporter.java
@@ -21,7 +21,7 @@
 
 package com.spotify.heroic.statistics;
 
-public interface ApiReporter {
+public interface QueryReporter {
     /**
      * Report on a full query, on an API node level
      */
@@ -35,4 +35,7 @@ public interface ApiReporter {
      * @param duration Duration of query, in ms
      */
     void reportSmallQueryLatency(long duration);
+
+    void reportClusterNodeRpcError();
+    void reportClusterNodeRpcCancellation();
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopHeroicReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopHeroicReporter.java
@@ -21,7 +21,7 @@
 
 package com.spotify.heroic.statistics.noop;
 
-import com.spotify.heroic.statistics.ApiReporter;
+import com.spotify.heroic.statistics.QueryReporter;
 import com.spotify.heroic.statistics.AnalyticsReporter;
 import com.spotify.heroic.statistics.ConsumerReporter;
 import com.spotify.heroic.statistics.HeroicReporter;
@@ -65,8 +65,8 @@ public class NoopHeroicReporter implements HeroicReporter {
     }
 
     @Override
-    public ApiReporter newApiReporter() {
-        return NoopApiReporter.get();
+    public QueryReporter newQueryReporter() {
+        return NoopQueryReporter.get();
     }
 
     @Override

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopQueryReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopQueryReporter.java
@@ -21,13 +21,13 @@
 
 package com.spotify.heroic.statistics.noop;
 
-import com.spotify.heroic.statistics.ApiReporter;
+import com.spotify.heroic.statistics.QueryReporter;
 import com.spotify.heroic.statistics.FutureReporter;
 
-public class NoopApiReporter implements ApiReporter {
-    private static final NoopApiReporter INSTANCE = new NoopApiReporter();
+public class NoopQueryReporter implements QueryReporter {
+    private static final NoopQueryReporter INSTANCE = new NoopQueryReporter();
 
-    public static NoopApiReporter get() {
+    public static NoopQueryReporter get() {
         return INSTANCE;
     }
 
@@ -38,5 +38,13 @@ public class NoopApiReporter implements ApiReporter {
 
     @Override
     public void reportSmallQueryLatency(final long duration) {
+    }
+
+    @Override
+    public void reportClusterNodeRpcError() {
+    }
+
+    @Override
+    public void reportClusterNodeRpcCancellation() {
     }
 }

--- a/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
@@ -67,7 +67,7 @@ import com.spotify.heroic.metric.WriteMetric;
 import com.spotify.heroic.querylogging.QueryContext;
 import com.spotify.heroic.querylogging.QueryLogger;
 import com.spotify.heroic.querylogging.QueryLoggerFactory;
-import com.spotify.heroic.statistics.ApiReporter;
+import com.spotify.heroic.statistics.QueryReporter;
 import com.spotify.heroic.suggest.KeySuggest;
 import com.spotify.heroic.suggest.TagKeyCount;
 import com.spotify.heroic.suggest.TagSuggest;
@@ -107,7 +107,7 @@ public class CoreQueryManager implements QueryManager {
     private final QueryCache queryCache;
     private final AggregationFactory aggregations;
     private final OptionalLimit groupLimit;
-    private final ApiReporter reporter;
+    private final QueryReporter reporter;
     private final QueryLogger queryLogger;
 
     private final long smallQueryThreshold;
@@ -117,7 +117,7 @@ public class CoreQueryManager implements QueryManager {
         @Named("features") final Features features, final AsyncFramework async, final Clock clock,
         final ClusterManager cluster, final QueryParser parser, final QueryCache queryCache,
         final AggregationFactory aggregations, @Named("groupLimit") final OptionalLimit groupLimit,
-        @Named("smallQueryThreshold") final long smallQueryThreshold, final ApiReporter reporter,
+        @Named("smallQueryThreshold") final long smallQueryThreshold, final QueryReporter reporter,
         final QueryLoggerFactory queryLoggerFactory
     ) {
         this.features = features;

--- a/heroic-core/src/main/java/com/spotify/heroic/QueryModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/QueryModule.java
@@ -22,7 +22,7 @@
 package com.spotify.heroic;
 
 import com.spotify.heroic.common.OptionalLimit;
-import com.spotify.heroic.statistics.ApiReporter;
+import com.spotify.heroic.statistics.QueryReporter;
 import com.spotify.heroic.statistics.HeroicReporter;
 import dagger.Module;
 import dagger.Provides;
@@ -51,7 +51,7 @@ public class QueryModule {
 
     @Provides
     @QueryScope
-    public ApiReporter apiReporter(HeroicReporter heroicReporter) {
-        return heroicReporter.newApiReporter();
+    public QueryReporter queryReporter(HeroicReporter heroicReporter) {
+        return heroicReporter.newQueryReporter();
     }
 }

--- a/heroic-core/src/main/java/com/spotify/heroic/cluster/ClusterManagerModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/cluster/ClusterManagerModule.java
@@ -36,6 +36,8 @@ import com.spotify.heroic.lifecycle.LifeCycle;
 import com.spotify.heroic.lifecycle.LifeCycleManager;
 import com.spotify.heroic.metadata.MetadataComponent;
 import com.spotify.heroic.metric.MetricComponent;
+import com.spotify.heroic.statistics.HeroicReporter;
+import com.spotify.heroic.statistics.QueryReporter;
 import com.spotify.heroic.suggest.SuggestComponent;
 import dagger.Module;
 import dagger.Provides;
@@ -92,6 +94,12 @@ public class ClusterManagerModule {
     @Named("topology")
     public Set<Map<String, String>> topology() {
         return topology;
+    }
+
+    @Provides
+    @ClusterScope
+    public QueryReporter queryReporter(HeroicReporter heroicReporter) {
+        return heroicReporter.newQueryReporter();
     }
 
     @Provides

--- a/heroic-core/src/test/java/com/spotify/heroic/CoreQueryManagerTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/CoreQueryManagerTest.java
@@ -14,7 +14,7 @@ import com.spotify.heroic.common.OptionalLimit;
 import com.spotify.heroic.grammar.QueryParser;
 import com.spotify.heroic.querylogging.QueryLogger;
 import com.spotify.heroic.querylogging.QueryLoggerFactory;
-import com.spotify.heroic.statistics.ApiReporter;
+import com.spotify.heroic.statistics.QueryReporter;
 import com.spotify.heroic.time.Clock;
 import eu.toolchain.async.AsyncFramework;
 import org.junit.Before;
@@ -44,7 +44,7 @@ public class CoreQueryManagerTest {
 
     @Before
     public void setup() {
-        ApiReporter apiReporter = mock(ApiReporter.class);
+        QueryReporter queryReporter = mock(QueryReporter.class);
         long smallQueryThreshold = 0;
 
         QueryLogger queryLogger = mock(QueryLogger.class);
@@ -52,7 +52,7 @@ public class CoreQueryManagerTest {
         when(queryLoggerFactory.create(any())).thenReturn(queryLogger);
 
         manager = new CoreQueryManager(Features.empty(), async, Clock.system(), cluster, parser,
-            queryCache, aggregations, OptionalLimit.empty(), smallQueryThreshold, apiReporter,
+            queryCache, aggregations, OptionalLimit.empty(), smallQueryThreshold, queryReporter,
             queryLoggerFactory);
     }
 

--- a/heroic-core/src/test/java/com/spotify/heroic/cluster/CoreClusterManagerTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/cluster/CoreClusterManagerTest.java
@@ -4,12 +4,14 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableSet;
 import com.spotify.heroic.HeroicConfiguration;
 import com.spotify.heroic.HeroicContext;
 import com.spotify.heroic.scheduler.Scheduler;
+import com.spotify.heroic.statistics.QueryReporter;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import java.util.Map;
@@ -48,6 +50,9 @@ public class CoreClusterManagerTest {
     @Mock
     HeroicContext context;
 
+    @Mock
+    private QueryReporter reporter;
+
     private CoreClusterManager manager;
 
     @Before
@@ -55,7 +60,7 @@ public class CoreClusterManagerTest {
         final boolean useLocal = true;
 
         manager = spy(new CoreClusterManager(async, discovery, localMetadata, protocols, scheduler,
-            useLocal, options, local, context, ImmutableSet.of()));
+            useLocal, options, local, context, ImmutableSet.of(), reporter));
     }
 
     @Test
@@ -63,5 +68,7 @@ public class CoreClusterManagerTest {
         doReturn(voidFuture).when(manager).refreshDiscovery(any(String.class));
         assertEquals(voidFuture, manager.refresh());
         verify(manager).refreshDiscovery(any(String.class));
+        verify(reporter, times(0)).reportClusterNodeRpcError();
+        verify(reporter, times(0)).reportClusterNodeRpcCancellation();
     }
 }

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticHeroicReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticHeroicReporter.java
@@ -21,7 +21,7 @@
 
 package com.spotify.heroic.statistics.semantic;
 
-import com.spotify.heroic.statistics.ApiReporter;
+import com.spotify.heroic.statistics.QueryReporter;
 import com.spotify.heroic.statistics.AnalyticsReporter;
 import com.spotify.heroic.statistics.ClusteredManager;
 import com.spotify.heroic.statistics.ConsumerReporter;
@@ -76,8 +76,8 @@ public class SemanticHeroicReporter implements HeroicReporter {
     }
 
     @Override
-    public ApiReporter newApiReporter() {
-        return new SemanticApiReporter(registry);
+    public QueryReporter newQueryReporter() {
+        return new SemanticQueryReporter(registry);
     }
 
     @Override


### PR DESCRIPTION
Sometimes an RPC call to a node in the cluster may be cancelled. This
used to cause the whole query to be cancelled. This PR does two things:
* Adds metrics so that we know how often RPC calls gets errors and cancellations
* Now Heroic simply retries with the next node in the shard, when an RPC call was cancelled.

Possibly, the metrics should have their own reporter. However, I chose to put them in the same as the query metrics now, since it's quite related.
