### PR TITLE
[aggregation] Fix Delta aggregation with dist agg

### DIFF
--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/DeltaInstance.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/DeltaInstance.java
@@ -67,6 +67,11 @@ public class DeltaInstance implements AggregationInstance {
     }
 
     @Override
+    public AggregationInstance reducer() {
+        return INNER;
+    }
+
+    @Override
     public boolean distributable() {
         return false;
     }


### PR DESCRIPTION
When using distributed aggregations, a delta aggregation were combining the data with a second delta aggregation, causing inaccurate result.