### PR TITLE
[core] Correct scale for dataDensity query log

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -490,7 +490,8 @@ public class LocalMetricManager implements MetricManager {
             g.getAverageDistanceBetweenMetrics().ifPresent(msBetweenSamples -> {
                 final double metricsPerSecond = 1000.0 / msBetweenSamples;
                 dataInMemoryReporter.reportRowDensity(metricsPerSecond);
-                rowDensityData.add((long) (metricsPerSecond));
+                final long metricsPerMegaSecond = (long) (metricsPerSecond * 1_000_000);
+                rowDensityData.add(metricsPerMegaSecond);
             });
         }
 


### PR DESCRIPTION
The query log entries for dataDensity was almost always 0 due to wrong
scaling. It's now correctly metrics per million seconds.