### PR TITLE
[metadata,suggest] Rework write metrics

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/MetadataBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/MetadataBackendReporter.java
@@ -24,9 +24,13 @@ package com.spotify.heroic.statistics;
 import com.spotify.heroic.metadata.MetadataBackend;
 
 public interface MetadataBackendReporter {
+    void reportWriteDroppedByCacheHit();
+
     void reportWriteDroppedByRateLimit();
 
-    FutureReporter.Context setupWriteReporter();
+    void reportWriteDroppedByDuplicate();
+
+    FutureReporter.Context setupBackendWriteReporter();
 
     /**
      * report number of successful operations in a batch

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/SuggestBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/SuggestBackendReporter.java
@@ -26,7 +26,11 @@ import com.spotify.heroic.suggest.SuggestBackend;
 public interface SuggestBackendReporter {
     SuggestBackend decorate(SuggestBackend backend);
 
+    void reportWriteDroppedByCacheHit();
+
     void reportWriteDroppedByRateLimit();
+
+    void reportWriteDroppedByDuplicate();
 
     FutureReporter.Context setupWriteReporter();
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetadataBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetadataBackendReporter.java
@@ -49,11 +49,19 @@ public class NoopMetadataBackendReporter implements MetadataBackendReporter {
     }
 
     @Override
+    public void reportWriteDroppedByCacheHit() {
+    }
+
+    @Override
     public void reportWriteDroppedByRateLimit() {
     }
 
     @Override
-    public FutureReporter.Context setupWriteReporter() {
+    public void reportWriteDroppedByDuplicate() {
+    }
+
+    @Override
+    public FutureReporter.Context setupBackendWriteReporter() {
         return NoopFutureReporterContext.get();
     }
 

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopSuggestBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopSuggestBackendReporter.java
@@ -35,7 +35,15 @@ public class NoopSuggestBackendReporter implements SuggestBackendReporter {
     }
 
     @Override
+    public void reportWriteDroppedByCacheHit() {
+    }
+
+    @Override
     public void reportWriteDroppedByRateLimit() {
+    }
+
+    @Override
+    public void reportWriteDroppedByDuplicate() {
     }
 
     @Override

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/DisabledRateLimitedCache.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/DisabledRateLimitedCache.java
@@ -30,7 +30,7 @@ public class DisabledRateLimitedCache<K> implements RateLimitedCache<K> {
     private final ConcurrentMap<K, Boolean> cache;
 
     @Override
-    public boolean acquire(K key) {
+    public boolean acquire(K key, final Runnable cacheHit, final Runnable rateLimitHit) {
         return cache.putIfAbsent(key, true) == null;
     }
 

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/RateLimitedCache.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/RateLimitedCache.java
@@ -25,7 +25,7 @@ public interface RateLimitedCache<K> {
     /**
      * Acquire a permit to perform a piece of work identified by the given key.
      */
-    public boolean acquire(K key);
+    public boolean acquire(K key, Runnable cacheHit, Runnable rateLimitHit);
 
     /**
      * Get number of cached entries.

--- a/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/index/DefaultRateLimitedCacheTest.java
+++ b/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/index/DefaultRateLimitedCacheTest.java
@@ -1,21 +1,20 @@
 package com.spotify.heroic.elasticsearch.index;
 
-import com.google.common.util.concurrent.RateLimiter;
-import com.spotify.heroic.elasticsearch.DefaultRateLimitedCache;
-import com.spotify.heroic.elasticsearch.RateLimitExceededException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
-
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+
+import com.google.common.util.concurrent.RateLimiter;
+import com.spotify.heroic.elasticsearch.DefaultRateLimitedCache;
+import com.spotify.heroic.elasticsearch.RateLimitExceededException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultRateLimitedCacheTest {
@@ -33,12 +32,15 @@ public class DefaultRateLimitedCacheTest {
     @Mock
     Callable<V> callable;
 
+    @Mock
+    Runnable notifier;
+
     @Test
     public void testCacheEarlyHit() throws ExecutionException, RateLimitExceededException {
         final DefaultRateLimitedCache<K> c = new DefaultRateLimitedCache<K>(cache, rateLimiter);
         doReturn(value).when(cache).get(key);
 
-        assertEquals(false, c.acquire(key));
+        assertEquals(false, c.acquire(key, notifier, notifier));
 
         verify(cache).get(key);
         verify(rateLimiter, never()).tryAcquire();
@@ -51,7 +53,7 @@ public class DefaultRateLimitedCacheTest {
         doReturn(null).when(cache).get(key);
         doReturn(false).when(rateLimiter).tryAcquire();
 
-        assertEquals(false, c.acquire(key));
+        assertEquals(false, c.acquire(key, notifier, notifier));
 
         verify(cache).get(key);
         verify(rateLimiter).tryAcquire();
@@ -65,7 +67,7 @@ public class DefaultRateLimitedCacheTest {
         doReturn(true).when(rateLimiter).tryAcquire();
         doReturn(null).when(cache).putIfAbsent(key, true);
 
-        assertEquals(true, c.acquire(key));
+        assertEquals(true, c.acquire(key, notifier, notifier));
 
         verify(cache).get(key);
         verify(rateLimiter).tryAcquire();


### PR DESCRIPTION
write-* - the full set of write requests coming to metadata/suggest BE
writes-dropped-by-cache-hit - writes dropped by the write cache
backend-write-* - the write requests that are actually sent to ES
writes-dropped-by-rate-limit - write requests where ES says the document
already existed.