### PR TITLE
[metadata,suggest] Metrics for actual writes

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/MetadataBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/MetadataBackendReporter.java
@@ -26,6 +26,8 @@ import com.spotify.heroic.metadata.MetadataBackend;
 public interface MetadataBackendReporter {
     void reportWriteDroppedByRateLimit();
 
+    FutureReporter.Context setupWriteReporter();
+
     /**
      * report number of successful operations in a batch
      *

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/SuggestBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/SuggestBackendReporter.java
@@ -27,4 +27,6 @@ public interface SuggestBackendReporter {
     SuggestBackend decorate(SuggestBackend backend);
 
     void reportWriteDroppedByRateLimit();
+
+    FutureReporter.Context setupWriteReporter();
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetadataBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetadataBackendReporter.java
@@ -22,6 +22,7 @@
 package com.spotify.heroic.statistics.noop;
 
 import com.spotify.heroic.metadata.MetadataBackend;
+import com.spotify.heroic.statistics.FutureReporter;
 import com.spotify.heroic.statistics.MetadataBackendReporter;
 
 public class NoopMetadataBackendReporter implements MetadataBackendReporter {
@@ -49,6 +50,11 @@ public class NoopMetadataBackendReporter implements MetadataBackendReporter {
 
     @Override
     public void reportWriteDroppedByRateLimit() {
+    }
+
+    @Override
+    public FutureReporter.Context setupWriteReporter() {
+        return NoopFutureReporterContext.get();
     }
 
     private static final NoopMetadataBackendReporter instance = new NoopMetadataBackendReporter();

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopSuggestBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopSuggestBackendReporter.java
@@ -21,6 +21,7 @@
 
 package com.spotify.heroic.statistics.noop;
 
+import com.spotify.heroic.statistics.FutureReporter;
 import com.spotify.heroic.statistics.SuggestBackendReporter;
 import com.spotify.heroic.suggest.SuggestBackend;
 
@@ -35,6 +36,11 @@ public class NoopSuggestBackendReporter implements SuggestBackendReporter {
 
     @Override
     public void reportWriteDroppedByRateLimit() {
+    }
+
+    @Override
+    public FutureReporter.Context setupWriteReporter() {
+        return NoopFutureReporterContext.get();
     }
 
     private static final NoopSuggestBackendReporter instance = new NoopSuggestBackendReporter();

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
@@ -63,6 +63,7 @@ import com.spotify.heroic.metadata.MetadataBackend;
 import com.spotify.heroic.metadata.WriteMetadata;
 import com.spotify.heroic.metric.QueryError;
 import com.spotify.heroic.metric.RequestError;
+import com.spotify.heroic.statistics.FutureReporter;
 import com.spotify.heroic.statistics.MetadataBackendReporter;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
@@ -205,9 +206,11 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
                     .setOpType(OpType.CREATE);
 
                 final RequestTimer<WriteMetadata> timer = WriteMetadata.timer();
+                final FutureReporter.Context writeContext = reporter.setupWriteReporter();
 
-                AsyncFuture<WriteMetadata> result =
-                    bind(builder.execute()).directTransform(response -> timer.end());
+                AsyncFuture<WriteMetadata> result = bind(builder.execute())
+                    .directTransform(response -> timer.end())
+                    .onDone(writeContext);
 
                 writes.add(result);
             }

--- a/suggest/elasticsearch/src/main/java/com/spotify/heroic/suggest/elasticsearch/SuggestBackendKV.java
+++ b/suggest/elasticsearch/src/main/java/com/spotify/heroic/suggest/elasticsearch/SuggestBackendKV.java
@@ -55,6 +55,7 @@ import com.spotify.heroic.filter.StartsWithFilter;
 import com.spotify.heroic.filter.TrueFilter;
 import com.spotify.heroic.lifecycle.LifeCycleRegistry;
 import com.spotify.heroic.lifecycle.LifeCycles;
+import com.spotify.heroic.statistics.FutureReporter;
 import com.spotify.heroic.statistics.SuggestBackendReporter;
 import com.spotify.heroic.suggest.KeySuggest;
 import com.spotify.heroic.suggest.SuggestBackend;
@@ -570,13 +571,14 @@ public class SuggestBackendKV extends AbstractElasticsearchBackend
                     suggest.endObject();
 
                     final String suggestId = seriesId + ":" + Integer.toHexString(e.hashCode());
+                    final FutureReporter.Context writeContext = reporter.setupWriteReporter();
 
                     writes.add(bind(c
                         .index(index, TAG_TYPE)
                         .setId(suggestId)
                         .setSource(suggest)
                         .setOpType(DocWriteRequest.OpType.CREATE)
-                        .execute()).directTransform(response -> timer.end()));
+                        .execute()).directTransform(response -> timer.end()).onDone(writeContext));
                 }
             }
 


### PR DESCRIPTION
Renamed write-* group of metrics to cached-write-* for metadata and
suggest. These metrics measure the full set of writes, including the
ones that hit the internal write-cache in these modules, and thus
actually aren't sent to ES.

Added new write-* group of metrics. These measure the actual writes sent
to ES.