### PR TITLE
New metric for data density of reads

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/DataInMemoryReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/DataInMemoryReporter.java
@@ -36,9 +36,9 @@ public interface DataInMemoryReporter {
     /**
      * report the density of a row that was read from the metric backend
      *
-     * @param msBetweenSamples density, number of samples per hour
+     * @param samplesPerSecond density, average number of samples per second
      */
-    void reportRowDensity(long msBetweenSamples);
+    void reportRowDensity(double samplesPerSecond);
 
     /**
      * report that data has been read into memory

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
@@ -34,7 +34,8 @@ public class NoopMetricBackendReporter implements MetricBackendReporter {
         }
 
         @Override
-        public void reportRowDensity(final long msBetweenSamples) {
+        public void reportRowDensity(final double samplesPerSecond) {
+
         }
 
         @Override

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -485,8 +485,9 @@ public class LocalMetricManager implements MetricManager {
             dataInMemoryReporter.reportDataNoLongerNeeded(g.size());
 
             g.getAverageDistanceBetweenMetrics().ifPresent(msBetweenSamples -> {
-                dataInMemoryReporter.reportRowDensity(msBetweenSamples);
-                rowDensityData.add(msBetweenSamples);
+                final double metricsPerSecond = 1000.0 / msBetweenSamples;
+                dataInMemoryReporter.reportRowDensity(metricsPerSecond);
+                rowDensityData.add((long) (metricsPerSecond));
             });
         }
 


### PR DESCRIPTION
Renamed metric:
query-metrics-row-density -> query-metrics-row-metric-distance
This metric existed but actually measured the distance between metrics,
instead of the density. Now renamed. Measurement is average ms between
samples.

New metric:
query-metrics-row-density
Actually measure the density of read data. Measurement is average
number of samples per million seconds. The slightly awkward prefix is
due to floating numbers not being supported in histograms.