### PR TITLE
[dist] Fix HeroicService param in help doc

### DIFF
--- a/heroic-dist/src/main/java/com/spotify/heroic/HeroicService.java
+++ b/heroic-dist/src/main/java/com/spotify/heroic/HeroicService.java
@@ -225,7 +225,7 @@ public class HeroicService {
         if (params.help) {
             parser.printUsage(System.out);
             System.out.println();
-            HeroicModules.printAllUsage(System.out, "-p");
+            HeroicModules.printAllUsage(System.out, "-P");
             return null;
         }
 


### PR DESCRIPTION
Correct parameter in HeroicService help
documentation #277 (use -P instead of -p)
in 'Available profiles' secton