### PR TITLE
[component,core] more detailed caching information

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/metric/CacheInfo.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/CacheInfo.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.metric;
+
+import lombok.Data;
+
+@Data
+public class CacheInfo {
+    /**
+     * Indicates if the response was fetched from cache or not.
+     */
+    private final boolean cached;
+
+    /**
+     * TTL for which an item has been, or is cached for in seconds.
+     */
+    private final int ttl;
+
+    /**
+     * The key used for caching.
+     */
+    private final String cacheKey;
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetricsResponse.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetricsResponse.java
@@ -67,7 +67,7 @@ public class QueryMetricsResponse {
     private final Optional<Long> preAggregationSampleSize;
 
     @NonNull
-    private final boolean cached;
+    private final Optional<CacheInfo> cache;
 
     public static class Serializer extends JsonSerializer<QueryMetricsResponse> {
         @Override
@@ -83,7 +83,9 @@ public class QueryMetricsResponse {
             g.writeObjectField("range", response.getRange());
             g.writeObjectField("trace", response.getTrace());
             g.writeObjectField("limits", response.getLimits());
-            g.writeBooleanField("cached", response.isCached());
+            g.writeBooleanField("cached",
+                response.getCache().map(CacheInfo::isCached).orElse(false));
+            g.writeObjectField("cache", response.getCache());
 
             g.writeFieldName("commonTags");
             serializeCommonTags(g, common);
@@ -250,7 +252,7 @@ public class QueryMetricsResponse {
 
     public Summary summarize() {
         return new Summary(range, ShardedResultGroup.summarize(result), statistics, errors, trace,
-            limits, preAggregationSampleSize, cached);
+            limits, preAggregationSampleSize, cache);
     }
 
     // Only include data suitable to log to query log
@@ -263,6 +265,6 @@ public class QueryMetricsResponse {
         private final QueryTrace trace;
         private final ResultLimits limits;
         private final Optional<Long> preAggregationSampleSize;
-        private final boolean cached;
+        private final Optional<CacheInfo> cache;
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryResult.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryResult.java
@@ -30,6 +30,7 @@ import eu.toolchain.async.Collector;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import lombok.Data;
 
 @Data
@@ -61,9 +62,19 @@ public class QueryResult {
     private final long preAggregationSampleSize;
 
     /**
-     * Indicates if the result was from a cached source or not.
+     * Extra information about caching.
      */
-    private final boolean cached;
+    private final Optional<CacheInfo> cache;
+
+    /**
+     * Add cache info to the result.
+     * @param cache cache info to add.
+     * @return an copied instanceof query result with cache info added
+     */
+    public QueryResult withCache(final CacheInfo cache) {
+        return new QueryResult(range, groups, errors, trace, limits, preAggregationSampleSize,
+            Optional.of(cache));
+    }
 
     /**
      * Collect result parts into a complete result.
@@ -105,13 +116,13 @@ public class QueryResult {
             }
 
             return new QueryResult(range, groupLimit.limitList(groups), errors, trace,
-                new ResultLimits(limits.build()), preAggregationSampleSize, false);
+                new ResultLimits(limits.build()), preAggregationSampleSize, Optional.empty());
         };
     }
 
     public static QueryResult error(DateRange range, String errorMessage, QueryTrace trace) {
         return new QueryResult(range, Collections.emptyList(),
             Collections.singletonList(QueryError.fromMessage(errorMessage)), trace,
-            ResultLimits.of(), 0, false);
+            ResultLimits.of(), 0, Optional.empty());
     }
 }

--- a/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryResource.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryResource.java
@@ -157,7 +157,7 @@ public class QueryResource {
                     final QueryMetricsResponse qmr =
                         new QueryMetricsResponse(queryContext.getQueryId(), r.getRange(),
                             r.getGroups(), r.getErrors(), r.getTrace(), r.getLimits(),
-                            Optional.of(r.getPreAggregationSampleSize()), r.isCached());
+                            Optional.of(r.getPreAggregationSampleSize()), r.getCache());
 
                     queryLogger.logFinalResponse(queryContext, qmr);
 
@@ -179,10 +179,10 @@ public class QueryResource {
         response.setTimeout(300, TimeUnit.SECONDS);
 
         httpAsync.bind(response, callback, r -> {
-            QueryMetricsResponse qmr =
+            final QueryMetricsResponse qmr =
                 new QueryMetricsResponse(queryContext.getQueryId(), r.getRange(), r.getGroups(),
                     r.getErrors(), r.getTrace(), r.getLimits(),
-                    Optional.of(r.getPreAggregationSampleSize()), r.isCached());
+                    Optional.of(r.getPreAggregationSampleSize()), r.getCache());
             queryLogger.logFinalResponse(queryContext, qmr);
             return qmr;
         });

--- a/heroic-core/src/test/java/com/spotify/heroic/metric/BasicSerializationTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/metric/BasicSerializationTest.java
@@ -79,7 +79,7 @@ public class BasicSerializationTest {
 
         final QueryMetricsResponse toVerify =
             new QueryMetricsResponse(queryId, range, result, errors, trace, limits,
-                Optional.empty(), false);
+                Optional.empty(), Optional.empty());
 
         assertSerialization("QueryMetricsResponse.json", toVerify);
     }

--- a/heroic-core/src/test/resources/com/spotify/heroic/metric/QueryMetricsResponse.json
+++ b/heroic-core/src/test/resources/com/spotify/heroic/metric/QueryMetricsResponse.json
@@ -13,6 +13,7 @@
   },
   "limits": [],
   "cached": false,
+  "cache": null,
   "commonTags": {},
   "result": [
     {


### PR DESCRIPTION
This introduces the `CacheInfo` object as a part of the `QueryMetricsResponse`.

This tells us:
* What the cache key used was.
* What the ttl of the cached item was.
* If a cached result was used, or not.