### PR TITLE
[component,core] Add darkload functionality

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/cluster/ClusterShard.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/cluster/ClusterShard.java
@@ -45,6 +45,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ClusterShard {
     private static final QueryTrace.Identifier RETRY_BACKOFF =
         new QueryTrace.Identifier("retry-backoff");
+    private static final String DARKLOAD = "darkload";
 
     private final AsyncFramework async;
 
@@ -113,6 +114,10 @@ public class ClusterShard {
             .map(Object::toString)
             .collect(Collectors.toList());
         return nodes;
+    }
+
+    public boolean isDarkload() {
+        return shard.containsKey(DARKLOAD);
     }
 
     private List<QueryTrace> queryTracesFromRetries(

--- a/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
@@ -275,7 +275,11 @@ public class CoreQueryManager implements QueryManager {
                         })
                         .directTransform(QueryResultPart.fromResultGroup(shard));
 
-                    futures.add(queryPart);
+                    if (!shard.isDarkload()) {
+                        // Stash the future to be able to gather result from all shards.
+                        // Except if this shard is a darkload shard, then we will just fire & forget
+                        futures.add(queryPart);
+                    }
                 }
 
                 final OptionalLimit limit = options.getGroupLimit().orElse(groupLimit);


### PR DESCRIPTION
When testing a new configuration option, backend type, code change, etc
it can be very good to be able to test with the same query load as your
main production cluster. This commit adds this possibility.
Set magic tag darkload:true on your shard. This will cause queries to
fan out to it, but the result will be discarded.