### PR TITLE
[component,core,tools] Add rawSampleSize in query log

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetricsResponse.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetricsResponse.java
@@ -32,10 +32,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.UUID;
-
 import lombok.Data;
 import lombok.NonNull;
 
@@ -63,6 +63,9 @@ public class QueryMetricsResponse {
     @NonNull
     private final ResultLimits limits;
 
+    @NonNull
+    private final Optional<Long> preAggregationSampleSize;
+
     public static class Serializer extends JsonSerializer<QueryMetricsResponse> {
         @Override
         public void serialize(
@@ -83,6 +86,8 @@ public class QueryMetricsResponse {
 
             g.writeFieldName("result");
             serializeResult(g, common, result);
+
+            g.writeObjectField("preAggregationSampleSize", response.getPreAggregationSampleSize());
 
             g.writeFieldName("errors");
             serializeErrors(g, response.getErrors());
@@ -241,7 +246,7 @@ public class QueryMetricsResponse {
 
     public Summary summarize() {
         return new Summary(range, ShardedResultGroup.summarize(result), statistics, errors, trace,
-            limits);
+            limits, preAggregationSampleSize);
     }
 
     // Only include data suitable to log to query log
@@ -253,5 +258,6 @@ public class QueryMetricsResponse {
         private final List<RequestError> errors;
         private final QueryTrace trace;
         private final ResultLimits limits;
+        private final Optional<Long> preAggregationSampleSize;
     }
 }

--- a/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryResource.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryResource.java
@@ -156,7 +156,8 @@ public class QueryResource {
                     final QueryResult r = e.getRight();
                     final QueryMetricsResponse qmr =
                         new QueryMetricsResponse(queryContext.getQueryId(), r.getRange(),
-                            r.getGroups(), r.getErrors(), r.getTrace(), r.getLimits());
+                            r.getGroups(), r.getErrors(), r.getTrace(), r.getLimits(),
+                            Optional.of(r.getPreAggregationSampleSize()));
 
                     queryLogger.logFinalResponse(queryContext, qmr);
 
@@ -180,7 +181,8 @@ public class QueryResource {
         httpAsync.bind(response, callback, r -> {
             QueryMetricsResponse qmr =
                 new QueryMetricsResponse(queryContext.getQueryId(), r.getRange(), r.getGroups(),
-                    r.getErrors(), r.getTrace(), r.getLimits());
+                    r.getErrors(), r.getTrace(), r.getLimits(),
+                    Optional.of(r.getPreAggregationSampleSize()));
             queryLogger.logFinalResponse(queryContext, qmr);
             return qmr;
         });

--- a/heroic-core/src/test/java/com/spotify/heroic/metric/BasicSerializationTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/metric/BasicSerializationTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.junit.Test;
@@ -77,7 +78,8 @@ public class BasicSerializationTest {
         final ResultLimits limits = ResultLimits.of();
 
         final QueryMetricsResponse toVerify =
-            new QueryMetricsResponse(queryId, range, result, errors, trace, limits);
+            new QueryMetricsResponse(queryId, range, result, errors, trace, limits,
+                Optional.empty());
 
         assertSerialization("QueryMetricsResponse.json", toVerify);
     }

--- a/heroic-core/src/test/resources/com/spotify/heroic/metric/QueryMetricsResponse.json
+++ b/heroic-core/src/test/resources/com/spotify/heroic/metric/QueryMetricsResponse.json
@@ -25,5 +25,6 @@
       "tagCounts": {}
     }
   ],
+  "preAggregationSampleSize":null,
   "errors": []
 }

--- a/tools/querylog_mappings.yaml
+++ b/tools/querylog_mappings.yaml
@@ -142,3 +142,6 @@ _common:
         errors: *request_error
         trace: *raw_object
         limits: *raw_string
+        rawSampleSize:
+          type: long
+


### PR DESCRIPTION
Expose in query response and query log a measurement of how many data points that were read from the metric backend. The measurement is done before aggregations etc, so gives an indication of how much load the query put on the metric backend.