### PR TITLE
Add metrics for metric backend reads

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/metric/FetchQuotaWatcher.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/FetchQuotaWatcher.java
@@ -43,6 +43,13 @@ public interface FetchQuotaWatcher {
     int getReadDataQuota();
 
     /**
+     * Indicates that backend did access {@code n} more rows
+     *
+     * @param n The number of rows accessed by the backend.
+     */
+    void accessedRows(long n);
+
+    /**
      * Special quota watcher indicating no quota should be applied.
      */
     FetchQuotaWatcher NO_QUOTA = new FetchQuotaWatcher() {
@@ -58,6 +65,10 @@ public interface FetchQuotaWatcher {
         @Override
         public int getReadDataQuota() {
             return Integer.MAX_VALUE;
+        }
+
+        @Override
+        public void accessedRows(final long n) {
         }
     };
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/DataInMemoryReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/DataInMemoryReporter.java
@@ -27,6 +27,13 @@ package com.spotify.heroic.statistics;
  */
 public interface DataInMemoryReporter {
     /**
+     * report that rows in metric backend has been accessed
+     *
+     * @param n amount of rows
+     */
+    void reportRowsAccessed(long n);
+
+    /**
      * report that data has been read into memory
      *
      * @param n amount of data

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
@@ -30,6 +30,10 @@ public class NoopMetricBackendReporter implements MetricBackendReporter {
 
     public static final DataInMemoryReporter DATA_IN_MEMORY_REPORTER = new DataInMemoryReporter() {
         @Override
+        public void reportRowsAccessed(final long n) {
+        }
+
+        @Override
         public void reportDataHasBeenRead(final long n) {
 
         }

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -176,14 +176,14 @@ public class LocalMetricManager implements MetricManager {
                     throw new IllegalArgumentException(Feature.END_BUCKET + ": must be set");
                 });
 
+            final DataInMemoryReporter dataInMemoryReporter = reporter.newDataInMemoryReporter();
+
             final QuotaWatcher watcher = new QuotaWatcher(
                 options.getDataLimit().orElse(dataLimit).asLong().orElse(Long.MAX_VALUE), options
                 .getAggregationLimit()
                 .orElse(aggregationLimit)
                 .asLong()
-                .orElse(Long.MAX_VALUE), reporter.newDataInMemoryReporter());
-
-            final DataInMemoryReporter dataInMemoryReporter = reporter.newDataInMemoryReporter();
+                .orElse(Long.MAX_VALUE), dataInMemoryReporter);
 
             final OptionalLimit seriesLimit =
                 options.getSeriesLimit().orElse(LocalMetricManager.this.seriesLimit);
@@ -565,6 +565,11 @@ public class LocalMetricManager implements MetricManager {
         @Override
         public int getReadDataQuota() {
             return getLeft(dataLimit, read.get());
+        }
+
+        @Override
+        public void accessedRows(final long n) {
+            dataInMemoryReporter.reportRowsAccessed(n);
         }
 
         @Override

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
@@ -440,13 +440,14 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
             }));
         }
 
-        return async.collect(fetches, FetchData.collect(FETCH));
+        return async
+            .collect(fetches, FetchData.collect(FETCH))
+            .onResolved(ignore -> watcher.accessedRows(prepared.size()));
     }
 
     private AsyncFuture<FetchData.Result> fetchBatch(
-        final FetchQuotaWatcher watcher, final MetricType type,
-        final List<PreparedQuery> prepared, final BigtableConnection c,
-        final Consumer<MetricCollection> metricsConsumer
+        final FetchQuotaWatcher watcher, final MetricType type, final List<PreparedQuery> prepared,
+        final BigtableConnection c, final Consumer<MetricCollection> metricsConsumer
     ) {
         final BigtableDataClient client = c.dataClient();
 
@@ -477,7 +478,9 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
                 return FetchData.result(fs.end());
             }));
         }
-        return async.collect(fetches, FetchData.collectResult(FETCH));
+        return async
+            .collect(fetches, FetchData.collectResult(FETCH))
+            .onResolved(ignore -> watcher.accessedRows(prepared.size()));
     }
 
     <T> ByteString serialize(T rowKey, Serializer<T> serializer) throws IOException {


### PR DESCRIPTION
* query-metrics-samples-read - Per-query histogram of number of samples
  read from metric backend on data-node
* query-metrics-rows-accessed - Per-query histogram of number of rows in
  metric backend that was accessed on data-node. Can give an additional
  indication of the load that the query put on the backend.