### PR TITLE
Add metrics for measuring query load

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/common/Histogram.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/Histogram.java
@@ -45,6 +45,10 @@ public class Histogram {
         return new Builder();
     }
 
+    public static Histogram empty() {
+        return builder().build();
+    }
+
     public static class Builder {
         private final TreeMultiset<Long> samples = TreeMultiset.create(Long::compareTo);
 

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/FullQuery.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/FullQuery.java
@@ -28,12 +28,14 @@ import com.spotify.heroic.aggregation.AggregationInstance;
 import com.spotify.heroic.cluster.ClusterShard;
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Features;
+import com.spotify.heroic.common.Histogram;
 import com.spotify.heroic.common.Statistics;
 import com.spotify.heroic.filter.Filter;
 import com.spotify.heroic.querylogging.QueryContext;
 import eu.toolchain.async.Collector;
 import eu.toolchain.async.Transform;
 import java.util.List;
+import java.util.Optional;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
@@ -45,15 +47,23 @@ public final class FullQuery {
     private final List<ResultGroup> groups;
     private final Statistics statistics;
     private final ResultLimits limits;
+    private final Optional<Histogram> dataDensity;
 
     public static FullQuery error(final QueryTrace trace, final RequestError error) {
         return new FullQuery(trace, ImmutableList.of(error), ImmutableList.of(), Statistics.empty(),
-            ResultLimits.of());
+            ResultLimits.of(), Optional.empty());
+    }
+
+    public static FullQuery limitsError(
+        final QueryTrace trace, final RequestError error, final ResultLimits limits
+    ) {
+        return new FullQuery(trace, ImmutableList.of(error), ImmutableList.of(), Statistics.empty(),
+            limits, Optional.empty());
     }
 
     public static FullQuery empty(final QueryTrace trace, final ResultLimits limits) {
         return new FullQuery(trace, ImmutableList.of(), ImmutableList.of(), Statistics.empty(),
-            limits);
+            limits, Optional.empty());
     }
 
     public static Collector<FullQuery, FullQuery> collect(final QueryTrace.Identifier what) {
@@ -75,7 +85,7 @@ public final class FullQuery {
             }
 
             return new FullQuery(w.end(traces.build()), errors.build(), groups.build(), statistics,
-                new ResultLimits(limits.build()));
+                new ResultLimits(limits.build()), Optional.empty());
         };
     }
 
@@ -83,20 +93,22 @@ public final class FullQuery {
         final QueryTrace.NamedWatch watch, final ClusterShard c
     ) {
         return e -> new FullQuery(watch.end(), ImmutableList.of(ShardError.fromThrowable(c, e)),
-            ImmutableList.of(), Statistics.empty(), ResultLimits.of());
+            ImmutableList.of(), Statistics.empty(), ResultLimits.of(), Optional.empty());
     }
 
     public static Transform<FullQuery, FullQuery> trace(final QueryTrace.Identifier what) {
         final QueryTrace.NamedWatch w = QueryTrace.watch(what);
-        return r -> new FullQuery(w.end(r.trace), r.errors, r.groups, r.statistics, r.limits);
+        return r -> new FullQuery(w.end(r.trace), r.errors, r.groups, r.statistics, r.limits,
+            r.dataDensity);
     }
 
     public FullQuery withTrace(QueryTrace newTrace) {
-        return new FullQuery(newTrace, errors, groups, statistics, limits);
+        return new FullQuery(newTrace, errors, groups, statistics, limits, dataDensity);
     }
 
     public Summary summarize() {
-        return new Summary(trace, errors, ResultGroup.summarize(groups), statistics, limits);
+        return new Summary(trace, errors, ResultGroup.summarize(groups), statistics, limits,
+            dataDensity.orElse(Histogram.empty()));
     }
 
     // Only include data suitable to log to query log
@@ -107,6 +119,7 @@ public final class FullQuery {
         private final ResultGroup.MultiSummary groups;
         private final Statistics statistics;
         private final ResultLimits limits;
+        private final Histogram dataDensity;
     }
 
     @Data

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/MetricCollection.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/MetricCollection.java
@@ -30,6 +30,7 @@ import com.spotify.heroic.aggregation.AggregationSession;
 import com.spotify.heroic.common.Series;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import lombok.AccessLevel;
