### PR TITLE
Remove non-sliced metric fetch code path

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/common/Features.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/Features.java
@@ -40,8 +40,11 @@ public class Features {
     /**
      * Default set of features.
      */
-    public static final Features DEFAULT = Features.create(
-        ImmutableSet.<Feature>builder().add(Feature.SHIFT_RANGE).add(Feature.END_BUCKET).build());
+    public static final Features DEFAULT = Features.create(ImmutableSet.<Feature>builder()
+        .add(Feature.SHIFT_RANGE)
+        .add(Feature.END_BUCKET)
+        .add(Feature.SLICED_DATA_FETCH)
+        .build());
 
     private final SortedSet<Feature> features;
 

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/MetricBackend.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/MetricBackend.java
@@ -59,16 +59,6 @@ public interface MetricBackend extends Initializing, Grouped, Collected {
      *
      * @param request Fetch request to use.
      * @param watcher The watcher implementation to use when fetching metrics.
-     * @return A future containing the fetched data wrapped in a {@link FetchData} structure.
-     */
-    @Deprecated
-    AsyncFuture<FetchData> fetch(FetchData.Request request, FetchQuotaWatcher watcher);
-
-    /**
-     * Query for data points that is part of the specified list of rows and range.
-     *
-     * @param request Fetch request to use.
-     * @param watcher The watcher implementation to use when fetching metrics.
      * @param metricsConsumer The consumer that receives the fetched data
      * @return A future containing the fetch result.
      */

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -176,7 +176,6 @@ public class LocalMetricManager implements MetricManager {
             private final QueryOptions options;
             private final DataInMemoryReporter dataInMemoryReporter;
             private final MetricType source;
-            private final boolean slicedFetch;
 
             private Transform(
                 final FullQuery.Request request, final boolean failOnLimits,
@@ -198,7 +197,6 @@ public class LocalMetricManager implements MetricManager {
                 this.dataInMemoryReporter = dataInMemoryReporter;
 
                 final Features features = request.getFeatures();
-                this.slicedFetch = features.hasFeature(Feature.SLICED_DATA_FETCH);
                 this.bucketStrategy = options
                     .getBucketStrategy()
                     .orElseGet(
@@ -209,12 +207,6 @@ public class LocalMetricManager implements MetricManager {
             @Override
             public AsyncFuture<FullQuery> transform(final FindSeries result) throws Exception {
                 final ResultLimits limits;
-
-                if (!slicedFetch) {
-                    return async.resolved(FullQuery.error(namedWatch.end(), QueryError.fromMessage(
-                        "Unable to read metrics data due to mandatory feature 'com.spotify.heroic" +
-                            ".sliced_data_fetch' being disabled.")));
-                }
 
                 if (result.isLimited()) {
                     if (failOnLimits) {

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/Fetch.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/Fetch.java
@@ -132,20 +132,10 @@ public class Fetch implements ShellTask {
             return async.resolved();
         };
 
-        if (params.slicedDataFetch) {
-            return readGroup
-                .fetch(new FetchData.Request(source, series, range, options),
-                    FetchQuotaWatcher.NO_QUOTA, printMetricsCollection)
-                .lazyTransform(handleResult);
-        } else {
-            return readGroup
-                .fetch(new FetchData.Request(source, series, range, options),
-                    FetchQuotaWatcher.NO_QUOTA)
-                .lazyTransform(resultData -> {
-                    resultData.getGroups().forEach(printMetricsCollection);
-                    return handleResult.transform(resultData.getResult());
-                });
-        }
+        return readGroup
+            .fetch(new FetchData.Request(source, series, range, options),
+                FetchQuotaWatcher.NO_QUOTA, printMetricsCollection)
+            .lazyTransform(handleResult);
     }
 
     private boolean flipped(Calendar last, Calendar current) {

--- a/heroic-dist/src/test/java/com/spotify/heroic/LoggingMetricModule.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/LoggingMetricModule.java
@@ -74,13 +74,6 @@ class LoggingMetricModule implements MetricModule {
         }
 
         @Override
-        public AsyncFuture<FetchData> fetch(
-            final FetchData.Request request, final FetchQuotaWatcher watcher
-        ) {
-            return delegate.fetch(request, watcher);
-        }
-
-        @Override
         public AsyncFuture<FetchData.Result> fetch(
             final FetchData.Request request, final FetchQuotaWatcher watcher,
             final Consumer<MetricCollection> metricsConsumer

--- a/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsMetricBackend.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsMetricBackend.java
@@ -73,14 +73,6 @@ class BigtableAnalyticsMetricBackend implements MetricBackend {
     }
 
     @Override
-    public AsyncFuture<FetchData> fetch(
-        final FetchData.Request request, final FetchQuotaWatcher watcher
-    ) {
-        analytics.reportFetchSeries(LocalDate.now(), request.getSeries());
-        return backend.fetch(request, watcher);
-    }
-
-    @Override
     public AsyncFuture<FetchData.Result> fetch(
         final FetchData.Request request, final FetchQuotaWatcher watcher,
         final Consumer<MetricCollection> metricsConsumer

--- a/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryBackend.java
+++ b/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryBackend.java
@@ -116,14 +116,6 @@ public class MemoryBackend extends AbstractMetricBackend {
     }
 
     @Override
-    public AsyncFuture<FetchData> fetch(FetchData.Request request, FetchQuotaWatcher watcher) {
-        final QueryTrace.NamedWatch w = QueryTrace.watch(FETCH);
-        final MemoryKey key = new MemoryKey(request.getType(), request.getSeries());
-        final MetricCollection metrics = doFetch(key, request.getRange(), watcher);
-        return async.resolved(FetchData.of(w.end(), ImmutableList.of(), ImmutableList.of(metrics)));
-    }
-
-    @Override
     public AsyncFuture<FetchData.Result> fetch(
         FetchData.Request request, FetchQuotaWatcher watcher,
         Consumer<MetricCollection> metricsConsumer

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
@@ -225,13 +225,6 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
         }
 
         @Override
-        public AsyncFuture<FetchData> fetch(
-            final FetchData.Request request, final FetchQuotaWatcher watcher
-        ) {
-            return delegate.fetch(request, watcher).onDone(fetch.setup());
-        }
-
-        @Override
         public AsyncFuture<FetchData.Result> fetch(
             final FetchData.Request request, final FetchQuotaWatcher watcher,
             final Consumer<MetricCollection> metricsConsumer


### PR DESCRIPTION
This code path was already marked deprecated before, and was kept
as a safety fallback while adding the sliced fetch support.
Removing this code will make it easier to do future changes.