### PR TITLE
Back to bt 0.9.6.2

### DIFF
--- a/metric/bigtable/pom.xml
+++ b/metric/bigtable/pom.xml
@@ -22,7 +22,7 @@
   </description>
 
   <properties>
-    <bigtable.version>0.9.7.1</bigtable.version>
+    <bigtable.version>0.9.6.2</bigtable.version>
   </properties>
 
   <dependencies>

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnectionBuilder.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnectionBuilder.java
@@ -21,12 +21,12 @@
 
 package com.spotify.heroic.metric.bigtable;
 
+import com.google.appengine.repackaged.com.google.common.collect.ImmutableList;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.BulkOptions;
 import com.google.cloud.bigtable.config.CredentialOptions;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.grpc.BigtableSession;
-import com.google.common.collect.ImmutableList;
 import com.spotify.heroic.bigtable.grpc.Status;
 import com.spotify.heroic.metric.bigtable.api.BigtableDataClient;
 import com.spotify.heroic.metric.bigtable.api.BigtableDataClientImpl;

--- a/repackaged/bigtable/pom.xml
+++ b/repackaged/bigtable/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <bigtable.version>0.9.7.1</bigtable.version>
+    <bigtable.version>0.9.6.2</bigtable.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
   </properties>
 
   <groupId>com.spotify.heroic.repackaged</groupId>
   <artifactId>bigtable-client-core</artifactId>
   <packaging>jar</packaging>
-  <version>0.9.7.1</version>
+  <version>0.9.6.2</version>
 
   <name>Heroic: Re-Packaging of Bigtable Client Utilities</name>
 

--- a/rpc/grpc/pom.xml
+++ b/rpc/grpc/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <properties>
-    <grpc.version>1.3.0</grpc.version>
+    <grpc.version>1.2.0</grpc.version>
   </properties>
 
   <groupId>com.spotify.heroic.rpc</groupId>


### PR DESCRIPTION
Revert the BT client library from 0.9.7.1 to 0.9.6.2, because of a known issue in 0.9.7.1. Version 1.0.0 will have the fix, but is not out yet.