### PR TITLE
[rpc/grpc] Actually use maxFrameSize option

### DIFF
--- a/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcProtocol.java
+++ b/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcProtocol.java
@@ -115,6 +115,7 @@ public class GrpcRpcProtocol implements RpcProtocol {
                     .usePlaintext(true)
                     .executor(workerGroup)
                     .eventLoopGroup(workerGroup)
+                    .maxInboundMessageSize(maxFrameSize)
                     .build();
 
                 return async.resolved(channel);


### PR DESCRIPTION
There was already an option maxFrameSize in the Grpc module, but it
wasn't being honoured. Now it is.