### PR TITLE
Bigtable / grpc / netty, version bumps

### DIFF
--- a/metric/bigtable/pom.xml
+++ b/metric/bigtable/pom.xml
@@ -22,7 +22,7 @@
   </description>
 
   <properties>
-    <bigtable.version>0.9.4</bigtable.version>
+    <bigtable.version>0.9.6.2</bigtable.version>
   </properties>
 
   <dependencies>

--- a/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsModule.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsModule.java
@@ -40,15 +40,12 @@ import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.Managed;
 import eu.toolchain.async.ManagedSetup;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import javax.inject.Named;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
-
-import javax.inject.Named;
-import java.util.Optional;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-
 
 @ToString
 @RequiredArgsConstructor
@@ -85,16 +82,14 @@ public class BigtableAnalyticsModule implements AnalyticsModule {
 
     @Provides
     @BigtableScope
-    public Managed<BigtableConnection> connection(
-        final AsyncFramework async, final ExecutorService executorService
-    ) {
+    public Managed<BigtableConnection> connection(final AsyncFramework async) {
         return async.managed(new ManagedSetup<BigtableConnection>() {
             @Override
             public AsyncFuture<BigtableConnection> construct() throws Exception {
                 return async.call(
                     new BigtableConnectionBuilder(project, cluster, credentials, async,
-                        executorService, DEFAULT_DISABLE_BULK_MUTATIONS,
-                        DEFAULT_FLUSH_INTERVAL_SECONDS, Optional.empty()));
+                        DEFAULT_DISABLE_BULK_MUTATIONS, DEFAULT_FLUSH_INTERVAL_SECONDS,
+                        Optional.empty()));
             }
 
             @Override

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnectionBuilder.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnectionBuilder.java
@@ -36,12 +36,10 @@ import com.spotify.heroic.metric.bigtable.api.BigtableTableAdminClient;
 import com.spotify.heroic.metric.bigtable.api.BigtableTableTableAdminClientImpl;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
-
 import java.util.Optional;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
 @ToString(of = {"project", "instance", "credentials"})
 @RequiredArgsConstructor
@@ -54,7 +52,6 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
     private final CredentialsBuilder credentials;
 
     private final AsyncFramework async;
-    private final ExecutorService executorService;
 
     private final boolean disableBulkMutations;
     private final int flushIntervalSeconds;
@@ -83,11 +80,11 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
             .setBulkOptions(bulkOptions)
             .build();
 
-        final BigtableSession session = new BigtableSession(options, executorService);
+        final BigtableSession session = new BigtableSession(options);
 
         final BigtableTableAdminClient adminClient =
             new BigtableTableTableAdminClientImpl(async, session.getTableAdminClient(), project,
-              instance);
+                instance);
 
         final BigtableMutator mutator =
             new BigtableMutatorImpl(async, session, disableBulkMutations, flushIntervalSeconds);
@@ -95,8 +92,8 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
         final BigtableDataClient client =
             new BigtableDataClientImpl(async, session, mutator, project, instance);
 
-        return new GrpcBigtableConnection(
-            async, project, instance, session, mutator, adminClient, client);
+        return new GrpcBigtableConnection(async, project, instance, session, mutator, adminClient,
+            client);
     }
 
     @RequiredArgsConstructor

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableMetricModule.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableMetricModule.java
@@ -46,7 +46,6 @@ import eu.toolchain.async.Managed;
 import eu.toolchain.async.ManagedSetup;
 import eu.toolchain.serializer.Serializer;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
 import javax.inject.Named;
 import lombok.Data;
 
@@ -128,8 +127,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         @Provides
         @BigtableScope
         public Managed<BigtableConnection> connection(
-            final AsyncFramework async, final ExecutorService executorService,
-            final Lazy<FakeBigtableConnection> fakeBigtableConnection
+            final AsyncFramework async, final Lazy<FakeBigtableConnection> fakeBigtableConnection
         ) {
             if (fake) {
                 return async.managed(new ManagedSetup<BigtableConnection>() {
@@ -151,8 +149,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
                 public AsyncFuture<BigtableConnection> construct() throws Exception {
                     return async.call(
                         new BigtableConnectionBuilder(project, instance, credentials, async,
-                            executorService, disableBulkMutations, flushIntervalSeconds,
-                            batchSize));
+                            disableBulkMutations, flushIntervalSeconds, batchSize));
                 }
 
                 @Override
@@ -183,7 +180,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         @Provides
         @BigtableScope
         public Serializer<RowKey> rowKeySerializer() {
-           return new MetricsRowKeySerializer();
+            return new MetricsRowKeySerializer();
         }
 
         @Provides
@@ -255,7 +252,6 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
             this.disableBulkMutations = of(disableBulkMutations);
             return this;
         }
-
 
         public Builder flushIntervalSeconds(int flushIntervalSeconds) {
             this.flushIntervalSeconds = of(flushIntervalSeconds);

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <lucene.version>4.10.4</lucene.version>
     <datastax.version>3.0.2</datastax.version>
     <semantic-metrics.version>0.2.3</semantic-metrics.version>
-    <netty.version>4.1.0.CR3</netty.version>
+    <netty.version>4.1.8.Final</netty.version>
     <tiny-async.version>1.11.0</tiny-async.version>
     <tiny-serializer.version>1.4.5</tiny-serializer.version>
     <antlr.version>4.5</antlr.version>

--- a/repackaged/bigtable/pom.xml
+++ b/repackaged/bigtable/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <bigtable.version>0.9.4</bigtable.version>
+    <bigtable.version>0.9.6.2</bigtable.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
   </properties>
 
   <groupId>com.spotify.heroic.repackaged</groupId>
   <artifactId>bigtable-client-core</artifactId>
   <packaging>jar</packaging>
-  <version>0.9.4</version>
+  <version>0.9.6.2</version>
 
   <name>Heroic: Re-Packaging of Bigtable Client Utilities</name>
 

--- a/rpc/grpc/pom.xml
+++ b/rpc/grpc/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <properties>
-    <grpc.version>0.13.2</grpc.version>
+    <grpc.version>1.2.0</grpc.version>
   </properties>
 
   <groupId>com.spotify.heroic.rpc</groupId>


### PR DESCRIPTION
Upgrade bigtable client to 0.9.6.2, which requires updated grpc, which requires updated netty.