### PR TITLE
[core] Fix query error output of node name

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/cluster/TracingClusterNode.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/cluster/TracingClusterNode.java
@@ -68,6 +68,10 @@ public class TracingClusterNode implements ClusterNode {
         return new Group(delegateNode.useOptionalGroup(group));
     }
 
+    public String toString() {
+        return delegateNode.toString();
+    }
+
     @RequiredArgsConstructor
     public class Group implements ClusterNode.Group {
         private final ClusterNode.Group delegateGroup;


### PR DESCRIPTION
This fixes a regression where the node name went missing in the
error field in the query response. Instead of a node name the
wrapper TracingClusterNode was shown. This commit fixes that.