### PR TITLE
[datastax] Upgrade & repackage Datastax driver

### DIFF
--- a/metric/datastax/pom.xml
+++ b/metric/datastax/pom.xml
@@ -16,6 +16,10 @@
 
   <name>Heroic: Datastax Backend</name>
 
+  <properties>
+    <datastax.version>3.2.0</datastax.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.projectlombok</groupId>
@@ -29,9 +33,9 @@
     </dependency>
 
     <dependency>
-      <groupId>com.datastax.cassandra</groupId>
-      <artifactId>cassandra-driver-core</artifactId>
-      <classifier>shaded</classifier>
+      <groupId>com.spotify.heroic.repackaged</groupId>
+      <artifactId>datastax-driver-core</artifactId>
+      <version>${datastax.version}</version>
     </dependency>
 
     <dependency>
@@ -62,4 +66,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
     <hk2.version>2.3.0</hk2.version>
     <jetty.version>9.3.7.v20160115</jetty.version>
     <lucene.version>4.10.4</lucene.version>
-    <datastax.version>3.0.2</datastax.version>
     <semantic-metrics.version>0.2.3</semantic-metrics.version>
     <netty.version>4.1.8.Final</netty.version>
     <tiny-async.version>1.11.0</tiny-async.version>
@@ -248,6 +247,7 @@
 
       <modules>
         <module>repackaged/bigtable</module>
+        <module>repackaged/datastax</module>
       </modules>
     </profile>
   </profiles>
@@ -475,20 +475,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>3.3.2</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.datastax.cassandra</groupId>
-        <artifactId>cassandra-driver-core</artifactId>
-        <classifier>shaded</classifier>
-        <version>${datastax.version}</version>
-
-        <exclusions>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <!-- useful collections and utilities -->

--- a/repackaged/datastax/pom.xml
+++ b/repackaged/datastax/pom.xml
@@ -1,0 +1,62 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <properties>
+    <datastax.version>3.2.0</datastax.version>
+  </properties>
+
+  <groupId>com.spotify.heroic.repackaged</groupId>
+  <artifactId>datastax-driver-core</artifactId>
+  <packaging>jar</packaging>
+  <version>3.2.0</version>
+
+  <name>Heroic: Re-Packaging of Datastax Driver</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-core</artifactId>
+      <version>${datastax.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <!-- excluded dependencies will be kept as a promoted dependency -->
+              <artifactSet>
+                <excludes>
+                </excludes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>io.netty</pattern>
+                  <!-- The datastax driver specifically tries to load io.netty.x.y with fall back to com.datastax.shaded.netty.x.y -->
+                  <shadedPattern>com.datastax.shaded.netty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.codahale.metrics</pattern>
+                  <shadedPattern>com.spotify.heroic.datastax.metrics</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+


### PR DESCRIPTION
NOTE: You need to re-run ./tools/install-repackaged after this commit.

* Upgrades Datastax driver to 3.2.0
* Isolates the Datastax driver so that its dependencies doesn't clash
with other Heroic dependencies.