### PR TITLE
Blocking write cache

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/HeroicReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/HeroicReporter.java
@@ -23,6 +23,7 @@ package com.spotify.heroic.statistics;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 public interface HeroicReporter {
     ConsumerReporter newConsumer(String id);
@@ -40,4 +41,9 @@ public interface HeroicReporter {
     QueryReporter newQueryReporter();
 
     void registerShards(Set<Map<String, String>> knownShards);
+
+    /**
+     * Register cache size instrumentation.
+     */
+    void registerCacheSize(String id, Supplier<Long> cacheSize);
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopHeroicReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopHeroicReporter.java
@@ -32,6 +32,7 @@ import com.spotify.heroic.statistics.SuggestBackendReporter;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 public class NoopHeroicReporter implements HeroicReporter {
     @Override
@@ -71,6 +72,10 @@ public class NoopHeroicReporter implements HeroicReporter {
 
     @Override
     public void registerShards(Set<Map<String, String>> knownShards) {
+    }
+
+    @Override
+    public void registerCacheSize(final String id, final Supplier<Long> cacheSize) {
     }
 
     private static final NoopHeroicReporter instance = new NoopHeroicReporter();

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/DefaultRateLimitedCache.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/DefaultRateLimitedCache.java
@@ -37,16 +37,13 @@ public class DefaultRateLimitedCache<K> implements RateLimitedCache<K> {
     private final ConcurrentMap<K, Boolean> cache;
     private final RateLimiter rateLimiter;
 
-    public boolean acquire(K key, final Runnable cacheHit, final Runnable rateLimitHit) {
+    public boolean acquire(K key, final Runnable cacheHit) {
         if (cache.get(key) != null) {
             cacheHit.run();
             return false;
         }
 
-        if (!rateLimiter.tryAcquire()) {
-            rateLimitHit.run();
-            return false;
-        }
+        rateLimiter.acquire();
 
         if (cache.putIfAbsent(key, true) != null) {
             cacheHit.run();

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/DisabledRateLimitedCache.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/DisabledRateLimitedCache.java
@@ -21,16 +21,15 @@
 
 package com.spotify.heroic.elasticsearch;
 
-import lombok.RequiredArgsConstructor;
-
 import java.util.concurrent.ConcurrentMap;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class DisabledRateLimitedCache<K> implements RateLimitedCache<K> {
     private final ConcurrentMap<K, Boolean> cache;
 
     @Override
-    public boolean acquire(K key, final Runnable cacheHit, final Runnable rateLimitHit) {
+    public boolean acquire(K key, final Runnable cacheHit) {
         return cache.putIfAbsent(key, true) == null;
     }
 

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/RateLimitedCache.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/RateLimitedCache.java
@@ -25,12 +25,12 @@ public interface RateLimitedCache<K> {
     /**
      * Acquire a permit to perform a piece of work identified by the given key.
      */
-    public boolean acquire(K key, Runnable cacheHit, Runnable rateLimitHit);
+    boolean acquire(K key, Runnable cacheHit);
 
     /**
      * Get number of cached entries.
      *
      * @return Number of entries cached.
      */
-    public int size();
+    int size();
 }

--- a/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/index/DefaultRateLimitedCacheTest.java
+++ b/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/index/DefaultRateLimitedCacheTest.java
@@ -40,7 +40,7 @@ public class DefaultRateLimitedCacheTest {
         final DefaultRateLimitedCache<K> c = new DefaultRateLimitedCache<K>(cache, rateLimiter);
         doReturn(value).when(cache).get(key);
 
-        assertEquals(false, c.acquire(key, notifier, notifier));
+        assertEquals(false, c.acquire(key, notifier));
 
         verify(cache).get(key);
         verify(rateLimiter, never()).tryAcquire();
@@ -48,29 +48,16 @@ public class DefaultRateLimitedCacheTest {
     }
 
     @Test
-    public void testGetRateLimiting() throws ExecutionException, RateLimitExceededException {
-        final DefaultRateLimitedCache<K> c = new DefaultRateLimitedCache<K>(cache, rateLimiter);
-        doReturn(null).when(cache).get(key);
-        doReturn(false).when(rateLimiter).tryAcquire();
-
-        assertEquals(false, c.acquire(key, notifier, notifier));
-
-        verify(cache).get(key);
-        verify(rateLimiter).tryAcquire();
-        verify(cache, never()).putIfAbsent(key, true);
-    }
-
-    @Test
     public void testGet() throws ExecutionException, RateLimitExceededException {
         final DefaultRateLimitedCache<K> c = new DefaultRateLimitedCache<K>(cache, rateLimiter);
         doReturn(null).when(cache).get(key);
-        doReturn(true).when(rateLimiter).tryAcquire();
+        doReturn(1D).when(rateLimiter).acquire();
         doReturn(null).when(cache).putIfAbsent(key, true);
 
-        assertEquals(true, c.acquire(key, notifier, notifier));
+        assertEquals(true, c.acquire(key, notifier));
 
         verify(cache).get(key);
-        verify(rateLimiter).tryAcquire();
+        verify(rateLimiter).acquire();
         verify(cache).putIfAbsent(key, true);
     }
 

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
@@ -191,8 +191,7 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
 
             for (final String index : indices) {
                 if (!writeCache.acquire(Pair.of(index, series.getHashCode()),
-                    reporter::reportWriteDroppedByCacheHit,
-                    reporter::reportWriteDroppedByRateLimit)) {
+                    reporter::reportWriteDroppedByCacheHit)) {
                     continue;
                 }
 

--- a/suggest/elasticsearch/src/main/java/com/spotify/heroic/suggest/elasticsearch/SuggestBackendKV.java
+++ b/suggest/elasticsearch/src/main/java/com/spotify/heroic/suggest/elasticsearch/SuggestBackendKV.java
@@ -544,8 +544,7 @@ public class SuggestBackendKV extends AbstractElasticsearchBackend
             for (final String index : indices) {
                 final Pair<String, HashCode> key = Pair.of(index, s.getHashCode());
 
-                if (!writeCache.acquire(key, reporter::reportWriteDroppedByCacheHit,
-                    reporter::reportWriteDroppedByRateLimit)) {
+                if (!writeCache.acquire(key, reporter::reportWriteDroppedByCacheHit)) {
                     continue;
                 }
 


### PR DESCRIPTION
This changes the behaviour of the write cache & rate limiter for metadata/suggest consumptiom. It used to drop metadata/suggest ingestion of metrics that went above the rate limit. It will now instead block, causing a queue of metrics to build up if the rate limit is too low.

The upside of this change is that the delay for a new timeseries to show up becomes deterministic - it will take as long as it takes to read through the current queue of metrics. Previously it was a matter of probability.