### PR TITLE
Better min/max statistics for high-rate Histograms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -737,15 +737,15 @@
 
       <!-- testing -->
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>java-hamcrest</artifactId>
         <version>${hamcrest.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/statistics/semantic/pom.xml
+++ b/statistics/semantic/pom.xml
@@ -44,6 +44,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>java-hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/HistogramBuilder.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/HistogramBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.statistics.semantic;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Metric;
+import com.spotify.metrics.core.SemanticMetricBuilder;
+import java.util.concurrent.TimeUnit;
+
+public class HistogramBuilder {
+    public static final SemanticMetricBuilder<Histogram> HISTOGRAM =
+        new SemanticMetricBuilder<Histogram>() {
+            public Histogram newMetric() {
+                return new Histogram(
+                    // A min/max value will stay around for 2 * 30 seconds
+                    new MinMaxSlidingTimeReservoir(Clock.defaultClock(), 2, 30, TimeUnit.SECONDS,
+                        new ExponentiallyDecayingReservoir()));
+            }
+
+            public boolean isInstance(Metric metric) {
+                return Histogram.class.isInstance(metric);
+            }
+        };
+}

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoir.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoir.java
@@ -1,0 +1,135 @@
+package com.spotify.heroic.statistics.semantic;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Reservoir;
+import com.codahale.metrics.Snapshot;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+public class MinMaxSlidingTimeReservoir implements Reservoir {
+    // max spins until calling Thread.yield()
+    private static final int MAX_SPINS = 4;
+
+    private final ConcurrentSkipListMap<Long, AtomicReference<MinMaxEntry>> measurements;
+    private final int size;
+    private final Clock clock;
+    private final long step;
+    private final Reservoir delegate;
+
+    /**
+     * Build a new reservoir.
+     *
+     * @param clock Clock to use as a time source
+     * @param size Number of buckets to maintain
+     * @param step Step between each bucket
+     * @param delegate Delegate reservoir that min/max is being corrected for.
+     */
+    public MinMaxSlidingTimeReservoir(
+        final Clock clock, final int size, final long step, final Reservoir delegate
+    ) {
+        this.measurements = new ConcurrentSkipListMap<>();
+        this.clock = clock;
+        this.size = size;
+        this.step = step;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public void update(long value) {
+        trimIfNeeded();
+
+        final long offset = clock.getTick() / step;
+
+        final AtomicReference<MinMaxEntry> reference = measurements.computeIfAbsent(offset,
+            o -> new AtomicReference<>(new MinMaxEntry(value, value)));
+
+        int spins = 0;
+
+        while (true) {
+            final MinMaxEntry old = reference.get();
+
+            if (old.min <= value && value <= old.max) {
+                break;
+            }
+
+            final MinMaxEntry newEntry =
+                new MinMaxEntry(Math.min(old.min, value), Math.max(old.max, value));
+
+            if (reference.compareAndSet(old, newEntry)) {
+                break;
+            }
+
+            if (spins++ >= MAX_SPINS) {
+                Thread.yield();
+                spins = 0;
+            }
+        }
+
+        delegate.update(value);
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        trimIfNeeded();
+
+        final long first = calculateFirstBucket();
+
+        final Optional<MinMaxEntry> value = measurements
+            .tailMap(first)
+            .values()
+            .stream()
+            .map(AtomicReference::get)
+            .reduce((a, b) -> new MinMaxEntry(Math.min(a.min, b.min), Math.max(a.max, b.max)));
+
+        final Snapshot snapshot = delegate.getSnapshot();
+
+        return value.map(minMax -> {
+            final long[] values = snapshot.getValues();
+
+            if (values.length > 0) {
+                values[0] = Math.min(minMax.min, values[0]);
+                values[values.length - 1] = Math.max(minMax.max, values[values.length - 1]);
+            }
+
+            return new Snapshot(values);
+        }).orElse(snapshot);
+    }
+
+    /**
+     * Trim min-max entries before the first bucket.
+     */
+    private void trimIfNeeded() {
+        final long first = calculateFirstBucket();
+
+        final Map.Entry<Long, AtomicReference<MinMaxEntry>> firstEntry =
+            measurements.firstEntry();
+
+        if (firstEntry != null && firstEntry.getKey() <= first) {
+            // removes all entries older than first
+            measurements.headMap(first, true).clear();
+        }
+    }
+
+    /**
+     * Calculate the first possible bucket that is within the current time interval.
+     */
+    long calculateFirstBucket() {
+        return (clock.getTick() - (step * size)) / step;
+    }
+
+    @ToString
+    @RequiredArgsConstructor
+    private static class MinMaxEntry {
+        private final long min;
+        private final long max;
+    }
+}

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticConsumerReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticConsumerReporter.java
@@ -65,9 +65,11 @@ public class SemanticConsumerReporter implements ConsumerReporter {
         consumerThreadsLiveRatio = new SemanticRatioGauge();
         registry.register(base.tagged("what", "consumer-threads-live-ratio", "unit", Units.RATIO),
             consumerThreadsLiveRatio);
-        messageSize = registry.histogram(base.tagged("what", "message-size", "unit", Units.BYTE));
+        messageSize = registry.getOrAdd(base.tagged("what", "message-size", "unit", Units.BYTE),
+            HistogramBuilder.HISTOGRAM);
         messageDrift =
-            registry.histogram(base.tagged("what", "message-drift", "unit", Units.MILLISECOND));
+            registry.getOrAdd(base.tagged("what", "message-drift", "unit", Units.MILLISECOND),
+                HistogramBuilder.HISTOGRAM);
 
         consumer = new SemanticFutureReporter(registry,
             base.tagged("what", "consumer", "unit", Units.WRITE));

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
@@ -109,18 +109,24 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
         sampleSizeAccumulated =
             registry.counter(base.tagged("what", "sample-size-accumulated", "unit", Units.SAMPLE));
 
-        querySamplesRead = registry.histogram(
-            base.tagged("what", "query-metrics-samples-read", "unit", Units.COUNT));
-        queryRowsAccessed = registry.histogram(
-            base.tagged("what", "query-metrics-rows-accessed", "unit", Units.COUNT));
-        queryMaxLiveSamples = registry.histogram(
-            base.tagged("what", "query-metrics-max-live-samples", "unit", Units.COUNT));
+        querySamplesRead = registry.getOrAdd(
+            base.tagged("what", "query-metrics-samples-read", "unit", Units.COUNT),
+            HistogramBuilder.HISTOGRAM);
+        queryRowsAccessed = registry.getOrAdd(
+            base.tagged("what", "query-metrics-rows-accessed", "unit", Units.COUNT),
+            HistogramBuilder.HISTOGRAM);
+        queryMaxLiveSamples = registry.getOrAdd(
+            base.tagged("what", "query-metrics-max-live-samples", "unit", Units.COUNT),
+            HistogramBuilder.HISTOGRAM);
         queryReadRate =
-            registry.histogram(base.tagged("what", "query-metrics-read-rate", "unit", Units.COUNT));
-        queryRowMsBetweenSamples = registry.histogram(
-            base.tagged("what", "query-metrics-row-metric-distance", "unit", Units.MILLISECOND));
-        queryRowDensity = registry.histogram(
-            base.tagged("what", "query-metrics-row-density", "unit", Units.COUNT));
+            registry.getOrAdd(base.tagged("what", "query-metrics-read-rate", "unit", Units.COUNT),
+                HistogramBuilder.HISTOGRAM);
+        queryRowMsBetweenSamples = registry.getOrAdd(
+            base.tagged("what", "query-metrics-row-metric-distance", "unit", Units.MILLISECOND),
+            HistogramBuilder.HISTOGRAM);
+        queryRowDensity =
+            registry.getOrAdd(base.tagged("what", "query-metrics-row-density", "unit", Units.COUNT),
+                HistogramBuilder.HISTOGRAM);
     }
 
     @Override

--- a/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoirIT.java
+++ b/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoirIT.java
@@ -56,7 +56,7 @@ public class MinMaxSlidingTimeReservoirIT {
             };
 
             final MinMaxSlidingTimeReservoir reservoir =
-                new MinMaxSlidingTimeReservoir(clock, SIZE, STEP, delegate);
+                new MinMaxSlidingTimeReservoir(clock, SIZE, STEP, TimeUnit.NANOSECONDS, delegate);
 
             final LongAccumulator min = new LongAccumulator(Math::min, Long.MAX_VALUE);
             final LongAccumulator max = new LongAccumulator(Math::max, Long.MIN_VALUE);

--- a/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoirIT.java
+++ b/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoirIT.java
@@ -1,15 +1,25 @@
 package com.spotify.heroic.statistics.semantic;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.codahale.metrics.Clock;
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.codahale.metrics.Reservoir;
 import com.codahale.metrics.Snapshot;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAccumulator;
@@ -23,6 +33,9 @@ public class MinMaxSlidingTimeReservoirIT {
     private static final int SAMPLE_SIZE = 100_000;
     private static final int CLOCK_INTERVAL = 10000;
     private static final long ITERATIONS = 10L;
+    private static final long VALUE_RANGE = 1000_000;
+    private static final long MAX_VALUE = VALUE_RANGE * 11;
+    private static final long MIN_VALUE = -VALUE_RANGE * 11;
 
     /**
      * Test many threads updating the reservoir.
@@ -100,6 +113,124 @@ public class MinMaxSlidingTimeReservoirIT {
         }
 
         pool.shutdown();
+    }
+
+    @Test
+    public void testBasicStatisticsSlowRate() throws Exception {
+        final DeterministicClock clock = new DeterministicClock();
+
+        int iterations = 10;
+        int numSamples = 100;
+
+        final Reservoir delegate = new ExponentiallyDecayingReservoir(1028, 0.015, clock);
+        final MinMaxSlidingTimeReservoir reservoir =
+            new MinMaxSlidingTimeReservoir(clock, SIZE, STEP, TimeUnit.NANOSECONDS, delegate);
+        long exactValues[] = new long[(numSamples + 2) * iterations];
+        int i = 0;
+
+        for (int iteration = 0; iteration < iterations; iteration++) {
+            long maxPos = ThreadLocalRandom.current().nextInt(0, numSamples);
+            long minPos = ThreadLocalRandom.current().nextInt(0, numSamples);
+            for (long pos = 0; pos < numSamples; pos++) {
+                long val = ThreadLocalRandom.current().nextLong(-VALUE_RANGE, VALUE_RANGE);
+                reservoir.update(val);
+                exactValues[i] = val;
+                i++;
+                if (pos == maxPos) {
+                    reservoir.update(MAX_VALUE);
+                    exactValues[i] = MAX_VALUE;
+                    i++;
+                }
+                if (pos == minPos) {
+                    reservoir.update(MIN_VALUE);
+                    exactValues[i] = MIN_VALUE;
+                    i++;
+                }
+            }
+
+            final Snapshot snapshot = reservoir.getSnapshot();
+
+            assertEquals(MAX_VALUE, snapshot.getMax());
+            assertEquals(MIN_VALUE, snapshot.getMin());
+
+            long expectedValues[] = Arrays.copyOf(exactValues, i);
+            Arrays.sort(expectedValues);
+            long reservoirValues[] =
+                Arrays.copyOf(snapshot.getValues(), snapshot.getValues().length);
+            Arrays.sort(reservoirValues);
+
+            assertArrayEquals(expectedValues, reservoirValues);
+        }
+    }
+
+    @Test
+    public void testBasicStatisticsHighRate() throws Exception {
+        final DeterministicClock clock = new DeterministicClock();
+
+        int iterations = 2;
+        for (int iteration = 0; iteration < iterations; iteration++) {
+            final Reservoir delegate = new ExponentiallyDecayingReservoir(1028, 0.015, clock);
+            final MinMaxSlidingTimeReservoir reservoir =
+                new MinMaxSlidingTimeReservoir(clock, SIZE, STEP, TimeUnit.NANOSECONDS, delegate);
+
+            int numSamples = 1000000;
+            int clockInterval = numSamples / SIZE;
+            long exactValues[] = new long[numSamples + 2];
+            long maxPos = ThreadLocalRandom.current().nextInt(0, numSamples);
+            long minPos = ThreadLocalRandom.current().nextInt(0, numSamples);
+            int i = 0;
+            for (long pos = 0; pos < numSamples; pos++) {
+                if (pos > 0 && pos % clockInterval == 0) {
+                    clock.add(STEP);
+                }
+                long val = ThreadLocalRandom.current().nextLong(-VALUE_RANGE, VALUE_RANGE);
+                reservoir.update(val);
+                exactValues[i] = val;
+                i++;
+                // Insert an extreme max / min value at a random point in the reservoir
+                if (pos == maxPos) {
+                    reservoir.update(MAX_VALUE);
+                    exactValues[i] = MAX_VALUE;
+                    i++;
+                }
+                if (pos == minPos) {
+                    reservoir.update(MIN_VALUE);
+                    exactValues[i] = MIN_VALUE;
+                    i++;
+                }
+            }
+
+            final Snapshot snapshot = reservoir.getSnapshot();
+
+            assertEquals("Max value", MAX_VALUE, snapshot.getMax());
+            assertEquals("Min value", MIN_VALUE, snapshot.getMin());
+
+            final long actualValues[] = Arrays.copyOf(snapshot.getValues(), snapshot.getValues().length);
+            assertTrue("Reservoir contains values", actualValues.length > 1000);
+
+            final Set<Long> exactValueSet = new HashSet<>();
+            for (i = 0; i < exactValues.length; i++) {
+                exactValueSet.add(exactValues[i]);
+            }
+            assertTrue("Only known values in the reservoir", Arrays
+                .stream(actualValues)
+                .filter(value -> !exactValueSet.contains(value))
+                .count() == 0);
+
+            final long zeroValueRange = (VALUE_RANGE * 10) / 100;
+            assertThat("Mean value is within 10% error rate of 0", (long) snapshot.getMean(),
+                allOf(greaterThan(-zeroValueRange), lessThan(zeroValueRange)));
+
+            final long stdDev = (long) snapshot.getStdDev();
+            assertThat("Mean deviation is more than 40% of value range", stdDev,
+                greaterThan((VALUE_RANGE * 40) / 100));
+            assertThat("Mean deviation is less than the max value range", stdDev,
+                lessThan(MAX_VALUE));
+
+            final Snapshot snapshot2 = reservoir.getSnapshot();
+            assertArrayEquals("Two calls to get snapshot results in same data",
+                snapshot.getValues(), snapshot2.getValues());
+        }
     }
 
     public static class DeterministicClock extends Clock {

--- a/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoirIT.java
+++ b/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoirIT.java
@@ -1,0 +1,121 @@
+package com.spotify.heroic.statistics.semantic;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Reservoir;
+import com.codahale.metrics.Snapshot;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAccumulator;
+import org.junit.Test;
+
+public class MinMaxSlidingTimeReservoirIT {
+    private static final int SIZE = 10;
+    private static final long STEP = TimeUnit.NANOSECONDS.convert(1, TimeUnit.SECONDS);
+    private static final Snapshot DELEGATE_SNAPSHOT = new Snapshot(new long[]{0, 1, 2});
+    private static final int THREAD_COUNT = 4;
+    private static final int SAMPLE_SIZE = 100_000;
+    private static final int CLOCK_INTERVAL = 10000;
+    private static final long ITERATIONS = 10L;
+
+    /**
+     * Test many threads updating the reservoir.
+     */
+    @Test
+    public void testManyThreads() throws Exception {
+        final ExecutorService pool = Executors.newWorkStealingPool(4);
+
+        // last possible bucket position according to current configuration
+        final long lastBucket = THREAD_COUNT * (SAMPLE_SIZE / CLOCK_INTERVAL) - SIZE;
+
+        for (long iteration = 0L; iteration < ITERATIONS; iteration++) {
+            final Random random = new Random(0x1234123412341234L + iteration);
+
+            final DeterministicClock clock = new DeterministicClock();
+
+            final Reservoir delegate = new Reservoir() {
+                @Override
+                public int size() {
+                    return 0;
+                }
+
+                @Override
+                public void update(final long value) {
+                }
+
+                @Override
+                public Snapshot getSnapshot() {
+                    return DELEGATE_SNAPSHOT;
+                }
+            };
+
+            final MinMaxSlidingTimeReservoir reservoir =
+                new MinMaxSlidingTimeReservoir(clock, SIZE, STEP, delegate);
+
+            final LongAccumulator min = new LongAccumulator(Math::min, Long.MAX_VALUE);
+            final LongAccumulator max = new LongAccumulator(Math::max, Long.MIN_VALUE);
+
+            final CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+
+            for (int i = 0; i < THREAD_COUNT; i++) {
+                pool.execute(() -> {
+                    for (int s = 0; s < SAMPLE_SIZE; s++) {
+                        final long sample = random.nextLong();
+
+                        if (s % CLOCK_INTERVAL == 0) {
+                            clock.add(STEP);
+                        }
+
+                        // check if first bucket according to the clock is after the last possible
+                        // bucket. if so, they should be taken into account.
+                        if ((reservoir.calculateFirstBucket() + SIZE) > lastBucket) {
+                            // start accumulating for reference comparison
+                            min.accumulate(sample);
+                            max.accumulate(sample);
+                        }
+
+                        reservoir.update(sample);
+                    }
+
+                    latch.countDown();
+                });
+            }
+
+            // wait for all threads to complete
+            latch.await();
+
+            final Snapshot snapshot = reservoir.getSnapshot();
+
+            assertArrayEquals("expected snapshot for iteration #" + iteration,
+                new long[]{min.get(), 1, max.get()}, snapshot.getValues());
+
+            assertEquals("expected max for iteration #" + iteration, max.get(), snapshot.getMax());
+            assertEquals("expected min for iteration #" + iteration, min.get(), snapshot.getMin());
+        }
+
+        pool.shutdown();
+    }
+
+    public static class DeterministicClock extends Clock {
+        private final AtomicLong now = new AtomicLong();
+
+        @Override
+        public long getTick() {
+            return now.get();
+        }
+
+        public void set(final long now) {
+            this.now.set(now);
+        }
+
+        public void add(final long step) {
+            this.now.addAndGet(step);
+        }
+    }
+}

--- a/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoirTest.java
+++ b/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoirTest.java
@@ -28,7 +28,8 @@ public class MinMaxSlidingTimeReservoirTest {
     @Before
     public void setup() {
         delegate = mock(Reservoir.class);
-        reservoir = spy(new MinMaxSlidingTimeReservoir(clock, SIZE, STEP, delegate));
+        reservoir =
+            spy(new MinMaxSlidingTimeReservoir(clock, SIZE, STEP, TimeUnit.NANOSECONDS, delegate));
         doReturn(DELEGATE_SNAPSHOT).when(delegate).getSnapshot();
     }
 

--- a/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoirTest.java
+++ b/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoirTest.java
@@ -1,0 +1,71 @@
+package com.spotify.heroic.statistics.semantic;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Reservoir;
+import com.codahale.metrics.Snapshot;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MinMaxSlidingTimeReservoirTest {
+    private static final int SIZE = 10;
+    private static final long STEP = TimeUnit.NANOSECONDS.convert(1, TimeUnit.SECONDS);
+    private static final Snapshot DELEGATE_SNAPSHOT = new Snapshot(new long[]{0, 1, 2});
+
+    private final DeterministicClock clock = new DeterministicClock();
+
+    private Reservoir delegate;
+    private MinMaxSlidingTimeReservoir reservoir;
+
+    @Before
+    public void setup() {
+        delegate = mock(Reservoir.class);
+        reservoir = spy(new MinMaxSlidingTimeReservoir(clock, SIZE, STEP, delegate));
+        doReturn(DELEGATE_SNAPSHOT).when(delegate).getSnapshot();
+    }
+
+    @Test
+    public void testMinMaxCalculation() {
+        reservoir.update(200L);
+        reservoir.update(-200L);
+
+        // cause first updates to go out of range
+        clock.set(STEP * (SIZE + 1));
+
+        reservoir.update(100L);
+        reservoir.update(-100L);
+
+        verify(delegate).update(100L);
+        verify(delegate).update(-100L);
+
+        final Snapshot snapshot = reservoir.getSnapshot();
+
+        assertEquals(100L, snapshot.getMax());
+        assertEquals(-100L, snapshot.getMin());
+
+        assertArrayEquals(new long[]{-100L, 1, 100L}, snapshot.getValues());
+        assertEquals(-100L, snapshot.getMin());
+        assertEquals(100L, snapshot.getMax());
+    }
+
+    public static class DeterministicClock extends Clock {
+        private final AtomicLong now = new AtomicLong();
+
+        @Override
+        public long getTick() {
+            return now.get();
+        }
+
+        public void set(final long now) {
+            this.now.set(now);
+        }
+    }
+}


### PR DESCRIPTION
The common semantic metrics Histogram uses a reservoir that provides statistically relevant data without saving all samples, by performing random sampling. That, however, means that min/max isn't accurate for high-rate metrics.
This commit introduces a new reservoir that can be layered on top of the old one, to keep special track of min/max values.