### PR TITLE
Consumer: Handle messages with invalid timestamp

### DIFF
--- a/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/ConsumerThread.java
+++ b/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/ConsumerThread.java
@@ -217,6 +217,7 @@ public final class ConsumerThread extends Thread {
             if (retry) {
                 handleRetry(sleep);
                 sleep = Math.min(sleep * 2, RETRY_MAX_SLEEP);
+                reporter.reportMessageRetry();
                 continue;
             }
 

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/ConsumerReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/ConsumerReporter.java
@@ -26,6 +26,8 @@ public interface ConsumerReporter {
 
     void reportMessageError();
 
+    void reportMessageRetry();
+
     void reportConsumerSchemaError();
 
     void reportConsumerThreadsWanted(final long count);

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopConsumerReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopConsumerReporter.java
@@ -38,6 +38,10 @@ public class NoopConsumerReporter implements ConsumerReporter {
     }
 
     @Override
+    public void reportMessageRetry() {
+    }
+
+    @Override
     public void reportConsumerSchemaError() {
     }
 

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100.java
@@ -159,6 +159,11 @@ public class Spotify100 implements ConsumerSchema {
                     "'" + TIME + "' field must be defined: " + message);
             }
 
+            if (metric.getTime() <= 0) {
+                throw new ConsumerSchemaValidationException(
+                    "'" + TIME + "' field must be a positive number: " + message);
+            }
+
             if (metric.getKey() == null) {
                 throw new ConsumerSchemaValidationException(
                     "'" + KEY + "' field must be defined: " + message);

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticConsumerReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticConsumerReporter.java
@@ -41,6 +41,7 @@ public class SemanticConsumerReporter implements ConsumerReporter {
 
     private final Meter messageIn;
     private final Meter messageError;
+    private final Meter messageRetry;
     private final Meter consumerSchemaError;
     private final SemanticRatioGauge consumerThreadsLiveRatio;
     private final Histogram messageSize;
@@ -58,6 +59,7 @@ public class SemanticConsumerReporter implements ConsumerReporter {
 
         messageIn = registry.meter(base.tagged("what", "message-in", "unit", Units.MESSAGE));
         messageError = registry.meter(base.tagged("what", "message-error", "unit", Units.FAILURE));
+        messageRetry = registry.meter(base.tagged("what", "message-retry", "unit", Units.COUNT));
         consumerSchemaError =
             registry.meter(base.tagged("what", "consumer-schema-error", "unit", Units.FAILURE));
         consumerThreadsLiveRatio = new SemanticRatioGauge();
@@ -90,6 +92,11 @@ public class SemanticConsumerReporter implements ConsumerReporter {
     @Override
     public void reportMessageError() {
         messageError.mark();
+    }
+
+    @Override
+    public void reportMessageRetry() {
+        messageRetry.mark();
     }
 
     @Override


### PR DESCRIPTION
A message with timestamp <= 0 currently causes infinite retries in the consumer. Let's check explicitly for that case and fail with a schema validation error so that the message is dropped.

Also adds a new metric 'message-retry' that indicates message consumption retries.