@@ -101,6 +102,17 @@ public abstract class MetricCollection {
 
     public boolean isEmpty() {
         return data.isEmpty();
+    }
+
+    public Optional<Long> getAverageDistanceBetweenMetrics() {
+        if (data.size() <= 1) {
+            return Optional.empty();
+        }
+
+        final long timeDiff = data.get(data.size() - 1).getTimestamp() - data.get(0).getTimestamp();
+        final long spans = data.size() - 1;
+
+        return Optional.of(timeDiff / spans);
     }
 
     private static final MetricCollection empty = new EmptyMetricCollection();

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/DataInMemoryReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/DataInMemoryReporter.java
@@ -34,6 +34,13 @@ public interface DataInMemoryReporter {
     void reportRowsAccessed(long n);
 
     /**
+     * report the density of a row that was read from the metric backend
+     *
+     * @param msBetweenSamples density, number of samples per hour
+     */
+    void reportRowDensity(long msBetweenSamples);
+
+    /**
      * report that data has been read into memory
      *
      * @param n amount of data

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/QueryReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/QueryReporter.java
@@ -36,6 +36,9 @@ public interface QueryReporter {
      */
     void reportSmallQueryLatency(long duration);
 
+    void reportLatencyVsSize(long durationNs, long preAggregationSampleSize);
+
     void reportClusterNodeRpcError();
+
     void reportClusterNodeRpcCancellation();
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
@@ -34,6 +34,10 @@ public class NoopMetricBackendReporter implements MetricBackendReporter {
         }
 
         @Override
+        public void reportRowDensity(final long msBetweenSamples) {
+        }
+
+        @Override
         public void reportDataHasBeenRead(final long n) {
 
         }

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopQueryReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopQueryReporter.java
@@ -21,8 +21,8 @@
 
 package com.spotify.heroic.statistics.noop;
 
-import com.spotify.heroic.statistics.QueryReporter;
 import com.spotify.heroic.statistics.FutureReporter;
+import com.spotify.heroic.statistics.QueryReporter;
 
 public class NoopQueryReporter implements QueryReporter {
     private static final NoopQueryReporter INSTANCE = new NoopQueryReporter();
@@ -38,6 +38,10 @@ public class NoopQueryReporter implements QueryReporter {
 
     @Override
     public void reportSmallQueryLatency(final long duration) {
+    }
+
+    @Override
+    public void reportLatencyVsSize(final long durationNs, final long preAggregationSampleSize) {
     }
 
     @Override

--- a/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
@@ -297,8 +297,10 @@ public class CoreQueryManager implements QueryManager {
             if (sampleSize > smallQueryThreshold) {
                 return;
             }
-            final long duration = fullQueryWatch.elapsed(TimeUnit.MILLISECONDS);
-            reporter.reportSmallQueryLatency(duration);
+            final long durationNs = fullQueryWatch.elapsed(TimeUnit.NANOSECONDS);
+            reporter.reportLatencyVsSize(durationNs, result.getPreAggregationSampleSize());
+            final long durationMs = TimeUnit.NANOSECONDS.toMillis(durationNs);
+            reporter.reportSmallQueryLatency(durationMs);
         }
 
         @Override

--- a/heroic-core/src/test/java/com/spotify/heroic/metric/BasicSerializationTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/metric/BasicSerializationTest.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.spotify.heroic.common.DateRange;
+import com.spotify.heroic.common.Histogram;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.common.Statistics;
 import com.spotify.heroic.test.FakeModuleLoader;
@@ -58,7 +59,7 @@ public class BasicSerializationTest {
         final List<RequestError> errors = new ArrayList<>();
         final FullQuery expected =
             new FullQuery(QueryTrace.of(QueryTrace.identifier("test"), 0L), errors, groups,
-                Statistics.empty(), ResultLimits.of());
+                Statistics.empty(), ResultLimits.of(), Optional.empty());
 
         assertSerialization("FullQuery.json", expected, FullQuery.class);
     }

--- a/heroic-core/src/test/java/com/spotify/heroic/querylogging/Slf4jQueryLoggerTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/querylogging/Slf4jQueryLoggerTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.spotify.heroic.Query;
+import com.spotify.heroic.common.Histogram;
 import com.spotify.heroic.common.Statistics;
 import com.spotify.heroic.metric.FullQuery;
 import com.spotify.heroic.metric.QueryMetrics;
@@ -18,6 +19,7 @@ import com.spotify.heroic.metric.QueryMetricsResponse;
 import com.spotify.heroic.metric.QueryTrace;
 import com.spotify.heroic.metric.ResultLimits;
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.function.Consumer;
 import org.junit.Before;
 import org.junit.Test;
@@ -95,7 +97,7 @@ public class Slf4jQueryLoggerTest {
     public void testOutgoingResponseAtNode() {
         final FullQuery response =
             new FullQuery(QueryTrace.of(QueryTrace.identifier("test"), 0L), new ArrayList<>(),
-                new ArrayList<>(), Statistics.empty(), ResultLimits.of());
+                new ArrayList<>(), Statistics.empty(), ResultLimits.of(), Optional.empty());
         slf4jQueryLogger.logOutgoingResponseAtNode(queryContext, response);
         verify(logger, times(1)).accept(any(String.class));
     }
@@ -104,7 +106,7 @@ public class Slf4jQueryLoggerTest {
     public void testIncomingResponseFromShard() {
         final FullQuery response =
             new FullQuery(QueryTrace.of(QueryTrace.identifier("test"), 0L), new ArrayList<>(),
-                new ArrayList<>(), Statistics.empty(), ResultLimits.of());
+                new ArrayList<>(), Statistics.empty(), ResultLimits.of(), Optional.empty());
         slf4jQueryLogger.logIncomingResponseFromShard(queryContext, response);
         verify(logger, times(1)).accept(any(String.class));
     }

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
@@ -472,7 +472,7 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
             fetches.add(readRows.directTransform(result -> {
                 for (final FlatRow row : result) {
                     watcher.readData(row.getCells().size());
-                    List<Metric> metrics = Lists.transform(row.getCells(), transform);
+                    final List<Metric> metrics = Lists.transform(row.getCells(), transform);
                     metricsConsumer.accept(MetricCollection.build(type, metrics));
                 }
                 return FetchData.result(fs.end());

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
@@ -23,6 +23,7 @@ package com.spotify.heroic.statistics.semantic;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
+import com.google.common.base.Stopwatch;
 import com.spotify.heroic.QueryOptions;
 import com.spotify.heroic.async.AsyncObservable;
 import com.spotify.heroic.common.Groups;
@@ -43,6 +44,7 @@ import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricRegistry;
 import eu.toolchain.async.AsyncFuture;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAccumulator;
 import java.util.function.Consumer;
@@ -75,6 +77,8 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
     private final Histogram queryRowsAccessed;
     /* Maximum amount of data points in memory at any time for a query */
     private final Histogram queryMaxLiveSamples;
+    private final Histogram queryReadRate;
+    private final Histogram queryRowDensity;
 
     public SemanticMetricBackendReporter(SemanticMetricRegistry registry) {
         final MetricId base = MetricId.build().tagged("component", COMPONENT);
@@ -108,6 +112,10 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
             base.tagged("what", "query-metrics-rows-accessed", "unit", Units.COUNT));
         queryMaxLiveSamples = registry.histogram(
             base.tagged("what", "query-metrics-max-live-samples", "unit", Units.COUNT));
+        queryReadRate =
+            registry.histogram(base.tagged("what", "query-metrics-read-rate", "unit", Units.COUNT));
+        queryRowDensity = registry.histogram(
+            base.tagged("what", "query-metrics-row-density", "unit", Units.COUNT));
     }
 
     @Override
@@ -122,6 +130,7 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
             private final AtomicLong dataInMemory = new AtomicLong(0L);
             private final LongAccumulator rowsAccessed = new LongAccumulator((x, y) -> x + y, 0L);
             private final LongAccumulator maxDataInMemory = new LongAccumulator(Long::max, 0L);
+            private final Stopwatch queryWatch = Stopwatch.createStarted();
 
             @Override
             public void reportRowsAccessed(final long n) {
@@ -129,10 +138,16 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
             }
 
             @Override
+            public void reportRowDensity(final long msBetweenSamples) {
+                queryRowDensity.update(msBetweenSamples);
+            }
+
+            @Override
             public void reportDataHasBeenRead(final long n) {
                 dataRead.accumulate(n);
 
-                maxDataInMemory.accumulate(dataInMemory.addAndGet(n));
+                final long currDataInMemory = dataInMemory.addAndGet(n);
+                maxDataInMemory.accumulate(currDataInMemory);
 
                 sampleSizeLive.inc(n);
                 sampleSizeAccumulated.inc(n);
@@ -149,13 +164,21 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
             public void reportOperationEnded() {
                 // Decrement any remaining live memory
                 sampleSizeLive.dec(dataInMemory.get());
+
+                final long finalDataRead = dataRead.get();
                 /* The accumulated count has previously been incremented with all of the data read,
                  * so decrease the full amount now */
-                sampleSizeAccumulated.dec(dataRead.get());
+                sampleSizeAccumulated.dec(finalDataRead);
 
-                querySamplesRead.update(dataRead.get());
+                querySamplesRead.update(finalDataRead);
                 queryRowsAccessed.update(rowsAccessed.get());
                 queryMaxLiveSamples.update(maxDataInMemory.get());
+
+                final long durationNs = queryWatch.elapsed(TimeUnit.NANOSECONDS);
+                if (durationNs != 0) {
+                    // Amount of data read per second
+                    queryReadRate.update((1_000_000_000 * finalDataRead) / durationNs);
+                }
             }
         };
     }


### PR DESCRIPTION
query-metrics-max-live-samples - Maximum amount of data points in memory
at any time for a query.

query-sample-latency - Effectively the latency of 1 sample read. This
makes for a latency measurement that is comparable across queries. This
can be used to show if any query loaded the system more than what would
have been expected from just the number of samples.