### PR TITLE
[core] fix maxTtl cache setting

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/cache/memcached/MemcachedCacheModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/cache/memcached/MemcachedCacheModule.java
@@ -157,8 +157,12 @@ public class MemcachedCacheModule implements CacheModule {
         private Optional<Duration> maxTtl = Optional.empty();
 
         @JsonCreator
-        public Builder(@JsonProperty("addresses") final Optional<List<String>> addresses) {
+        public Builder(
+            @JsonProperty("addresses") final Optional<List<String>> addresses,
+            @JsonProperty("maxTtl") Optional<Duration> maxTtl
+        ) {
             this.addresses = addresses;
+            this.maxTtl = maxTtl;
         }
 
         public Builder addresses(final List<String> addresses) {


### PR DESCRIPTION
Currently `maxTtl` is not being read from configuration file. This fixes that.