### PR TITLE
[all] provide object-based deserialization for filters

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/filter/AndFilter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/filter/AndFilter.java
@@ -21,6 +21,7 @@
 
 package com.spotify.heroic.filter;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.spotify.heroic.ObjectHasher;
@@ -37,15 +38,16 @@ import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.StringUtils;
 
 @Data
-@EqualsAndHashCode(of = {"OPERATOR", "statements"}, doNotUseGetters = true)
+@EqualsAndHashCode(of = {"OPERATOR", "filters"}, doNotUseGetters = true)
+@JsonTypeName("and")
 public class AndFilter implements Filter {
     public static final String OPERATOR = "and";
 
-    private final List<Filter> statements;
+    private final List<Filter> filters;
 
     @Override
     public boolean apply(Series series) {
-        return statements.stream().allMatch(s -> s.apply(series));
+        return filters.stream().allMatch(s -> s.apply(series));
     }
 
     @Override
@@ -55,10 +57,10 @@ public class AndFilter implements Filter {
 
     @Override
     public String toString() {
-        final List<String> parts = new ArrayList<>(statements.size() + 1);
+        final List<String> parts = new ArrayList<>(filters.size() + 1);
         parts.add(OPERATOR);
 
-        for (final Filter statement : statements) {
+        for (final Filter statement : filters) {
             parts.add(statement.toString());
         }
 
@@ -67,13 +69,13 @@ public class AndFilter implements Filter {
 
     @Override
     public Filter optimize() {
-        return optimize(flatten(this.statements));
+        return optimize(flatten(this.filters));
     }
 
-    static SortedSet<Filter> flatten(final Collection<Filter> statements) {
+    static SortedSet<Filter> flatten(final Collection<Filter> filters) {
         final SortedSet<Filter> result = new TreeSet<>();
 
-        statements.stream().flatMap(f -> f.optimize().visit(new Filter.Visitor<Stream<Filter>>() {
+        filters.stream().flatMap(f -> f.optimize().visit(new Filter.Visitor<Stream<Filter>>() {
             @Override
             public Stream<Filter> visitAnd(final AndFilter and) {
                 return and.terms().stream().map(Filter::optimize);
@@ -104,22 +106,22 @@ public class AndFilter implements Filter {
         return result;
     }
 
-    static Filter optimize(final SortedSet<Filter> statements) {
+    static Filter optimize(final SortedSet<Filter> filters) {
         final SortedSet<Filter> result = new TreeSet<>();
 
-        for (final Filter f : statements) {
+        for (final Filter f : filters) {
             if (f instanceof NotFilter) {
                 // Optimize away expressions which are always false.
                 // Example: foo = bar and !(foo = bar)
 
-                if (statements.contains(((NotFilter) f).getFilter())) {
+                if (filters.contains(((NotFilter) f).getFilter())) {
                     return FalseFilter.get();
                 }
             } else if (f instanceof StartsWithFilter) {
                 // Optimize away prefixes which encompass each other.
                 // Example: foo ^ hello and foo ^ helloworld -> foo ^ helloworld
 
-                if (FilterUtils.containsPrefixedWith(statements, (StartsWithFilter) f,
+                if (FilterUtils.containsPrefixedWith(filters, (StartsWithFilter) f,
                     (inner, outer) -> FilterUtils.prefixedWith(inner.getValue(),
                         outer.getValue()))) {
                     continue;
@@ -128,14 +130,14 @@ public class AndFilter implements Filter {
                 // Optimize matchTag expressions which are always false.
                 // Example: foo = bar and foo = baz
 
-                if (FilterUtils.containsConflictingMatchTag(statements, (MatchTagFilter) f)) {
+                if (FilterUtils.containsConflictingMatchTag(filters, (MatchTagFilter) f)) {
                     return FalseFilter.get();
                 }
             } else if (f instanceof MatchKeyFilter) {
                 // Optimize matchTag expressions which are always false.
                 // Example: $key = bar and $key = baz
 
-                if (FilterUtils.containsConflictingMatchKey(statements, (MatchKeyFilter) f)) {
+                if (FilterUtils.containsConflictingMatchKey(filters, (MatchKeyFilter) f)) {
                     return FalseFilter.get();
                 }
             }
@@ -160,7 +162,7 @@ public class AndFilter implements Filter {
     }
 
     public List<Filter> terms() {
-        return statements;
+        return filters;
     }
 
     @Override
@@ -177,13 +179,13 @@ public class AndFilter implements Filter {
 
     @Override
     public String toDSL() {
-        return "(" + and.join(statements.stream().map(Filter::toDSL).iterator()) + ")";
+        return "(" + and.join(filters.stream().map(Filter::toDSL).iterator()) + ")";
     }
 
     @Override
     public void hashTo(final ObjectHasher hasher) {
         hasher.putObject(this.getClass(), () -> {
-            hasher.putField("statements", statements, hasher.list(hasher.with(Filter::hashTo)));
+            hasher.putField("filters", filters, hasher.list(hasher.with(Filter::hashTo)));
         });
     }
 

--- a/heroic-component/src/main/java/com/spotify/heroic/filter/FalseFilter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/filter/FalseFilter.java
@@ -21,6 +21,7 @@
 
 package com.spotify.heroic.filter;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.spotify.heroic.ObjectHasher;
 import com.spotify.heroic.common.Series;
 import lombok.Data;
@@ -28,6 +29,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(of = {"OPERATOR"}, doNotUseGetters = true)
+@JsonTypeName("false")
 public class FalseFilter implements Filter {
     public static final String OPERATOR = "false";
 

--- a/heroic-component/src/main/java/com/spotify/heroic/filter/FilterUtils.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/filter/FilterUtils.java
@@ -119,7 +119,7 @@ public class FilterUtils {
             if (inner instanceof MatchKeyFilter) {
                 final MatchKeyFilter matchKey = (MatchKeyFilter) inner;
 
-                if (!outer.getValue().equals(matchKey.getValue())) {
+                if (!outer.getKey().equals(matchKey.getKey())) {
                     return true;
                 }
             }

--- a/heroic-component/src/main/java/com/spotify/heroic/filter/HasTagFilter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/filter/HasTagFilter.java
@@ -21,6 +21,7 @@
 
 package com.spotify.heroic.filter;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.spotify.heroic.ObjectHasher;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.grammar.DSL;
@@ -29,6 +30,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(of = {"OPERATOR", "tag"}, doNotUseGetters = true)
+@JsonTypeName("hasTag")
 public class HasTagFilter implements Filter {
     public static final String OPERATOR = "+";
 

--- a/heroic-component/src/main/java/com/spotify/heroic/filter/MatchKeyFilter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/filter/MatchKeyFilter.java
@@ -21,6 +21,7 @@
 
 package com.spotify.heroic.filter;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.spotify.heroic.ObjectHasher;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.grammar.DSL;
@@ -28,15 +29,16 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
-@EqualsAndHashCode(of = {"OPERATOR", "value"}, doNotUseGetters = true)
+@EqualsAndHashCode(of = {"OPERATOR", "key"}, doNotUseGetters = true)
+@JsonTypeName("key")
 public class MatchKeyFilter implements Filter {
     public static final String OPERATOR = "key";
 
-    private final String value;
+    private final String key;
 
     @Override
     public boolean apply(Series series) {
-        return series.getKey().equals(value);
+        return series.getKey().equals(key);
     }
 
     @Override
@@ -46,7 +48,7 @@ public class MatchKeyFilter implements Filter {
 
     @Override
     public String toString() {
-        return "[" + OPERATOR + ", " + value + "]";
+        return "[" + OPERATOR + ", " + key + "]";
     }
 
     @Override
@@ -66,18 +68,18 @@ public class MatchKeyFilter implements Filter {
         }
 
         final MatchKeyFilter other = (MatchKeyFilter) o;
-        return value.compareTo(other.value);
+        return key.compareTo(other.key);
     }
 
     @Override
     public String toDSL() {
-        return "$key = " + DSL.dumpString(value);
+        return "$key = " + DSL.dumpString(key);
     }
 
     @Override
     public void hashTo(final ObjectHasher hasher) {
         hasher.putObject(getClass(), () -> {
-            hasher.putField("value", value, hasher.string());
+            hasher.putField("key", key, hasher.string());
         });
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/filter/MatchTagFilter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/filter/MatchTagFilter.java
@@ -21,6 +21,7 @@
 
 package com.spotify.heroic.filter;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.spotify.heroic.ObjectHasher;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.grammar.DSL;
@@ -29,6 +30,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(of = {"OPERATOR", "tag", "value"}, doNotUseGetters = true)
+@JsonTypeName("matchTag")
 public class MatchTagFilter implements Filter {
     public static final String OPERATOR = "=";
 

--- a/heroic-component/src/main/java/com/spotify/heroic/filter/NotFilter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/filter/NotFilter.java
@@ -21,6 +21,7 @@
 
 package com.spotify.heroic.filter;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.spotify.heroic.ObjectHasher;
 import com.spotify.heroic.common.Series;
 import lombok.Data;
@@ -28,6 +29,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(of = {"OPERATOR", "filter"}, doNotUseGetters = true)
+@JsonTypeName("not")
 public class NotFilter implements Filter {
     public static final String OPERATOR = "not";
 

--- a/heroic-component/src/main/java/com/spotify/heroic/filter/RawFilter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/filter/RawFilter.java
@@ -21,6 +21,7 @@
 
 package com.spotify.heroic.filter;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.spotify.heroic.ObjectHasher;
 import com.spotify.heroic.common.Series;
 import lombok.Data;
@@ -28,6 +29,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(of = {"OPERATOR", "filter"}, doNotUseGetters = true)
+@JsonTypeName("raw")
 public class RawFilter implements Filter {
     public static final String OPERATOR = "q";
 

--- a/heroic-component/src/main/java/com/spotify/heroic/filter/RegexFilter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/filter/RegexFilter.java
@@ -21,6 +21,7 @@
 
 package com.spotify.heroic.filter;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.spotify.heroic.ObjectHasher;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.grammar.DSL;
@@ -30,6 +31,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(of = {"OPERATOR", "tag", "value"}, doNotUseGetters = true)
+@JsonTypeName("regex")
 public class RegexFilter implements Filter {
     public static final String OPERATOR = "~";
 

--- a/heroic-component/src/main/java/com/spotify/heroic/filter/StartsWithFilter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/filter/StartsWithFilter.java
@@ -21,6 +21,7 @@
 
 package com.spotify.heroic.filter;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.spotify.heroic.ObjectHasher;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.grammar.DSL;
@@ -29,6 +30,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(of = {"OPERATOR", "tag", "value"}, doNotUseGetters = true)
+@JsonTypeName("startsWith")
 public class StartsWithFilter implements Filter {
     public static final String OPERATOR = "^";
 

--- a/heroic-component/src/main/java/com/spotify/heroic/filter/TrueFilter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/filter/TrueFilter.java
@@ -21,6 +21,7 @@
 
 package com.spotify.heroic.filter;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.spotify.heroic.ObjectHasher;
 import com.spotify.heroic.common.Series;
 import lombok.Data;
@@ -28,6 +29,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(of = {"OPERATOR"}, doNotUseGetters = true)
+@JsonTypeName("true")
 public class TrueFilter implements Filter {
     public static final String OPERATOR = "true";
 

--- a/heroic-component/src/test/java/com/spotify/heroic/filter/FilterTest.java
+++ b/heroic-component/src/test/java/com/spotify/heroic/filter/FilterTest.java
@@ -1,17 +1,5 @@
 package com.spotify.heroic.filter;
 
-import com.google.common.collect.ImmutableList;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.TreeSet;
-
 import static com.spotify.heroic.filter.Filter.and;
 import static com.spotify.heroic.filter.Filter.hasTag;
 import static com.spotify.heroic.filter.Filter.matchKey;
@@ -22,6 +10,17 @@ import static com.spotify.heroic.filter.Filter.regex;
 import static com.spotify.heroic.filter.Filter.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FilterTest {
@@ -172,7 +171,6 @@ public class FilterTest {
 
         AndFilter andFilterC = and(matchTag(tag, value), startsWith(tag, value), a, a);
         assertEquals(1, andFilterB.compareTo(andFilterC));
-
     }
 
     @Test
@@ -183,7 +181,7 @@ public class FilterTest {
 
         AndFilter andFilter = (AndFilter) filter;
 
-        assertEquals(6, andFilter.getStatements().size());
+        assertEquals(6, andFilter.getFilters().size());
 
         Filter optimizedFilter = filter.optimize();
 
@@ -191,47 +189,43 @@ public class FilterTest {
 
         AndFilter optimizedAndFilter = (AndFilter) optimizedFilter;
 
-        assertEquals(5, optimizedAndFilter.getStatements().size());
-
-
+        assertEquals(5, optimizedAndFilter.getFilters().size());
     }
-
 
     @Test
     public void testAndFilterWithConflictingMatchKeys() {
-        Filter filter = AndFilter.of(matchKey(tag), matchKey(value), startsWith(tag, value), a, b, c);
+        Filter filter =
+            AndFilter.of(matchKey(tag), matchKey(value), startsWith(tag, value), a, b, c);
 
         assertTrue(filter instanceof AndFilter);
 
         AndFilter andFilter = (AndFilter) filter;
 
-        assertEquals(6, andFilter.getStatements().size());
+        assertEquals(6, andFilter.getFilters().size());
 
         Filter optimizedFilter = filter.optimize();
 
         assertTrue(optimizedFilter instanceof FalseFilter);
-
-
     }
 
     @Test
     public void testFilterToString() {
-        Filter filter = AndFilter.of(new TrueFilter(), new FalseFilter(), matchKey(tag), matchKey(value),
-            startsWith(tag, value), a, b, c, OrFilter.of(a, b, c));
+        Filter filter =
+            AndFilter.of(new TrueFilter(), new FalseFilter(), matchKey(tag), matchKey(value),
+                startsWith(tag, value), a, b, c, OrFilter.of(a, b, c));
 
-        assertEquals("[and, [true], [false], [key, tag], [key, value], [^, tag, value], [+, a], [+, b], [+, c], " +
-            "[or, [+, a], [+, b], [+, c]]]", filter.toString());
-
+        assertEquals(
+            "[and, [true], [false], [key, tag], [key, value], [^, tag, value], [+, a], [+, b], " +
+                "[+, c], " + "[or, [+, a], [+, b], [+, c]]]", filter.toString());
     }
 
     @Test
     public void testFilterToDSL() {
 
-        Filter filter = AndFilter.of(new TrueFilter(), new FalseFilter(), matchKey(tag), matchKey(value),
-            startsWith(tag, value), a, b, c, OrFilter.of(a, b, c));
+        Filter filter =
+            AndFilter.of(new TrueFilter(), new FalseFilter(), matchKey(tag), matchKey(value),
+                startsWith(tag, value), a, b, c, OrFilter.of(a, b, c));
         assertEquals("(true and false and $key = tag and $key = value and " +
             "tag ^ value and +a and +b and +c and (+a or +b or +c))", filter.toDSL());
-
     }
-
 }

--- a/heroic-core/src/test/java/com/spotify/heroic/filter/FilterSerializerTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/filter/FilterSerializerTest.java
@@ -1,17 +1,5 @@
 package com.spotify.heroic.filter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.spotify.heroic.HeroicMappers;
-import com.spotify.heroic.grammar.QueryParser;
-import com.spotify.heroic.test.FakeModuleLoader;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import java.io.IOException;
-
 import static com.spotify.heroic.filter.Filter.and;
 import static com.spotify.heroic.filter.Filter.hasTag;
 import static com.spotify.heroic.filter.Filter.matchKey;
@@ -22,12 +10,16 @@ import static com.spotify.heroic.filter.Filter.regex;
 import static com.spotify.heroic.filter.Filter.startsWith;
 import static org.junit.Assert.assertEquals;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.heroic.test.FakeModuleLoader;
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
 @RunWith(MockitoJUnitRunner.class)
 public class FilterSerializerTest {
-    @Mock
-    private QueryParser parser;
-
-    private ObjectMapper m = FakeModuleLoader.builder().build().json();;
+    private ObjectMapper m = FakeModuleLoader.builder().build().json();
 
     @Test
     public void serializeTest() throws IOException {
@@ -45,10 +37,41 @@ public class FilterSerializerTest {
             "[\"or\",[\"=\",\"a\",\"b\"],[\"=\",\"c\",\"d\"]]");
     }
 
+    /**
+     * Check that object type-based variants work as expected.
+     */
+    @Test
+    public void objectTest() throws IOException {
+        checkObjectFilter(matchTag("a", "b"),
+            "{\"type\":\"matchTag\",\"tag\":\"a\",\"value\":\"b\"}");
+
+        checkObjectFilter(startsWith("a", "b"),
+            "{\"type\":\"startsWith\",\"tag\":\"a\",\"value\":\"b\"}");
+        checkObjectFilter(hasTag("a"), "{\"type\":\"hasTag\",\"tag\":\"a\"}");
+        checkObjectFilter(matchKey("a"), "{\"type\":\"key\",\"key\":\"a\"}");
+        checkObjectFilter(regex("a", "b"), "{\"type\":\"regex\",\"tag\":\"a\",\"value\":\"b\"}");
+        checkObjectFilter(not(matchTag("a", "b")),
+            "{\"type\":\"not\",\"filter\":{\"type\":\"matchTag\",\"tag\":\"a\",\"value\":\"b\"}}");
+
+        checkObjectFilter(and(matchTag("a", "b"), matchTag("c", "d")),
+            "{\"type\":\"and\",\"filters\":[{\"type\":\"matchTag\",\"tag\":\"a\"," +
+                "\"value\":\"b\"}," + "{\"type\":\"matchTag\",\"tag\":\"c\",\"value\":\"d\"}]}");
+
+        checkObjectFilter(or(matchTag("a", "b"), matchTag("c", "d")),
+            "{\"type\":\"or\",\"filters\":[{\"type\":\"matchTag\",\"tag\":\"a\",\"value\":\"b\"}," +
+                "{\"type\":\"matchTag\",\"tag\":\"c\",\"value\":\"d\"}]}");
+    }
+
     private void checkFilter(final Filter filter, final String json) throws IOException {
         final Filter f = filter.optimize();
 
         assertEquals(f, m.readValue(json, Filter.class));
         assertEquals(json, m.writeValueAsString(f));
+    }
+
+    private void checkObjectFilter(final Filter filter, final String json) throws IOException {
+        final Filter f = filter.optimize();
+
+        assertEquals(f, m.readValue(json, Filter.class));
     }
 }

--- a/heroic-loading/src/main/java/com/spotify/heroic/filter/CoreFilterModifier.java
+++ b/heroic-loading/src/main/java/com/spotify/heroic/filter/CoreFilterModifier.java
@@ -21,9 +21,9 @@
 
 package com.spotify.heroic.filter;
 
-import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+import javax.inject.Inject;
 
 public final class CoreFilterModifier implements FilterModifier {
     @Inject
@@ -52,7 +52,7 @@ public final class CoreFilterModifier implements FilterModifier {
             public Filter visitOr(final OrFilter or) {
                 final List<Filter> statements = new ArrayList<Filter>();
 
-                for (final Filter f : or.getStatements()) {
+                for (final Filter f : or.getFilters()) {
                     statements.add(removeTag(f, tag));
                 }
 

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
@@ -376,8 +376,8 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
     }
 
     /**
-     * Collect the result of a list of operations and convert into a
-     * {@link com.spotify.heroic.metadata.DeleteSeries}.
+     * Collect the result of a list of operations and convert into a {@link
+     * com.spotify.heroic.metadata.DeleteSeries}.
      *
      * @return a {@link eu.toolchain.async.StreamCollector}
      */
@@ -550,7 +550,7 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
 
             @Override
             public QueryBuilder visitMatchKey(final MatchKeyFilter matchKey) {
-                return termQuery(KEY, matchKey.getValue());
+                return termQuery(KEY, matchKey.getKey());
             }
 
             @Override

--- a/suggest/elasticsearch/src/main/java/com/spotify/heroic/suggest/elasticsearch/SuggestBackendKV.java
+++ b/suggest/elasticsearch/src/main/java/com/spotify/heroic/suggest/elasticsearch/SuggestBackendKV.java
@@ -725,7 +725,7 @@ public class SuggestBackendKV extends AbstractElasticsearchBackend
 
             @Override
             public QueryBuilder visitMatchKey(final MatchKeyFilter matchKey) {
-                return termQuery(KEY, matchKey.getValue());
+                return termQuery(KEY, matchKey.getKey());
             }
 
             @Override


### PR DESCRIPTION
This commit adds object-based deserialization for filters.

Object-based deserialization emulates Jackson's type-based serialization, by allowing the following kind of objects to be accepted as filters (these two are now equivalent):
```json
["=", "foo", "bar"]
{"type": "matchTag", "tag": "foo", "value": "bar"}
```
The reason behind doing this is to better support static languages, and their corresponding serialization frameworks. While it is very common to immediately support the second variant, the first one is not.