### PR TITLE
[aggregation] sum squared

### DIFF
--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Module.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Module.java
@@ -77,6 +77,8 @@ public class Module implements HeroicModule {
 
             c.register(Sum.NAME, Sum.class, SumInstance.class, samplingBuilder(Sum::new));
 
+            c.register(Sum2.NAME, Sum2.class, Sum2Instance.class, samplingBuilder(Sum2::new));
+
             c.register(Average.NAME, Average.class, AverageInstance.class,
                 samplingBuilder(Average::new));
 

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StripedSum2Bucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StripedSum2Bucket.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+
+import com.spotify.heroic.aggregation.AbstractBucket;
+import com.spotify.heroic.aggregation.DoubleBucket;
+import com.spotify.heroic.metric.Point;
+import com.spotify.heroic.metric.Spread;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.concurrent.atomic.DoubleAdder;
+
+/**
+ * Bucket that keeps track of the amount of data points seen, and there summed value.
+ * <p>
+ * This bucket uses primitives based on striped atomic updates to reduce contention across CPUs.
+ *
+ * @author udoprog
+ */
+@RequiredArgsConstructor
+public class StripedSum2Bucket extends AbstractBucket implements DoubleBucket {
+    private final long timestamp;
+
+    /* the sum of all seen values */
+    private final DoubleAdder sum2 = new DoubleAdder();
+    /* if the sum is valid (e.g. has at least one value) */
+    private volatile boolean valid = false;
+
+    public long timestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public void updatePoint(Map<String, String> key, Point d) {
+        valid = true;
+        sum2.add(d.getValue() * d.getValue());
+    }
+
+    @Override
+    public void updateSpread(Map<String, String> key, Spread d) {
+        valid = true;
+        sum2.add(d.getSum2());
+    }
+
+    @Override
+    public double value() {
+        if (!valid) {
+            return Double.NaN;
+        }
+
+        return sum2.sum();
+    }
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Sum2.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Sum2.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+
+import com.spotify.heroic.aggregation.AggregationContext;
+import com.spotify.heroic.aggregation.SamplingAggregation;
+import com.spotify.heroic.aggregation.SamplingQuery;
+import com.spotify.heroic.common.Duration;
+import com.spotify.heroic.common.Optionals;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.beans.ConstructorProperties;
+import java.util.Optional;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class Sum2 extends SamplingAggregation {
+    public static final String NAME = "sum2";
+
+    @ConstructorProperties({"sampling", "size", "extent"})
+    public Sum2(
+        Optional<SamplingQuery> sampling, Optional<Duration> size, Optional<Duration> extent
+    ) {
+        super(Optionals.firstPresent(size, sampling.flatMap(SamplingQuery::getSize)),
+            Optionals.firstPresent(extent, sampling.flatMap(SamplingQuery::getExtent)));
+    }
+
+    @Override
+    public Sum2Instance apply(AggregationContext context, final long size, final long extent) {
+        return new Sum2Instance(size, extent);
+    }
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Sum2Bucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Sum2Bucket.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import com.spotify.heroic.aggregation.AbstractBucket;
+import com.spotify.heroic.aggregation.DoubleBucket;
+import com.spotify.heroic.metric.Point;
+import com.spotify.heroic.metric.Spread;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+/**
+ * Bucket that keeps track of the amount of data points seen, and their squared values summed.
+ * <p>
+ * Take care to not blindly trust {@link #value()} since it is initialized to 0 for simplicity.
+ * Always check {@link #count()}, which if zero indicates that the {@link #value()} is undefined
+ * (e.g. NaN).
+ *
+ * @author udoprog
+ */
+@RequiredArgsConstructor
+public class Sum2Bucket extends AbstractBucket implements DoubleBucket {
+    private final long timestamp;
+
+    /* the sum of seen values */
+    private final AtomicDouble sum2 = new AtomicDouble();
+    /* if the sum is valid (e.g. has at least one value) */
+    private volatile boolean valid = false;
+
+    public long timestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public void updatePoint(Map<String, String> key, Point d) {
+        valid = true;
+        sum2.addAndGet(d.getValue() * d.getValue());
+    }
+
+    @Override
+    public void updateSpread(Map<String, String> key, Spread d) {
+        valid = true;
+        sum2.addAndGet(d.getSum2());
+    }
+
+    @Override
+    public double value() {
+        if (!valid) {
+            return Double.NaN;
+        }
+        return sum2.get();
+    }
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Sum2Instance.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Sum2Instance.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+
+import com.google.common.collect.ImmutableSet;
+import com.spotify.heroic.aggregation.AggregationInstance;
+import com.spotify.heroic.metric.MetricType;
+import com.spotify.heroic.metric.Point;
+
+import java.beans.ConstructorProperties;
+
+public class Sum2Instance extends DistributedBucketInstance<StripedSum2Bucket> {
+    @ConstructorProperties({"size", "extent"})
+    public Sum2Instance(final long size, final long extent) {
+        super(size, extent, ImmutableSet.of(MetricType.POINT, MetricType.SPREAD), MetricType.POINT);
+    }
+
+    @Override
+    protected StripedSum2Bucket buildBucket(long timestamp) {
+        return new StripedSum2Bucket(timestamp);
+    }
+
+    @Override
+    protected Point build(StripedSum2Bucket bucket) {
+        return new Point(bucket.timestamp(), bucket.value());
+    }
+
+    @Override
+    public AggregationInstance distributed() {
+        return this;
+    }
+}

--- a/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/Sum2BucketTest.java
+++ b/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/Sum2BucketTest.java
@@ -1,0 +1,37 @@
+package com.spotify.heroic.aggregation.simple;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.spotify.heroic.aggregation.DoubleBucket;
+import com.spotify.heroic.metric.Point;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Sum2BucketTest {
+    private static final Map<String, String> tags = ImmutableMap.of();
+
+    public Collection<? extends DoubleBucket> buckets() {
+        return ImmutableList.<DoubleBucket>of(new Sum2Bucket(0L), new StripedSum2Bucket(0L));
+    }
+
+    @Test
+    public void testZeroValue() {
+        for (final DoubleBucket bucket : buckets()) {
+            assertTrue(bucket.getClass().getSimpleName(), Double.isNaN(bucket.value()));
+        }
+    }
+
+    @Test
+    public void testAddSome() {
+        for (final DoubleBucket bucket : buckets()) {
+            bucket.updatePoint(tags, new Point(0, 10.0));
+            bucket.updatePoint(tags, new Point(0, 20.0));
+            assertEquals(bucket.getClass().getSimpleName(), 500.0, bucket.value(), 0.0);
+        }
+    }
+}


### PR DESCRIPTION
I noticed that the `spread` aggregator includes `sum2` (sum of squares), which we are using for standard deviation calculations. I am proposing that `sum2` be made into a first-class aggregation (along with min, max, count, sum, etc.) It's a small, isolated change. Tested and working in our QA cluster.