### PR TITLE
[all] introduce sub-system for conditional features

### DIFF
--- a/heroic-all/src/main/java/com/spotify/heroic/HeroicModules.java
+++ b/heroic-all/src/main/java/com/spotify/heroic/HeroicModules.java
@@ -46,6 +46,9 @@ import java.util.Map;
 public class HeroicModules {
     // @formatter:off
     public static final List<HeroicModule> ALL_MODULES = ImmutableList.of(
+        new com.spotify.heroic.conditionalfeatures.Module(),
+        new com.spotify.heroic.requestcondition.Module(),
+
         new com.spotify.heroic.metric.datastax.Module(),
         new com.spotify.heroic.metric.memory.Module(),
 

--- a/heroic-component/src/main/java/com/spotify/heroic/conditionalfeatures/ConditionalFeatures.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/conditionalfeatures/ConditionalFeatures.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.conditionalfeatures;
+
+import com.spotify.heroic.common.FeatureSet;
+import com.spotify.heroic.querylogging.QueryContext;
+
+/**
+ * Maps features that are applied conditionally.
+ */
+public interface ConditionalFeatures {
+    FeatureSet match(QueryContext queryContext);
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/dagger/PrimaryComponent.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/dagger/PrimaryComponent.java
@@ -26,10 +26,12 @@ import com.spotify.heroic.HeroicContext;
 import com.spotify.heroic.HeroicCoreInstance;
 import com.spotify.heroic.ShellTasks;
 import com.spotify.heroic.common.Features;
+import com.spotify.heroic.conditionalfeatures.ConditionalFeatures;
 import com.spotify.heroic.grammar.QueryParser;
 import com.spotify.heroic.lifecycle.LifeCycleManager;
 import com.spotify.heroic.statistics.HeroicReporter;
 
+import java.util.Optional;
 import javax.inject.Named;
 
 public interface PrimaryComponent extends EarlyComponent {
@@ -53,4 +55,6 @@ public interface PrimaryComponent extends EarlyComponent {
     LifeCycleManager lifeCycleManager();
 
     HeroicContext context();
+
+    Optional<ConditionalFeatures> conditionalFeatures();
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/requestcondition/RequestCondition.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/requestcondition/RequestCondition.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.requestcondition;
+
+import com.spotify.heroic.querylogging.QueryContext;
+
+/**
+ * Sub-system that provides a mechanism for conditionally change the feature set based on a given
+ * criteria.
+ * <p>
+ * This can for example be used to add or remove a specific feature based on remote IP, or clientId.
+ */
+public interface RequestCondition {
+    /**
+     * Match the HttpContext and optionally provide a feature set to apply to a request.
+     */
+    boolean matches(QueryContext context);
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/HeroicConfig.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/HeroicConfig.java
@@ -41,6 +41,7 @@ import com.spotify.heroic.cache.noop.NoopCacheModule;
 import com.spotify.heroic.cluster.ClusterManagerModule;
 import com.spotify.heroic.common.Duration;
 import com.spotify.heroic.common.FeatureSet;
+import com.spotify.heroic.conditionalfeatures.ConditionalFeatures;
 import com.spotify.heroic.consumer.ConsumerModule;
 import com.spotify.heroic.generator.CoreGeneratorModule;
 import com.spotify.heroic.ingestion.IngestionModule;
@@ -114,6 +115,7 @@ public class HeroicConfig {
     private final CoreGeneratorModule generator;
     private final StatisticsModule statistics;
     private final QueryLoggingModule queryLogging;
+    private final Optional<ConditionalFeatures> conditionalFeature;
 
     private final String version;
     private final String service;
@@ -194,6 +196,7 @@ public class HeroicConfig {
         private Optional<CoreGeneratorModule.Builder> generator = empty();
         private Optional<StatisticsModule> statistics = empty();
         private Optional<QueryLoggingModule> queryLogging = empty();
+        private Optional<ConditionalFeatures> conditionalFeatures = empty();
 
         private Optional<String> version = empty();
         private Optional<String> service = empty();
@@ -289,6 +292,11 @@ public class HeroicConfig {
             return this;
         }
 
+        public Builder conditionalFeatures(ConditionalFeatures conditionalFeatures) {
+            this.conditionalFeatures = of(conditionalFeatures);
+            return this;
+        }
+
         public Builder merge(Builder o) {
             // @formatter:off
             return new Builder(
@@ -314,6 +322,7 @@ public class HeroicConfig {
                 mergeOptional(generator, o.generator, CoreGeneratorModule.Builder::merge),
                 pickOptional(statistics, o.statistics),
                 pickOptional(queryLogging, o.queryLogging),
+                pickOptional(conditionalFeatures, o.conditionalFeatures),
                 pickOptional(service, o.service),
                 pickOptional(version, o.version)
             );
@@ -354,6 +363,7 @@ public class HeroicConfig {
                 generator.orElseGet(CoreGeneratorModule::builder).build(),
                 statistics.orElseGet(NoopStatisticsModule::new),
                 queryLogging.orElseGet(NoopQueryLoggingModule::new),
+                conditionalFeatures,
                 version.orElse(defaultVersion),
                 service.orElse(DEFAULT_SERVICE)
             );

--- a/heroic-core/src/main/java/com/spotify/heroic/HeroicCore.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/HeroicCore.java
@@ -367,7 +367,8 @@ public class HeroicCore implements HeroicConfiguration {
         final CorePrimaryComponent primary = DaggerCorePrimaryComponent
             .builder()
             .coreEarlyComponent(early)
-            .primaryModule(new PrimaryModule(instance, config.getFeatures(), reporter))
+            .primaryModule(new PrimaryModule(instance, config.getFeatures(), reporter,
+                config.getConditionalFeature()))
             .build();
 
         final QueryLoggingComponent queryLogging = config.getQueryLogging().component(primary);

--- a/heroic-core/src/main/java/com/spotify/heroic/conditionalfeatures/List.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/conditionalfeatures/List.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.conditionalfeatures;
+
+import com.spotify.heroic.common.FeatureSet;
+import com.spotify.heroic.querylogging.QueryContext;
+import lombok.Data;
+
+/**
+ * Matches all features listed, one by one.
+ */
+@Data
+public class List implements ConditionalFeatures {
+    private final java.util.List<ConditionalFeatures> list;
+
+    @Override
+    public FeatureSet match(QueryContext queryContext) {
+        FeatureSet features = FeatureSet.empty();
+
+        for (final ConditionalFeatures conditionalFeatures : list) {
+            features = features.combine(conditionalFeatures.match(queryContext));
+        }
+
+        return features;
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/conditionalfeatures/Match.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/conditionalfeatures/Match.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.conditionalfeatures;
+
+import com.spotify.heroic.common.FeatureSet;
+import com.spotify.heroic.querylogging.QueryContext;
+import com.spotify.heroic.requestcondition.RequestCondition;
+import lombok.Data;
+
+/**
+ * Matches a single condition, and applies the matching features.
+ */
+@Data
+public class Match implements ConditionalFeatures {
+    private final RequestCondition condition;
+    private final FeatureSet features;
+
+    @Override
+    public FeatureSet match(QueryContext queryContext) {
+        if (condition.matches(queryContext)) {
+            return features;
+        }
+
+        return FeatureSet.empty();
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/conditionalfeatures/Module.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/conditionalfeatures/Module.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.conditionalfeatures;
+
+import com.spotify.heroic.HeroicConfigurationContext;
+import com.spotify.heroic.HeroicModule;
+import com.spotify.heroic.dagger.LoadingComponent;
+
+public class Module implements HeroicModule {
+    @Override
+    public Runnable setup(final LoadingComponent loading) {
+        return () -> {
+            final HeroicConfigurationContext context = loading.heroicConfigurationContext();
+            context.registerType("list", List.class);
+            context.registerType("match", Match.class);
+        };
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/dagger/PrimaryModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/dagger/PrimaryModule.java
@@ -33,6 +33,7 @@ import com.spotify.heroic.ShellTasks;
 import com.spotify.heroic.aggregation.AggregationRegistry;
 import com.spotify.heroic.common.FeatureSet;
 import com.spotify.heroic.common.Features;
+import com.spotify.heroic.conditionalfeatures.ConditionalFeatures;
 import com.spotify.heroic.grammar.CoreQueryParser;
 import com.spotify.heroic.grammar.QueryParser;
 import com.spotify.heroic.lifecycle.CoreLifeCycleManager;
@@ -44,6 +45,7 @@ import com.spotify.heroic.statistics.HeroicReporter;
 import dagger.Module;
 import dagger.Provides;
 import eu.toolchain.async.AsyncFramework;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 import javax.inject.Named;
@@ -57,6 +59,7 @@ public class PrimaryModule {
     private final HeroicCoreInstance instance;
     private final FeatureSet features;
     private final HeroicReporter reporter;
+    private final Optional<ConditionalFeatures> conditionalFeatures;
 
     @Provides
     @PrimaryScope
@@ -132,6 +135,12 @@ public class PrimaryModule {
     @PrimaryScope
     HeroicContext context(CoreHeroicContext context) {
         return context;
+    }
+
+    @Provides
+    @PrimaryScope
+    Optional<ConditionalFeatures> conditionalFeatures() {
+        return conditionalFeatures;
     }
 
     private SortedMap<String, ShellTask> setupTasks(

--- a/heroic-core/src/main/java/com/spotify/heroic/requestcondition/All.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/requestcondition/All.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.requestcondition;
+
+import com.spotify.heroic.querylogging.QueryContext;
+import java.util.List;
+import lombok.Data;
+
+/**
+ * A request condition that match if all child conditions match.
+ */
+@Data
+public class All implements RequestCondition {
+    private final List<RequestCondition> conditions;
+
+    @Override
+    public boolean matches(QueryContext context) {
+        return conditions.stream().allMatch(c -> c.matches(context));
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/requestcondition/Any.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/requestcondition/Any.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.requestcondition;
+
+import com.spotify.heroic.querylogging.QueryContext;
+import java.util.List;
+import lombok.Data;
+
+/**
+ * A request condition that match if any child condition match.
+ */
+@Data
+public class Any implements RequestCondition {
+    private final List<RequestCondition> conditions;
+
+    @Override
+    public boolean matches(QueryContext context) {
+        return conditions.stream().anyMatch(c -> c.matches(context));
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/requestcondition/ClientId.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/requestcondition/ClientId.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.requestcondition;
+
+import com.spotify.heroic.querylogging.QueryContext;
+import lombok.Data;
+
+/**
+ * A request condition that match a given client id.
+ */
+@Data
+public class ClientId implements RequestCondition {
+    private final String clientId;
+
+    /**
+     * Match the HttpContext and optionally provide a feature set to apply to a request.
+     */
+    @Override
+    public boolean matches(final QueryContext context) {
+        return context
+            .getHttpContext()
+            .flatMap(httpContext -> httpContext.getClientId().map(this.clientId::equals))
+            .orElse(false);
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/requestcondition/Module.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/requestcondition/Module.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.requestcondition;
+
+import com.spotify.heroic.HeroicConfigurationContext;
+import com.spotify.heroic.HeroicModule;
+import com.spotify.heroic.dagger.LoadingComponent;
+
+public class Module implements HeroicModule {
+    @Override
+    public Runnable setup(final LoadingComponent loading) {
+        return () -> {
+            final HeroicConfigurationContext context = loading.heroicConfigurationContext();
+            context.registerType("noop", Noop.class);
+            context.registerType("clientId", ClientId.class);
+            context.registerType("all", All.class);
+            context.registerType("any", Any.class);
+        };
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/requestcondition/Noop.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/requestcondition/Noop.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.requestcondition;
+
+import com.spotify.heroic.querylogging.QueryContext;
+import lombok.Data;
+
+/**
+ * Default request condition that match multiple ones.
+ */
+@Data
+public class Noop implements RequestCondition {
+    @Override
+    public boolean matches(final QueryContext context) {
+        return false;
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/requestcondition/UserAgent.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/requestcondition/UserAgent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.requestcondition;
+
+import com.spotify.heroic.querylogging.QueryContext;
+import lombok.Data;
+
+/**
+ * A request condition that match a given client id.
+ */
+@Data
+public class UserAgent implements RequestCondition {
+    private final String userAgent;
+
+    /**
+     * Match the HttpContext and optionally provide a feature set to apply to a request.
+     */
+    @Override
+    public boolean matches(final QueryContext context) {
+        return context
+            .getHttpContext()
+            .flatMap(httpContext -> httpContext.getUserAgent().map(this.userAgent::equals))
+            .orElse(false);
+    }
+}

--- a/heroic-core/src/test/java/com/spotify/heroic/requestcondition/RequestConditionTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/requestcondition/RequestConditionTest.java
@@ -1,0 +1,81 @@
+package com.spotify.heroic.requestcondition;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+
+import com.google.common.collect.ImmutableList;
+import com.spotify.heroic.querylogging.HttpContext;
+import com.spotify.heroic.querylogging.QueryContext;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RequestConditionTest {
+    @Mock
+    public RequestCondition a;
+
+    @Mock
+    public RequestCondition b;
+
+    @Mock
+    public QueryContext queryContext1;
+
+    @Mock
+    public QueryContext queryContext2;
+
+    @Mock
+    public HttpContext httpContext1;
+
+    @Mock
+    public HttpContext httpContext2;
+
+    @Before
+    public void setup() {
+        doReturn(false).when(a).matches(queryContext1);
+        doReturn(true).when(a).matches(queryContext2);
+        doReturn(true).when(b).matches(queryContext1);
+        doReturn(true).when(b).matches(queryContext2);
+
+        doReturn(Optional.of("foobar")).when(httpContext1).getClientId();
+        doReturn(Optional.empty()).when(httpContext2).getClientId();
+        doReturn(Optional.of("foobar")).when(httpContext1).getUserAgent();
+        doReturn(Optional.empty()).when(httpContext2).getUserAgent();
+        doReturn(Optional.of(httpContext1)).when(queryContext1).getHttpContext();
+        doReturn(Optional.of(httpContext2)).when(queryContext2).getHttpContext();
+    }
+
+    @Test
+    public void testAll() {
+        final All all = new All(ImmutableList.of(a, b));
+        assertFalse(all.matches(queryContext1));
+        assertTrue(all.matches(queryContext2));
+        assertTrue(new All(ImmutableList.of()).matches(queryContext1));
+    }
+
+    @Test
+    public void testAny() {
+        final Any any = new Any(ImmutableList.of(a, b));
+        assertTrue(any.matches(queryContext1));
+        assertTrue(any.matches(queryContext2));
+        assertFalse(new Any(ImmutableList.of()).matches(queryContext1));
+    }
+
+    @Test
+    public void testClientId() {
+        final ClientId clientId = new ClientId("foobar");
+        assertTrue(clientId.matches(queryContext1));
+        assertFalse(clientId.matches(queryContext2));
+    }
+
+    @Test
+    public void testUserAgent() {
+        final UserAgent userAgent = new UserAgent("foobar");
+        assertTrue(userAgent.matches(queryContext1));
+        assertFalse(userAgent.matches(queryContext2));
+    }
+}

--- a/heroic-dist/src/test/resources/heroic-conditional-features.yml
+++ b/heroic-dist/src/test/resources/heroic-conditional-features.yml
@@ -1,0 +1,19 @@
+conditionalFeatures:
+  type: list
+  list:
+    - type: match
+      features:
+        - com.spotify.heroic.cache_query
+      condition:
+        type: clientId
+        clientId: foobar
+    - type: match
+      features:
+        - com.spotify.heroic.cache_query
+      condition:
+        type: any
+        conditions:
+          - type: clientId
+            clientId: foo
+          - type: clientId
+            clientId: bar

--- a/heroic-loading/src/main/java/com/spotify/heroic/HeroicMappers.java
+++ b/heroic-loading/src/main/java/com/spotify/heroic/HeroicMappers.java
@@ -39,6 +39,8 @@ import com.spotify.heroic.common.DurationSerialization;
 import com.spotify.heroic.common.Groups;
 import com.spotify.heroic.common.GroupsSerialization;
 import com.spotify.heroic.common.TypeNameMixin;
+import com.spotify.heroic.conditionalfeatures.ConditionalFeatures;
+import com.spotify.heroic.requestcondition.RequestCondition;
 import com.spotify.heroic.consumer.ConsumerModule;
 import com.spotify.heroic.filter.FilterRegistry;
 import com.spotify.heroic.generator.MetadataGenerator;
@@ -92,6 +94,8 @@ public final class HeroicMappers {
         m.addMixIn(StatisticsModule.class, TypeNameMixin.class);
         m.addMixIn(QueryLoggingModule.class, TypeNameMixin.class);
         m.addMixIn(CacheModule.Builder.class, TypeNameMixin.class);
+        m.addMixIn(RequestCondition.class, TypeNameMixin.class);
+        m.addMixIn(ConditionalFeatures.class, TypeNameMixin.class);
 
         m.registerModule(commonSerializers());
 


### PR DESCRIPTION
This introduces conditional features that can be set in the configuration file like the following:
```yaml
conditionalFeatures:
  type: list
  list:
    - type: match
      features:
        - com.spotify.heroic.cache_query
      condition:
        type: clientId
        clientId: foobar
    - type: match
      features:
        - com.spotify.heroic.cache_query
      condition:
        type: any
        conditions:
          - type: clientId
            clientId: foo
          - type: clientId
            clientId: bar
```

The current implementation permits enabling features depending on [client id](https://github.com/udoprog/heroic/blob/06f8d1e02bc507226a5821ff4f95df0b85311c79/heroic-core/src/main/java/com/spotify/heroic/requestcondition/ClientId.java), or [user agent](https://github.com/udoprog/heroic/blob/06f8d1e02bc507226a5821ff4f95df0b85311c79/heroic-core/src/main/java/com/spotify/heroic/requestcondition/UserAgent.java). More can be added later.

This introduces two new interfaces in heroic-components:
* `RequestCondition` - takes a QueryContext and returns a boolean if the context matches or not.
* `ConditionalFeatures` - takes a QueryContext and returns a `FeatureSet` that should be applied to the existing set of features.