### PR TITLE
Fix consumer slow-start mode

### DIFF
--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/SimpleRateLimiter.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/SimpleRateLimiter.java
@@ -21,39 +21,9 @@
 
 package com.spotify.heroic.elasticsearch;
 
-import java.util.concurrent.ConcurrentMap;
-import lombok.RequiredArgsConstructor;
-
-/**
- * A cache that does not allow to be called more than a specific rate.
- *
- * @author mehrdad
- */
-@RequiredArgsConstructor
-public class DefaultRateLimitedCache<K> implements RateLimitedCache<K> {
-    private final ConcurrentMap<K, Boolean> cache;
-    private final SimpleRateLimiter rateLimiter;
-
-    public boolean acquire(K key, final Runnable cacheHit, final Runnable rateLimitHit) {
-        if (cache.get(key) != null) {
-            cacheHit.run();
-            return false;
-        }
-
-        if (!rateLimiter.tryAcquire()) {
-            rateLimitHit.run();
-            return false;
-        }
-
-        if (cache.putIfAbsent(key, true) != null) {
-            cacheHit.run();
-            return false;
-        }
-
-        return true;
-    }
-
-    public int size() {
-        return cache.size();
-    }
+public interface SimpleRateLimiter {
+    /**
+     * Acquires a permit if it can be acquired immediately without delay.
+     */
+    boolean tryAcquire();
 }

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/SlowStartRateLimiter.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/SlowStartRateLimiter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.elasticsearch;
+
+import com.google.common.util.concurrent.RateLimiter;
+import com.spotify.heroic.time.Clock;
+import java.util.concurrent.TimeUnit;
+import lombok.Data;
+
+@Data
+public class SlowStartRateLimiter implements SimpleRateLimiter {
+    private final RateLimiter rateLimiter;
+    private final double ratePerSecond;
+    private final long slowStartDuration;
+    private final TimeUnit slowStartTimeUnit;
+    private final Clock clock;
+    private final long startTime;
+
+    /* Don't use an atomic type, to improve performance. The cost of this is that during startup
+     * there might be some extra slow path calls verifying the time in threads until all threads
+     * has seen the updated boolean value. No harm tho. This only affects startup performance and
+     * improves performance after. Repeated calls to setRate() are ok. */
+    private volatile boolean isSlowStartMode;
+
+    public SlowStartRateLimiter(
+        final double ratePerSecond, final double slowStartRatePerSecond,
+        final long slowStartDuration, final TimeUnit slowStartTimeUnit
+    ) {
+        this(ratePerSecond, slowStartRatePerSecond, slowStartDuration, slowStartTimeUnit,
+            Clock.system());
+    }
+
+    public SlowStartRateLimiter(
+        final double ratePerSecond, final double slowStartRatePerSecond,
+        final long slowStartDuration, final TimeUnit slowStartTimeUnit, final Clock clock
+    ) {
+        this.rateLimiter = RateLimiter.create(slowStartRatePerSecond);
+        this.ratePerSecond = ratePerSecond;
+        this.slowStartDuration = slowStartDuration;
+        this.slowStartTimeUnit = slowStartTimeUnit;
+        this.clock = clock;
+        this.startTime = clock.currentTimeMillis();
+        this.isSlowStartMode = true;
+    }
+
+    @Override
+    public boolean tryAcquire() {
+        return tryAcquire(1);
+    }
+
+    public boolean tryAcquire(final int num) {
+        if (isSlowStartMode) {
+            final long currTime = clock.currentTimeMillis();
+            if (startTime + slowStartTimeUnit.toMillis(slowStartDuration) < currTime) {
+                isSlowStartMode = false;
+                rateLimiter.setRate(ratePerSecond);
+            }
+        }
+
+        return rateLimiter.tryAcquire(num);
+    }
+}

--- a/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/index/DefaultRateLimitedCacheTest.java
+++ b/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/index/DefaultRateLimitedCacheTest.java
@@ -5,9 +5,9 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import com.google.common.util.concurrent.RateLimiter;
 import com.spotify.heroic.elasticsearch.DefaultRateLimitedCache;
 import com.spotify.heroic.elasticsearch.RateLimitExceededException;
+import com.spotify.heroic.elasticsearch.SimpleRateLimiter;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
@@ -22,7 +22,7 @@ public class DefaultRateLimitedCacheTest {
     ConcurrentMap<K, Boolean> cache;
 
     @Mock
-    RateLimiter rateLimiter;
+    SimpleRateLimiter rateLimiter;
 
     final Boolean value = true;
 

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/ElasticsearchMetadataModule.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/ElasticsearchMetadataModule.java
@@ -45,6 +45,8 @@ import com.spotify.heroic.elasticsearch.ConnectionModule;
 import com.spotify.heroic.elasticsearch.DefaultRateLimitedCache;
 import com.spotify.heroic.elasticsearch.DisabledRateLimitedCache;
 import com.spotify.heroic.elasticsearch.RateLimitedCache;
+import com.spotify.heroic.elasticsearch.SimpleRateLimiter;
+import com.spotify.heroic.elasticsearch.SlowStartRateLimiter;
 import com.spotify.heroic.lifecycle.LifeCycle;
 import com.spotify.heroic.lifecycle.LifeCycleManager;
 import com.spotify.heroic.metadata.MetadataBackend;
@@ -71,6 +73,7 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
     private static final int DEFAULT_DELETE_PARALLELISM = 20;
     private static final double DEFAULT_WRITES_PER_SECOND = 3000d;
     private static final long DEFAULT_RATE_LIMIT_SLOW_START_SECONDS = 0L;
+    private static final int DEFAULT_RATE_LIMIT_SLOW_START_MULTIPLIER = 4;
     private static final long DEFAULT_WRITE_CACHE_DURATION_MINUTES = 240L;
     public static final String DEFAULT_GROUP = "elasticsearch";
     public static final String DEFAULT_TEMPLATE_NAME = "heroic-metadata";
@@ -210,8 +213,22 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
                 return new DisabledRateLimitedCache<>(cache.asMap());
             }
 
-            return new DefaultRateLimitedCache<>(cache.asMap(),
-                RateLimiter.create(writesPerSecond, rateLimitSlowStartSeconds, TimeUnit.SECONDS));
+            SimpleRateLimiter rateLimiter;
+            if (rateLimitSlowStartSeconds <= 0) {
+                rateLimiter = new SimpleRateLimiter() {
+                    RateLimiter limiter = RateLimiter.create(writesPerSecond);
+                    @Override
+                    public boolean tryAcquire() {
+                        return limiter.tryAcquire();
+                    }
+                };
+            } else {
+                rateLimiter = new SlowStartRateLimiter(writesPerSecond,
+                    writesPerSecond / DEFAULT_RATE_LIMIT_SLOW_START_MULTIPLIER,
+                    rateLimitSlowStartSeconds, TimeUnit.SECONDS);
+            }
+
+            return new DefaultRateLimitedCache<>(cache.asMap(), rateLimiter);
         }
 
         @Provides


### PR DESCRIPTION
Reimplement so that we avoid using a seemingly problematic rate limiter implementation.

Instead of using the Guava SmoothWarmingUp implementation, use the
simple SmoothBursty and apply a manual slow start period to it in a
wrapper. Slow start duration is still configurable with
rateLimitSlowStartSeconds. The amount of slow start is hard coded to
factor 4. During startup the rate will be 4 times lower for x seconds.