### PR TITLE
Handle RPC cancellations

### DIFF
--- a/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcProtocol.java
+++ b/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcProtocol.java
@@ -140,9 +140,10 @@ public class GrpcRpcProtocol implements RpcProtocol {
         });
 
         /* close managed channel on errors */
-        return setup.lazyCatchFailed(e -> channel
-            .stop()
-            .lazyTransform(v -> async.<ClusterNode>failed(e)));
+        return setup
+            .lazyCatchFailed(e -> channel.stop().lazyTransform(v -> async.<ClusterNode>failed(e)))
+            .lazyCatchCancelled(
+                ignore -> channel.stop().lazyTransform(v -> async.<ClusterNode>cancelled()));
     }
 
     @Override


### PR DESCRIPTION
RPC calls that get cancelled unexpectedly should be handled. These commits make them be handled in a similar way as errors. Thus a cancelled 'metadata' RPC call in the cluster refresh will cause the node to be removed from the list of active nodes. Similarly for a cancelled initial 'metadata' RPC call directly after connect.
This also makes the grpc layer close the channel if the initial metadata RPC call is cancelled, just like it already does for errors. Potentially, this would otherwise be a rare tcp/ip socket leak.