### PR TITLE
[statistics/semantic] Use histogram-with-ttl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -735,6 +735,13 @@
         <scope>compile</scope>
       </dependency>
 
+      <!-- Histogram for low rate metrics -->
+      <dependency>
+        <groupId>com.spotify.metrics</groupId>
+        <artifactId>histogram-with-ttl</artifactId>
+        <version>0.0.5</version>
+      </dependency>
+
       <!-- testing -->
       <dependency>
         <groupId>org.hamcrest</groupId>

--- a/statistics/semantic/pom.xml
+++ b/statistics/semantic/pom.xml
@@ -38,6 +38,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.spotify.metrics</groupId>
+      <artifactId>histogram-with-ttl</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporter.java
@@ -92,8 +92,9 @@ public class SemanticMetadataBackendReporter implements MetadataBackendReporter 
         writesDroppedByRateLimit =
             registry.meter(base.tagged("what", "writes-dropped-by-rate-limit", "unit", Units.DROP));
 
-        writeBatchDuration = registry.histogram(
-            base.tagged("what", "write-bulk-duration", "unit", Units.MILLISECOND));
+        writeBatchDuration =
+            registry.getOrAdd(base.tagged("what", "write-bulk-duration", "unit", Units.MILLISECOND),
+                HistogramBuilder.HISTOGRAM);
     }
 
     @Override

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticQueryReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticQueryReporter.java
@@ -46,10 +46,12 @@ public class SemanticQueryReporter implements QueryReporter {
 
         query =
             new SemanticFutureReporter(registry, base.tagged("what", "query", "unit", Units.QUERY));
-        smallQueryLatency = registry.histogram(
-            base.tagged("what", "small-query-latency", "unit", Units.MILLISECOND));
+        smallQueryLatency =
+            registry.getOrAdd(base.tagged("what", "small-query-latency", "unit", Units.MILLISECOND),
+                HistogramBuilder.HISTOGRAM);
         queryReadRate =
-            registry.histogram(base.tagged("what", "query-read-rate", "unit", Units.COUNT));
+            registry.getOrAdd(base.tagged("what", "query-read-rate", "unit", Units.COUNT),
+                HistogramBuilder.HISTOGRAM);
 
         rpcError = registry.meter(base.tagged("what", "cluster-rpc-error", "unit", Units.FAILURE));
         rpcCancellation =


### PR DESCRIPTION
Combine MinMaxSlidingTimeReservoir and the ReservoirWithTtl from the
histogram-with-ttl repository, to get a nice behavior for Heroic
histogram metrics in both low rate and high rate scenarios.
This avoids histograms flatlining for low rate metrics, and also avoids
min/max from being incorrect for high rate metrics.