### PR TITLE
Add support for resource identifiers

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/common/Series.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/Series.java
@@ -193,6 +193,10 @@ public class Series implements Comparable<Series> {
         return of(key, tags.entrySet().iterator(), EMPTY_RESOURCE.entrySet().iterator());
     }
 
+    public static Series of(String key, Map<String, String> tags, Map<String, String> resource) {
+        return of(key, tags.entrySet().iterator(), resource.entrySet().iterator());
+    }
+
     public static Series of(String key, Set<Map.Entry<String, String>> tagEntries) {
         return of(key, tagEntries.iterator(), EMPTY_RESOURCE.entrySet().iterator());
     }

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/MetricBackend.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/MetricBackend.java
@@ -64,7 +64,7 @@ public interface MetricBackend extends Initializing, Grouped, Collected {
      */
     AsyncFuture<FetchData.Result> fetch(
         FetchData.Request request, FetchQuotaWatcher watcher,
-        Consumer<MetricCollection> metricsConsumer
+        Consumer<MetricReadResult> metricsConsumer
     );
 
     /**

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/MetricCollection.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/MetricCollection.java
@@ -91,7 +91,7 @@ public interface MetricCollection {
      * Update the given aggregation with the content of this collection.
      */
     void updateAggregation(
-        AggregationSession session, Map<String, String> tags, Set<Series> series
+        AggregationSession session, Map<String, String> key, Set<Series> series
     );
 
     /**
@@ -250,9 +250,9 @@ public interface MetricCollection {
 
         @Override
         public void updateAggregation(
-            AggregationSession session, Map<String, String> tags, Set<Series> series
+            AggregationSession session, Map<String, String> key, Set<Series> series
         ) {
-            session.updatePoints(tags, series, data);
+            session.updatePoints(key, series, data);
         }
     }
 
@@ -273,9 +273,9 @@ public interface MetricCollection {
 
         @Override
         public void updateAggregation(
-            AggregationSession session, Map<String, String> tags, Set<Series> series
+            AggregationSession session, Map<String, String> key, Set<Series> series
         ) {
-            session.updateEvents(tags, series, data);
+            session.updateEvents(key, series, data);
         }
     }
 
@@ -296,9 +296,9 @@ public interface MetricCollection {
 
         @Override
         public void updateAggregation(
-            AggregationSession session, Map<String, String> tags, Set<Series> series
+            AggregationSession session, Map<String, String> key, Set<Series> series
         ) {
-            session.updateSpreads(tags, series, data);
+            session.updateSpreads(key, series, data);
         }
     }
 
@@ -319,9 +319,9 @@ public interface MetricCollection {
 
         @Override
         public void updateAggregation(
-            AggregationSession session, Map<String, String> tags, Set<Series> series
+            AggregationSession session, Map<String, String> key, Set<Series> series
         ) {
-            session.updateGroup(tags, series, data);
+            session.updateGroup(key, series, data);
         }
     }
 
@@ -342,9 +342,9 @@ public interface MetricCollection {
 
         @Override
         public void updateAggregation(
-            AggregationSession session, Map<String, String> tags, Set<Series> series
+            AggregationSession session, Map<String, String> key, Set<Series> series
         ) {
-            session.updatePayload(tags, series, data);
+            session.updatePayload(key, series, data);
         }
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/MetricReadResult.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/MetricReadResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Spotify AB.
+ * Copyright (c) 2017 Spotify AB.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,13 +19,24 @@
  * under the License.
  */
 
-package com.spotify.heroic.metric.bigtable;
+package com.spotify.heroic.metric;
 
-import com.spotify.heroic.common.Series;
+import com.google.common.collect.ImmutableSortedMap;
+import java.util.SortedMap;
 import lombok.Data;
 
 @Data
-public class RowKey {
-    private final Series series;
-    private final long base;
+public class MetricReadResult {
+    private final MetricCollection metrics;
+    private final SortedMap<String, String> resource;
+
+    public static MetricReadResult create(final MetricCollection metrics) {
+        return new MetricReadResult(metrics, ImmutableSortedMap.of());
+    }
+
+    public static MetricReadResult create(
+        final MetricCollection metrics, final SortedMap<String, String> resources
+    ) {
+        return new MetricReadResult(metrics, resources);
+    }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetricsResponse.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetricsResponse.java
@@ -185,8 +185,9 @@ public class QueryMetricsResponse {
                 g.writeObjectField("values", collection.getData());
 
                 writeKey(g, series.getKeys());
-                writeTags(g, common, series.getTags());
+                writeTags(g, series.getTags());
                 writeTagCounts(g, series.getTags());
+                writeResource(g, series.getResource());
 
                 g.writeEndObject();
             }
@@ -205,8 +206,7 @@ public class QueryMetricsResponse {
         }
 
         void writeTags(
-            JsonGenerator g, final Map<String, SortedSet<String>> common,
-            final Map<String, SortedSet<String>> tags
+            JsonGenerator g, final Map<String, SortedSet<String>> tags
         ) throws IOException {
             g.writeFieldName("tags");
 
@@ -244,6 +244,26 @@ public class QueryMetricsResponse {
                 }
 
                 g.writeNumberField(pair.getKey(), values.size());
+            }
+
+            g.writeEndObject();
+        }
+
+        void writeResource(
+            JsonGenerator g, final Map<String, SortedSet<String>> resource
+        ) throws IOException {
+            g.writeFieldName("resource");
+
+            g.writeStartObject();
+
+            for (final Map.Entry<String, SortedSet<String>> pair : resource.entrySet()) {
+                final SortedSet<String> values = pair.getValue();
+
+                if (values.size() != 1) {
+                    continue;
+                }
+
+                g.writeStringField(pair.getKey(), values.iterator().next());
             }
 
             g.writeEndObject();

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/ResultGroup.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/ResultGroup.java
@@ -37,7 +37,9 @@ import lombok.Data;
 
 @Data
 public class ResultGroup {
+    // key-value pairs that act as a lookup key, identifying this result group
     final Map<String, String> key;
+
     final Set<Series> series;
     final MetricCollection group;
     /**

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/SeriesValues.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/SeriesValues.java
@@ -21,36 +21,45 @@
 
 package com.spotify.heroic.metric;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.spotify.heroic.common.Series;
-import lombok.Data;
-
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import lombok.Data;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
+/**
+ * Gathers keys, tags, and resources and partitions them.
+ *
+ * Tags are partitioned by their key, their values are sorted and unique.
+ * Resources are partitioned by their key, their values are sorted and unique.
+ *
+ * This is accomplished through a {@link Builder}, which permits building the data structure
+ * incrementally.
+ */
 @Data
 public class SeriesValues {
     final SortedSet<String> keys;
     final Map<String, SortedSet<String>> tags;
+    final Map<String, SortedSet<String>> resource;
 
     @JsonCreator
     public SeriesValues(
         @JsonProperty("keys") SortedSet<String> keys,
-        @JsonProperty("tags") Map<String, SortedSet<String>> tags
+        @JsonProperty("tags") Map<String, SortedSet<String>> tags,
+        @JsonProperty("resource") Map<String, SortedSet<String>> resource
     ) {
         this.keys = checkNotNull(keys, "keys");
         this.tags = checkNotNull(tags, "tags");
+        this.resource = checkNotNull(resource, "resource");
     }
 
     private static final Comparator<String> COMPARATOR = new Comparator<String>() {
@@ -72,6 +81,14 @@ public class SeriesValues {
         }
     };
 
+    /**
+     * Construct a SeriesValues instance from an iterator of series.
+     *
+     * This is a convenience method over using {@link Builder} directly.
+     *
+     * @param series Series to build for
+     * @return a new SeriesValues instance
+     */
     public static SeriesValues fromSeries(final Iterator<Series> series) {
         final SeriesValues.Builder builder = builder();
 
@@ -79,17 +96,14 @@ public class SeriesValues {
             final Series s = series.next();
             builder.addKey(s.getKey());
             builder.addSingleTags(s.getTags());
+            builder.addSingleResource(s.getResource());
         }
 
         return builder.build();
     }
 
-    public static SeriesValues of(final String k, final String v) {
-        return new SeriesValues(ImmutableSortedSet.of(), ImmutableMap.of());
-    }
-
     public static SeriesValues empty() {
-        return new SeriesValues(ImmutableSortedSet.of(), ImmutableMap.of());
+        return new SeriesValues(ImmutableSortedSet.of(), ImmutableMap.of(), ImmutableMap.of());
     }
 
     public static Builder builder() {
@@ -99,50 +113,37 @@ public class SeriesValues {
     public static class Builder {
         final SortedSet<String> keys = new TreeSet<>();
         final Map<String, SortedSet<String>> tags = new HashMap<>();
+        final Map<String, SortedSet<String>> resource = new HashMap<>();
 
         public void addKey(final String key) {
             this.keys.add(key);
         }
 
         public void addSingleTags(final Map<String, String> tags) {
-            for (final Map.Entry<String, String> e : tags.entrySet()) {
-                SortedSet<String> values = this.tags.get(e.getKey());
+            add(this.tags, tags);
+        }
+
+        public void addSingleResource(final Map<String, String> resource) {
+            add(this.resource, resource);
+        }
+
+        private void add(
+            final Map<String, SortedSet<String>> consumer, final Map<String, String> items
+        ) {
+            for (final Map.Entry<String, String> e : items.entrySet()) {
+                SortedSet<String> values = consumer.get(e.getKey());
 
                 if (values == null) {
-                    values = new TreeSet<String>(COMPARATOR);
-                    this.tags.put(e.getKey(), values);
+                    values = new TreeSet<>(COMPARATOR);
+                    consumer.put(e.getKey(), values);
                 }
 
                 values.add(e.getValue());
             }
         }
 
-        public void addKeys(final Collection<String> keys) {
-            this.keys.addAll(keys);
-        }
-
-        public void addTags(final Map<String, SortedSet<String>> tags) {
-            Set<Map.Entry<String, SortedSet<String>>> entries = tags.entrySet();
-
-            for (final Map.Entry<String, SortedSet<String>> t : entries) {
-                SortedSet<String> values = this.tags.get(t.getKey());
-
-                if (values == null) {
-                    values = new TreeSet<>();
-                    this.tags.put(t.getKey(), values);
-                }
-
-                values.addAll(t.getValue());
-            }
-        }
-
-        public void addSeriesValues(final SeriesValues series) {
-            addKeys(series.getKeys());
-            addTags(series.getTags());
-        }
-
         public SeriesValues build() {
-            return new SeriesValues(keys, tags);
+            return new SeriesValues(keys, tags, resource);
         }
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/ShardedResultGroup.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/ShardedResultGroup.java
@@ -45,7 +45,10 @@ public final class ShardedResultGroup {
     private static final HashFunction HASH_FUNCTION = murmur3_32();
 
     private final Map<String, String> shard;
+
+    // key-value pairs that act as a lookup key, identifying this result group
     private final Map<String, String> key;
+
     private final Set<Series> series;
     private final MetricCollection metrics;
     private final long cadence;

--- a/heroic-component/src/test/java/com/spotify/heroic/common/SeriesTest.java
+++ b/heroic-component/src/test/java/com/spotify/heroic/common/SeriesTest.java
@@ -1,12 +1,14 @@
 package com.spotify.heroic.common;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import org.junit.Test;
 
 import java.util.HashSet;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SeriesTest {
     @Test
@@ -38,7 +40,73 @@ public class SeriesTest {
                 "sto"));
 
         assertEquals(
-            "system.cpu-user-perc {host=heroicapi1.sto.spotify.net, role=heroicapi, site=sto}",
+            "system.cpu-user-perc {host=heroicapi1.sto.spotify.net, role=heroicapi, site=sto} {}",
             a.toDSL());
+    }
+
+    @Test
+    public void testCompareToTags() throws Exception {
+        {
+            final Series a = Series.of("foo", ImmutableMap.of("z", "s", "a", "d"));
+            final Series b = Series.of("foo", ImmutableMap.of("a", "d", "z", "s"));
+            assertEquals(0, a.compareTo(b));
+        }
+
+        {
+            final Series a = Series.of("foo", ImmutableMap.of("a", "d", "y", "s"));
+            final Series b = Series.of("foo", ImmutableMap.of("a", "d", "z", "s"));
+            assertEquals(-1, a.compareTo(b));
+        }
+
+        {
+            final Series a = Series.of("foo", ImmutableMap.of( "a", "e", "z", "s"));
+            final Series b = Series.of("foo", ImmutableMap.of("a", "d", "z", "s"));
+            assertEquals(1, a.compareTo(b));
+        }
+
+        {
+            final Series a = Series.of("foo", ImmutableMap.of( "a", "b"));
+            final Series b = Series.of("foo", ImmutableMap.of("a", "b", "z", "s"));
+            assertEquals(-1, a.compareTo(b));
+        }
+
+        {
+            final Series a = Series.of("foo", ImmutableMap.of( "a", "b", "z", "s"));
+            final Series b = Series.of("foo", ImmutableMap.of("a", "b"));
+            assertEquals(1, a.compareTo(b));
+        }
+    }
+
+    @Test
+    public void testCompareToResourceIdentifiers() throws Exception {
+        {
+            final Series a = Series.of("foo", ImmutableMap.of("a", "d"), ImmutableSortedMap.of("k", "v"));
+            final Series b = Series.of("foo", ImmutableMap.of("a", "d"), ImmutableSortedMap.of("k", "v"));
+            assertEquals(0, a.compareTo(b));
+        }
+
+        {
+            final Series a = Series.of("foo", ImmutableMap.of("a", "d"), ImmutableSortedMap.of("a", "v"));
+            final Series b = Series.of("foo", ImmutableMap.of("a", "d"), ImmutableSortedMap.of("k", "v"));
+            assertTrue(a.compareTo(b) < 0);
+        }
+
+        {
+            final Series a = Series.of("foo", ImmutableMap.of("a", "d"), ImmutableSortedMap.of("k", "z"));
+            final Series b = Series.of("foo", ImmutableMap.of("a", "d"), ImmutableSortedMap.of("k", "v"));
+            assertTrue(a.compareTo(b) > 0);
+        }
+
+        {
+            final Series a = Series.of("foo", ImmutableMap.of("a", "d"), ImmutableSortedMap.of("k", "v"));
+            final Series b = Series.of("foo", ImmutableMap.of("a", "d"), ImmutableSortedMap.of("k", "v", "z", "s"));
+            assertTrue (a.compareTo(b) < 0);
+        }
+
+        {
+            final Series a = Series.of("foo", ImmutableMap.of("a", "d"), ImmutableSortedMap.of("k", "v", "z", "a"));
+            final Series b = Series.of("foo", ImmutableMap.of("a", "d"), ImmutableSortedMap.of("k", "v"));
+            assertTrue(a.compareTo(b) > 0);
+        }
     }
 }

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100.java
@@ -25,12 +25,16 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TreeTraversingParser;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.spotify.heroic.common.Series;
@@ -56,44 +60,48 @@ import lombok.ToString;
 
 @ToString
 public class Spotify100 implements ConsumerSchema {
-    private static final String HOST = "host";
-    private static final String KEY = "key";
-    private static final String TIME = "time";
+    private static final String HOST_TAG = "host";
 
-    private static final ObjectMapper mapper = new ObjectMapper();
-
-    public static final String SCHEMA_VERSION = "1.0.0";
+    private static final ObjectMapper mapper = objectMapper();
 
     @Data
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class JsonMetric {
-        private final String version;
         private final String key;
         private final String host;
         private final Long time;
         @JsonDeserialize(using = TagsDeserializer.class)
         private final Map<String, String> attributes;
+        @JsonDeserialize(using = TagsDeserializer.class)
+        private final Map<String, String> resource;
         private final Double value;
 
         @JsonCreator
         public JsonMetric(
-            @JsonProperty("version") String version, @JsonProperty("key") String key,
-            @JsonProperty("host") String host, @JsonProperty("time") Long time,
+            @JsonProperty("key") String key, @JsonProperty("host") String host,
+            @JsonProperty("time") Long time,
             @JsonProperty("attributes") Map<String, String> attributes,
+            @JsonProperty("resource") Map<String, String> resource,
             @JsonProperty("value") Double value
         ) {
-            this.version = version;
             this.key = key;
             this.host = host;
             this.time = time;
             this.attributes = attributes;
+            this.resource = resource;
             this.value = value;
         }
 
         public static final class TagsDeserializer extends JsonDeserializer<Map<String, String>> {
             @Override
+            public Map<String, String> getNullValue(final DeserializationContext ctxt)
+                throws JsonMappingException {
+                return ImmutableMap.of();
+            }
+
+            @Override
             public Map<String, String> deserialize(JsonParser p, DeserializationContext ctxt)
-                throws IOException, JsonProcessingException {
+                throws IOException {
                 final ImmutableMap.Builder<String, String> tags = ImmutableMap.builder();
 
                 if (p.getCurrentToken() != JsonToken.START_OBJECT) {
@@ -135,12 +143,50 @@ public class Spotify100 implements ConsumerSchema {
 
         @Override
         public AsyncFuture<Void> consume(final byte[] message) throws ConsumerSchemaException {
+            final JsonNode tree;
+
+            try {
+                tree = mapper.readTree(message);
+            } catch (final Exception e) {
+                throw new ConsumerSchemaValidationException("Invalid metric", e);
+            }
+
+            if (tree.getNodeType() != JsonNodeType.OBJECT) {
+                throw new ConsumerSchemaValidationException(
+                    "Expected object, but got: " + tree.getNodeType());
+            }
+
+            final ObjectNode object = (ObjectNode) tree;
+
+            final JsonNode versionNode = object.remove("version");
+
+            if (versionNode == null) {
+                throw new ConsumerSchemaValidationException("Missing version in received object");
+            }
+
+            final Version version;
+
+            try {
+                version = Version.parse(versionNode.asText());
+            } catch (final Exception e) {
+                throw new ConsumerSchemaValidationException("Bad version: " + versionNode);
+            }
+
+            if (version.getMajor() == 1) {
+                return handleVersion1(tree);
+            }
+
+            throw new ConsumerSchemaValidationException("Unsupported version: " + version);
+        }
+
+        private AsyncFuture<Void> handleVersion1(final JsonNode tree)
+            throws ConsumerSchemaValidationException {
             final JsonMetric metric;
 
             try {
-                metric = mapper.readValue(message, JsonMetric.class);
-            } catch (final Exception e) {
-                throw new ConsumerSchemaValidationException("Received invalid metric", e);
+                metric = new TreeTraversingParser(tree, mapper).readValueAs(JsonMetric.class);
+            } catch (IOException e) {
+                throw new ConsumerSchemaValidationException("Invalid metric", e);
             }
 
             if (metric.getValue() == null) {
@@ -148,34 +194,28 @@ public class Spotify100 implements ConsumerSchema {
                     "Metric must have a value but this metric has a null value: " + metric);
             }
 
-            if (metric.getVersion() == null || !SCHEMA_VERSION.equals(metric.getVersion())) {
-                throw new ConsumerSchemaValidationException(
-                    String.format("Invalid version %s, expected %s", metric.getVersion(),
-                        SCHEMA_VERSION));
-            }
-
             if (metric.getTime() == null) {
-                throw new ConsumerSchemaValidationException(
-                    "'" + TIME + "' field must be defined: " + message);
+                throw new ConsumerSchemaValidationException("time: field must be defined: " + tree);
             }
 
             if (metric.getTime() <= 0) {
                 throw new ConsumerSchemaValidationException(
-                    "'" + TIME + "' field must be a positive number: " + message);
+                    "time: field must be a positive number: " + tree);
             }
 
             if (metric.getKey() == null) {
-                throw new ConsumerSchemaValidationException(
-                    "'" + KEY + "' field must be defined: " + message);
+                throw new ConsumerSchemaValidationException("key: field must be defined: " + tree);
             }
 
-            final Map<String, String> tags = new HashMap<String, String>(metric.getAttributes());
+            final Map<String, String> tags = new HashMap<>(metric.getAttributes());
 
             if (metric.getHost() != null) {
-                tags.put(HOST, metric.getHost());
+                tags.put(HOST_TAG, metric.getHost());
             }
 
-            final Series series = Series.of(metric.getKey(), tags);
+            final Map<String, String> resource = new HashMap<>(metric.getResource());
+
+            final Series series = Series.of(metric.getKey(), tags, resource);
             final Point p = new Point(metric.getTime(), metric.getValue());
             final List<Point> points = ImmutableList.of(p);
 
@@ -199,5 +239,40 @@ public class Spotify100 implements ConsumerSchema {
     interface C extends ConsumerSchema.Exposed {
         @Override
         Consumer consumer();
+    }
+
+    @Data
+    static class Version {
+        private final int major;
+        private final int minor;
+        private final int patch;
+
+        /**
+         * Parse the given version string.
+         */
+        public static Version parse(final String input) {
+            if (input == null) {
+                throw new NullPointerException();
+            }
+
+            final String[] parts = input.trim().split("\\.");
+
+            if (parts.length != 3) {
+                throw new IllegalArgumentException("too few components: " + input);
+            }
+
+            final int major = Integer.parseInt(parts[0]);
+            final int minor = Integer.parseInt(parts[1]);
+            final int patch = Integer.parseInt(parts[2]);
+
+            return new Version(major, minor, patch);
+        }
+    }
+
+    /**
+     * Setup the ObjectMapper necessary to serialize types in this protocol.
+     */
+    static ObjectMapper objectMapper() {
+        return new ObjectMapper();
     }
 }

--- a/heroic-core/src/main/java/com/spotify/heroic/generator/RandomMetadataGenerator.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/generator/RandomMetadataGenerator.java
@@ -55,7 +55,8 @@ public class RandomMetadataGenerator implements MetadataGenerator {
     private Series generateOne(int index) {
         final String key = generateKey(index);
         final Map<String, String> tags = generateTags(index);
-        return Series.of(key, tags);
+        final Map<String, String> resource = generateResource(index);
+        return Series.of(key, tags, resource);
     }
 
     private String generateKey(int index) {
@@ -69,6 +70,12 @@ public class RandomMetadataGenerator implements MetadataGenerator {
         builder.put("role", randomPick(ROLES));
         builder.put("what", randomPick(WHATS));
 
+        return builder.build();
+    }
+
+    private Map<String, String> generateResource(int index) {
+        final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        builder.put("instance", String.format("%d", index % 10));
         return builder.build();
     }
 

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/Fetch.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/Fetch.java
@@ -32,6 +32,7 @@ import com.spotify.heroic.metric.Metric;
 import com.spotify.heroic.metric.MetricBackendGroup;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.MetricManager;
+import com.spotify.heroic.metric.MetricReadResult;
 import com.spotify.heroic.metric.MetricType;
 import com.spotify.heroic.metric.Tracing;
 import com.spotify.heroic.shell.AbstractShellTaskParams;
@@ -105,7 +106,8 @@ public class Fetch implements ShellTask {
             QueryOptions.builder().tracing(Tracing.fromBoolean(params.tracing));
         final QueryOptions options = optionsBuilder.build();
 
-        final Consumer<MetricCollection> printMetricsCollection = g -> {
+        final Consumer<MetricReadResult> printMetricsCollection = metricsAndResources -> {
+            MetricCollection g = metricsAndResources.getMetrics();
             Calendar current = null;
             Calendar last = null;
 

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/WritePerformance.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/WritePerformance.java
@@ -105,7 +105,7 @@ public class WritePerformance implements ShellTask {
             reads.add(readGroup.fetch(
                 new FetchData.Request(MetricType.POINT, s, range, QueryOptions.defaults()),
                 FetchQuotaWatcher.NO_QUOTA,
-                mc -> writeRequests.add(new WriteMetric.Request(s, mc))));
+                mcr -> writeRequests.add(new WriteMetric.Request(s, mcr.getMetrics()))));
         }
 
         return async.collect(reads).lazyTransform(input -> {

--- a/heroic-core/src/test/java/com/spotify/heroic/consumer/schemas/Spotify100Test.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/consumer/schemas/Spotify100Test.java
@@ -1,18 +1,92 @@
 package com.spotify.heroic.consumer.schemas;
 
+import static org.junit.Assert.assertEquals;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
-import org.junit.Assert;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.io.Resources;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.Data;
 import org.junit.Test;
 
 public class Spotify100Test {
-    @Test
-    public void testIgnoreNullAttributes() throws Exception {
+    private static ObjectMapper expectedObjectMapper() {
         final ObjectMapper mapper = new ObjectMapper();
-        final Spotify100.JsonMetric m = mapper.readValue(
-            "{\"attributes\": {\"foo\": \"value\", \"bar\": null}, \"key\": \"a key\"}",
-            Spotify100.JsonMetric.class);
-        Assert.assertEquals(ImmutableMap.of("foo", "value"), m.getAttributes());
-        Assert.assertEquals("a key", m.getKey());
+        mapper.registerModule(new Jdk8Module());
+        return mapper;
+    }
+
+    @Data
+    public static class Expected {
+        private final Optional<String> version;
+        private final Optional<String> key;
+        private final Optional<String> host;
+        private final Optional<Long> time;
+        private final Optional<Map<String, String>> attributes;
+        private final Optional<Map<String, String>> resource;
+        private final Optional<Double> value;
+    }
+
+    @Test
+    public void testCases() throws Exception {
+        final ObjectMapper expectedMapper = expectedObjectMapper();
+        final ObjectMapper mapper = Spotify100.objectMapper();
+
+        final List<String> lines = Resources.readLines(
+            Resources.getResource(Spotify100Test.class, "spotify-100-tests.txt"),
+            StandardCharsets.UTF_8);
+
+        int i = 0;
+
+        for (final String test : lines) {
+            if (test.trim().isEmpty()) {
+                continue;
+            }
+
+            if (test.trim().startsWith("#")) {
+                continue;
+            }
+
+            final String[] parts = test.split("\\|");
+
+            final int line = i++;
+
+            final Spotify100.JsonMetric value;
+
+            try {
+                value = mapper.readValue(parts[0].trim(), Spotify100.JsonMetric.class);
+            } catch (final Exception e) {
+                throw new RuntimeException(line + ": " + e.getMessage(), e);
+            }
+
+            final Expected expected = expectedMapper.readValue(parts[1].trim(), Expected.class);
+
+            expected.getKey().ifPresent(key -> {
+                assertEquals(line + ": expected key", key, value.getKey());
+            });
+
+            expected.getHost().ifPresent(host -> {
+                assertEquals(line + ": expected host", host, value.getHost());
+            });
+
+            expected.getTime().ifPresent(time -> {
+                assertEquals(line + ": expected time", time, value.getTime());
+            });
+
+            expected.getAttributes().ifPresent(attributes -> {
+                assertEquals(line + ": expected attributes", attributes, value.getAttributes());
+            });
+
+            expected.getResource().ifPresent(resource -> {
+                assertEquals(line + ": expected resource", resource, value.getResource());
+            });
+
+            expected.getValue().ifPresent(v -> {
+                assertEquals(line + ": expected value", v, value.getValue());
+            });
+        }
     }
 }

--- a/heroic-core/src/test/resources/com/spotify/heroic/consumer/schemas/spotify-100-tests.txt
+++ b/heroic-core/src/test/resources/com/spotify/heroic/consumer/schemas/spotify-100-tests.txt
@@ -1,0 +1,14 @@
+# attributes (a.k.a tags)
+{"key": "foo", "attributes": {}} | {"key": "foo", "attributes": {}}
+{"key": "foo", "attributes": {}} | {"key": "foo", "attributes": {}}
+{"key": "foo", "attributes": {"foo": null}} | {"key": "foo", "attributes": {}}
+{"key": "foo", "attributes": {"foo": "bar"}} | {"key": "foo", "attributes": {"foo": "bar"}}
+{"key": "foo", "attributes": {"foo": "bar", "bar": "baz"}} | {"key": "foo", "attributes": {"foo": "bar", "bar": "baz"}}
+
+# resource tags
+{"key": "foo"} | {"key": "foo", "resource": {}}
+{"key": "foo", "resource": {}} | {"key": "foo", "resource": {}}
+{"key": "foo", "resource": null} | {"key": "foo", "resource": {}}
+{"key": "foo", "resource": {"foo": null}} | {"key": "foo", "resource": {}}
+{"key": "foo", "resource": {"foo": "bar"}} | {"key": "foo", "resource": {"foo": "bar"}}
+{"key": "foo", "resource": {"foo": "bar", "bar": "baz"}} | {"key": "foo", "resource": {"foo": "bar", "bar": "baz"}}

--- a/heroic-core/src/test/resources/com/spotify/heroic/metric/QueryMetricsResponse.json
+++ b/heroic-core/src/test/resources/com/spotify/heroic/metric/QueryMetricsResponse.json
@@ -24,7 +24,8 @@
       "values": [],
       "key": null,
       "tags": {},
-      "tagCounts": {}
+      "tagCounts": {},
+      "resource": {}
     }
   ],
   "preAggregationSampleSize":null,

--- a/heroic-core/src/test/resources/com/spotify/heroic/metric/QueryMetricsResponse.json
+++ b/heroic-core/src/test/resources/com/spotify/heroic/metric/QueryMetricsResponse.json
@@ -15,6 +15,7 @@
   "cached": false,
   "cache": null,
   "commonTags": {},
+  "commonResource": {},
   "result": [
     {
       "type": "points",
@@ -25,7 +26,8 @@
       "key": null,
       "tags": {},
       "tagCounts": {},
-      "resource": {}
+      "resource": {},
+      "resourceCounts": {}
     }
   ],
   "preAggregationSampleSize":null,

--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
@@ -18,8 +18,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import com.spotify.heroic.common.Feature;
 import com.spotify.heroic.common.FeatureSet;
 import com.spotify.heroic.common.Series;
@@ -51,9 +51,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
-    private final Series s1 = Series.of("key1", ImmutableMap.of("shared", "a", "diff", "a"));
-    private final Series s2 = Series.of("key1", ImmutableMap.of("shared", "a", "diff", "b"));
-    private final Series s3 = Series.of("key1", ImmutableMap.of("shared", "a", "diff", "c"));
+    private final Series s1 = new Series("key1", ImmutableSortedMap.of("shared", "a", "diff", "a"),
+        ImmutableSortedMap.of("resource", "a"));
+    private final Series s2 = new Series("key1", ImmutableSortedMap.of("shared", "a", "diff", "b"),
+        ImmutableSortedMap.of("resource", "b"));
+    private final Series s3 = new Series("key1", ImmutableSortedMap.of("shared", "a", "diff", "c"),
+        ImmutableSortedMap.of("resource", "c"));
 
     /* the number of queries run */
     private int queryCount = 0;
@@ -350,7 +353,8 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
         for (final RequestError e : result.getErrors()) {
             assertTrue((e instanceof QueryError));
             final QueryError q = (QueryError) e;
-            assertThat(q.getError(), containsString("Some fetches failed (1) or were cancelled (0)"));
+            assertThat(q.getError(),
+                containsString("Some fetches failed (1) or were cancelled (0)"));
         }
 
         assertEquals(ResultLimits.of(ResultLimit.AGGREGATION), result.getLimits());

--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractConsumerIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractConsumerIT.java
@@ -9,6 +9,7 @@ import com.spotify.heroic.common.Series;
 import com.spotify.heroic.metric.FetchData;
 import com.spotify.heroic.metric.FetchQuotaWatcher;
 import com.spotify.heroic.metric.MetricCollection;
+import com.spotify.heroic.metric.MetricReadResult;
 import com.spotify.heroic.metric.MetricType;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.WriteMetric;
@@ -48,9 +49,9 @@ public abstract class AbstractConsumerIT extends AbstractSingleNodeIT {
         consumer.accept(request);
 
         tryUntil(() -> {
-            final List<MetricCollection> data = Collections.synchronizedList(new ArrayList<>());
+            final List<MetricReadResult> data = Collections.synchronizedList(new ArrayList<>());
 
-            FetchData.Result result = instance.inject(coreComponent -> {
+            instance.inject(coreComponent -> {
                 FetchData.Request fetchDataRequest =
                     new FetchData.Request(MetricType.POINT, s1, new DateRange(0, 100),
                         QueryOptions.defaults());
@@ -60,7 +61,9 @@ public abstract class AbstractConsumerIT extends AbstractSingleNodeIT {
                     .fetch(fetchDataRequest, FetchQuotaWatcher.NO_QUOTA, data::add);
             }).get();
 
-            assertEquals(ImmutableList.of(mc), data);
+            final MetricCollection collection = data.iterator().next().getMetrics();
+
+            assertEquals(mc, collection);
             return null;
         });
     }
@@ -83,8 +86,9 @@ public abstract class AbstractConsumerIT extends AbstractSingleNodeIT {
         }
 
         tryUntil(() -> {
-            final List<MetricCollection> data = Collections.synchronizedList(new ArrayList<>());
-            FetchData.Result result = instance.inject(coreComponent -> {
+            final List<MetricReadResult> data = Collections.synchronizedList(new ArrayList<>());
+
+            instance.inject(coreComponent -> {
                 FetchData.Request fetchDataRequest =
                     new FetchData.Request(MetricType.POINT, s1, new DateRange(0, 100),
                         QueryOptions.defaults());
@@ -94,7 +98,9 @@ public abstract class AbstractConsumerIT extends AbstractSingleNodeIT {
                     .fetch(fetchDataRequest, FetchQuotaWatcher.NO_QUOTA, data::add);
             }).get();
 
-            assertEquals(ImmutableList.of(MetricCollection.points(consumedPoints)), data);
+            final MetricCollection collection = data.iterator().next().getMetrics();
+
+            assertEquals(MetricCollection.points(consumedPoints), collection);
             return null;
         });
     }

--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractConsumerIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractConsumerIT.java
@@ -1,6 +1,7 @@
 package com.spotify.heroic;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -61,8 +62,8 @@ public abstract class AbstractConsumerIT extends AbstractSingleNodeIT {
                     .fetch(fetchDataRequest, FetchQuotaWatcher.NO_QUOTA, data::add);
             }).get();
 
+            assertFalse(data.isEmpty());
             final MetricCollection collection = data.iterator().next().getMetrics();
-
             assertEquals(mc, collection);
             return null;
         });
@@ -98,8 +99,8 @@ public abstract class AbstractConsumerIT extends AbstractSingleNodeIT {
                     .fetch(fetchDataRequest, FetchQuotaWatcher.NO_QUOTA, data::add);
             }).get();
 
+            assertFalse(data.isEmpty());
             final MetricCollection collection = data.iterator().next().getMetrics();
-
             assertEquals(MetricCollection.points(consumedPoints), collection);
             return null;
         });

--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractKafkaConsumerIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractKafkaConsumerIT.java
@@ -19,8 +19,10 @@ import com.spotify.heroic.metric.MetricType;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.WriteMetric;
 import com.spotify.heroic.metric.memory.MemoryMetricModule;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import lombok.Data;
 import org.junit.After;
 
 public abstract class AbstractKafkaConsumerIT extends AbstractConsumerIT {
@@ -72,11 +74,12 @@ public abstract class AbstractKafkaConsumerIT extends AbstractConsumerIT {
 
             final Series series = request.getSeries();
             for (final Point p : mc.getDataAs(Point.class)) {
-                final Spotify100.JsonMetric src =
-                    new Spotify100.JsonMetric(Spotify100.SCHEMA_VERSION, series.getKey(),
-                        "localhost", p.getTimestamp(), series.getTags(), p.getValue());
+                final Version1 src =
+                    new Version1("1.1.0", series.getKey(), "localhost", p.getTimestamp(),
+                        series.getTags(), series.getResource(), p.getValue());
 
                 final byte[] message;
+
                 try {
                     message = objectMapper.writeValueAsBytes(src);
                 } catch (Exception e) {
@@ -118,5 +121,16 @@ public abstract class AbstractKafkaConsumerIT extends AbstractConsumerIT {
         if (expectAtLeastOneCommit) {
             assertTrue(offsetsCommits > 0);
         }
+    }
+
+    @Data
+    public static class Version1 {
+        private final String version;
+        private final String key;
+        private final String host;
+        private final Long time;
+        private final Map<String, String> attributes;
+        private final Map<String, String> resource;
+        private final double value;
     }
 }

--- a/heroic-dist/src/test/java/com/spotify/heroic/LoggingMetricModule.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/LoggingMetricModule.java
@@ -15,6 +15,7 @@ import com.spotify.heroic.metric.FetchQuotaWatcher;
 import com.spotify.heroic.metric.MetricBackend;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.MetricModule;
+import com.spotify.heroic.metric.MetricReadResult;
 import com.spotify.heroic.metric.WriteMetric;
 import eu.toolchain.async.AsyncFuture;
 import java.util.List;
@@ -76,7 +77,7 @@ class LoggingMetricModule implements MetricModule {
         @Override
         public AsyncFuture<FetchData.Result> fetch(
             final FetchData.Request request, final FetchQuotaWatcher watcher,
-            final Consumer<MetricCollection> metricsConsumer
+            final Consumer<MetricReadResult> metricsConsumer
         ) {
             return delegate.fetch(request, watcher, metricsConsumer);
         }

--- a/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsMetricBackend.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsMetricBackend.java
@@ -33,6 +33,7 @@ import com.spotify.heroic.metric.FetchData;
 import com.spotify.heroic.metric.FetchQuotaWatcher;
 import com.spotify.heroic.metric.MetricBackend;
 import com.spotify.heroic.metric.MetricCollection;
+import com.spotify.heroic.metric.MetricReadResult;
 import com.spotify.heroic.metric.WriteMetric;
 import eu.toolchain.async.AsyncFuture;
 import java.time.LocalDate;
@@ -75,7 +76,7 @@ class BigtableAnalyticsMetricBackend implements MetricBackend {
     @Override
     public AsyncFuture<FetchData.Result> fetch(
         final FetchData.Request request, final FetchQuotaWatcher watcher,
-        final Consumer<MetricCollection> metricsConsumer
+        final Consumer<MetricReadResult> metricsConsumer
     ) {
         analytics.reportFetchSeries(LocalDate.now(), request.getSeries());
         return backend.fetch(request, watcher, metricsConsumer);

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableByteBufferSerialReader.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableByteBufferSerialReader.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.metric.bigtable;
+
+import eu.toolchain.serializer.Serializer;
+import eu.toolchain.serializer.SharedPool;
+import eu.toolchain.serializer.io.AbstractSerialReader;
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+
+/*
+ * Identical to eu.toolchain.serializer.io.CoreByteBufferSerialReader, except that this
+ * implementation will update the offset in the provided ByteBuffer as the reader progresses.
+ */
+public class BigtableByteBufferSerialReader extends AbstractSerialReader {
+    private final ByteBuffer buffer;
+
+    public BigtableByteBufferSerialReader(
+        SharedPool pool, Serializer<Integer> scopeSize, ByteBuffer buffer
+    ) {
+        super(pool, scopeSize);
+        this.buffer = buffer;
+    }
+
+    public byte read() throws IOException {
+        try {
+            return this.buffer.get();
+        } catch (BufferUnderflowException var2) {
+            throw new EOFException();
+        }
+    }
+
+    public void read(byte[] bytes, int offset, int length) throws IOException {
+        try {
+            this.buffer.get(bytes, offset, length);
+        } catch (BufferUnderflowException var5) {
+            throw new EOFException();
+        }
+    }
+
+    public void skip(int length) throws IOException {
+        try {
+            this.buffer.position(this.buffer.position() + length);
+        } catch (IllegalArgumentException var3) {
+            throw new EOFException();
+        }
+    }
+}

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableMetricModule.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableMetricModule.java
@@ -44,7 +44,6 @@ import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.Managed;
 import eu.toolchain.async.ManagedSetup;
-import eu.toolchain.serializer.Serializer;
 import java.util.Optional;
 import javax.inject.Named;
 import lombok.Data;
@@ -179,7 +178,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
 
         @Provides
         @BigtableScope
-        public Serializer<RowKey> rowKeySerializer() {
+        public RowKeySerializer rowKeySerializer() {
             return new MetricsRowKeySerializer();
         }
 

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/MetricsRowKeySerializer.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/MetricsRowKeySerializer.java
@@ -21,29 +21,116 @@
 
 package com.spotify.heroic.metric.bigtable;
 
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.protobuf.ByteString;
+import com.spotify.heroic.common.Series;
+import eu.toolchain.serializer.AutoSerialize;
+import eu.toolchain.serializer.BytesSerialWriter;
 import eu.toolchain.serializer.SerialReader;
-import eu.toolchain.serializer.SerialWriter;
 import eu.toolchain.serializer.Serializer;
 import eu.toolchain.serializer.SerializerFramework;
 import eu.toolchain.serializer.TinySerializer;
-
+import eu.toolchain.serializer.io.ContinuousSharedPool;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.SortedMap;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 
-public class MetricsRowKeySerializer implements Serializer<RowKey> {
-    final SerializerFramework serializerFramework = TinySerializer
-        .builder()
-        .string(CustomStringSerializer::new)
-        .build();
+@Slf4j
+public class MetricsRowKeySerializer implements RowKeySerializer {
+    final SerializerFramework framework;
+    final SerializerFramework suffixFramework;
+    final RowKeyMinimal_Serializer minimalSerializer;
+    final Serializer<SortedMap<String, String>> sortedMap;
+    final Serializer<List<SuffixEntry>> suffixList;
 
-    final RowKey_Serializer serializer = new RowKey_Serializer(serializerFramework);
+    public MetricsRowKeySerializer() {
+        framework = TinySerializer.builder().string(CustomStringSerializer::new).build();
+        suffixFramework = TinySerializer.builder().build();
+        minimalSerializer = new RowKeyMinimal_Serializer(framework);
+        sortedMap = suffixFramework.sortedMap(suffixFramework.string(), suffixFramework.string());
 
-    @Override
-    public void serialize(SerialWriter serialWriter, RowKey rowKey) throws IOException {
-        serializer.serialize(serialWriter, rowKey);
+        suffixList = suffixFramework.list(
+            new MetricsRowKeySerializer_SuffixEntry_Serializer(suffixFramework));
     }
 
     @Override
-    public RowKey deserialize(SerialReader serialReader) throws IOException {
-        return serializer.deserialize(serialReader);
+    public ByteString serializeMinimal(final RowKeyMinimal value) throws IOException {
+        try (final BytesSerialWriter serialWriter = framework.writeBytes()) {
+            minimalSerializer.serialize(serialWriter, value);
+            return ByteString.copyFrom(serialWriter.toByteArray());
+        }
+    }
+
+    @Override
+    public ByteString serializeFull(final RowKey rowKey) throws IOException {
+        try (final BytesSerialWriter serialWriter = framework.writeBytes()) {
+            minimalSerializer.serialize(serialWriter, RowKeyMinimal.create(rowKey));
+
+            final List<SuffixEntry> suffixes = new ArrayList<>();
+
+            // Only serialize if non-empty, for backwards compatibility
+            if (!rowKey.getSeries().getResource().isEmpty()) {
+                final byte[] payload = fromByteBuffer(
+                    suffixFramework.serialize(sortedMap, rowKey.getSeries().getResource()));
+                suffixes.add(new SuffixEntry(SuffixEntryType.RESOURCE, payload));
+            }
+
+            if (!suffixes.isEmpty()) {
+                suffixList.serialize(serialWriter, suffixes);
+            }
+
+            return ByteString.copyFrom(serialWriter.toByteArray());
+        }
+    }
+
+    private byte[] fromByteBuffer(ByteBuffer buf) {
+        byte[] array = new byte[buf.remaining()];
+        buf.get(array);
+        return array;
+    }
+
+    @Override
+    public RowKey deserializeFull(final ByteBuffer buffer) throws IOException {
+        final SerialReader serialReader =
+            new BigtableByteBufferSerialReader(new ContinuousSharedPool(),
+                framework.variableInteger(), buffer);
+        final RowKeyMinimal rowKeyMinimal = minimalSerializer.deserialize(serialReader);
+
+        Optional<SortedMap<String, String>> resourceMaybe = Optional.empty();
+
+        if (buffer.remaining() > 0) {
+            // Only try to parse suffixes (such as 'resource') when there actually is data for it in
+            // the serialization For backwards compatibility
+            for (final SuffixEntry e : suffixFramework.deserialize(suffixList, buffer)) {
+                switch (e.type) {
+                    case RESOURCE:
+                        resourceMaybe = Optional.of(
+                            suffixFramework.deserialize(sortedMap, ByteBuffer.wrap(e.payload)));
+                        break;
+                    default:
+                        throw new RuntimeException("Unknown suffix type in RowKey");
+                }
+            }
+        }
+
+        final RowKeyMinimal.Series s = rowKeyMinimal.getSeries();
+        final SortedMap<String, String> resource = resourceMaybe.orElseGet(ImmutableSortedMap::of);
+        return new RowKey(new Series(s.getKey(), s.getTags(), resource), rowKeyMinimal.getBase());
+    }
+
+    enum SuffixEntryType {
+        RESOURCE
+    }
+
+    @AutoSerialize
+    @Data
+    public static class SuffixEntry {
+        private final SuffixEntryType type;
+        private final byte[] payload;
     }
 }

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/RowKeyMinimal.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/RowKeyMinimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Spotify AB.
+ * Copyright (c) 2015 Spotify AB.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,16 +19,30 @@
  * under the License.
  */
 
-package com.spotify.heroic.metric.bigtable.api;
+package com.spotify.heroic.metric.bigtable;
 
-import com.google.protobuf.ByteString;
-
+import eu.toolchain.serializer.AutoSerialize;
+import java.util.SortedMap;
 import lombok.Data;
 
+@AutoSerialize
 @Data
-public final class ReadRowRangeRequest {
-    private final ByteString rowKey;
-    private final String columnFamily;
-    private final ByteString startQualifierOpen;
-    private final ByteString endQualifierClosed;
+public class RowKeyMinimal {
+    private final Series series;
+    private final long base;
+
+    @AutoSerialize
+    @Data
+    static class Series {
+        private final String key;
+        private final SortedMap<String, String> tags;
+
+        public static Series create(com.spotify.heroic.common.Series series) {
+            return new Series(series.getKey(), series.getTags());
+        }
+    }
+
+    public static RowKeyMinimal create(RowKey rowKey) {
+        return new RowKeyMinimal(Series.create(rowKey.getSeries()), rowKey.getBase());
+    }
 }

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/RowKeySerializer.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/RowKeySerializer.java
@@ -21,11 +21,14 @@
 
 package com.spotify.heroic.metric.bigtable;
 
-import com.spotify.heroic.common.Series;
-import lombok.Data;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 
-@Data
-public class RowKey {
-    private final Series series;
-    private final long base;
+public interface RowKeySerializer {
+    ByteString serializeMinimal(RowKeyMinimal value) throws IOException;
+
+    ByteString serializeFull(RowKey value) throws IOException;
+
+    RowKey deserializeFull(ByteBuffer buffer) throws IOException;
 }

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/RowFilter.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/RowFilter.java
@@ -34,7 +34,7 @@ public interface RowFilter {
 
     /**
      * Test if the current filter matches the given column qualifier.
-     *
+     * <p>
      * This method is primarily used when testing.
      *
      * @param columnQualifier column qualifier to match
@@ -44,7 +44,7 @@ public interface RowFilter {
 
     /**
      * Test if the current filter matches the given column family.
-     *
+     * <p>
      * This method is primarily used when testing.
      *
      * @param familyName family to match
@@ -117,25 +117,25 @@ public interface RowFilter {
         @Override
         public boolean matchesColumn(final ByteString columnQualifier) {
             if (!startQualifierClosed
-                .map(sqo -> compareByteStrings(sqo, columnQualifier) <= 0)
+                .map(sqc -> compareByteStrings(sqc, columnQualifier) <= 0)
                 .orElse(true)) {
                 return false;
             }
 
             if (!startQualifierOpen
-                .map(q -> compareByteStrings(q, columnQualifier) < 0)
+                .map(sqo -> compareByteStrings(sqo, columnQualifier) < 0)
                 .orElse(true)) {
                 return false;
             }
 
             if (!endQualifierClosed
-                .map(sqo -> compareByteStrings(sqo, columnQualifier) >= 0)
+                .map(eqc -> compareByteStrings(eqc, columnQualifier) >= 0)
                 .orElse(true)) {
                 return false;
             }
 
             if (!endQualifierOpen
-                .map(sqo -> compareByteStrings(sqo, columnQualifier) > 0)
+                .map(eqo -> compareByteStrings(eqo, columnQualifier) > 0)
                 .orElse(true)) {
                 return false;
             }

--- a/metric/bigtable/src/test/java/com/spotify/heroic/metric/bigtable/MetricsRowKeySerializerTest.java
+++ b/metric/bigtable/src/test/java/com/spotify/heroic/metric/bigtable/MetricsRowKeySerializerTest.java
@@ -1,46 +1,69 @@
 package com.spotify.heroic.metric.bigtable;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.protobuf.ByteString;
 import com.spotify.heroic.common.Series;
-import eu.toolchain.serializer.BytesSerialWriter;
-import eu.toolchain.serializer.SerialReader;
-import eu.toolchain.serializer.Serializer;
+import eu.toolchain.serializer.HexUtils;
 import eu.toolchain.serializer.SerializerFramework;
 import eu.toolchain.serializer.TinySerializer;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import junit.framework.TestCase;
 import org.junit.Assert;
 
-
 public class MetricsRowKeySerializerTest extends TestCase {
     private Series series = Series.of("key", ImmutableMap.of("from", "123", "to", "4567"));
+    private Series seriesResource = Series.of("key", ImmutableMap.of("from", "123", "to", "4567"),
+        ImmutableSortedMap.of("resource1", "abc"));
 
-    private static final String EXPECTED_SERIALIZATION =
-        "\u0003\u0003key" +
-        "\u0002\u0004\u0004from\u0003\u0003123" +
-        "\u0002\u0002to\u0004\u00044567" +
-        "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001";
+    // V1: Without resource tags
+    private static final String EXPECTED_SERIALIZATION_V1 =
+        "\u0003\u0003key" + "\u0002\u0004\u0004from\u0003\u0003123" +
+            "\u0002\u0002to\u0004\u00044567" + "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001";
 
+    // V2: With resource tags
+    private static final String EXPECTED_SERIALIZATION_V2 =
+        "\u0003\u0003key" + "\u0002\u0004\u0004from\u0003\u0003123" +
+            "\u0002\u0002to\u0004\u00044567" + "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001" +
+            "\u0001\u0000\u000f\u0001\u0009resource1\u0003abc";
 
     private final SerializerFramework serializerFramework = TinySerializer.builder().build();
-    private final Serializer<RowKey> serializer = new MetricsRowKeySerializer();
+    private final RowKeySerializer serializer = new MetricsRowKeySerializer();
 
-    public void testSerializationIsBackwardsCompatible() throws Exception {
+    public void testSerializationIsBackwardsCompatibleV1() throws Exception {
         final RowKey rowKey = new RowKey(series, 1);
 
-        final BytesSerialWriter serializedBytes = serializerFramework.writeBytes();
-        serializer.serialize(serializedBytes, rowKey);
+        final ByteString serializedBytes = serializer.serializeFull(rowKey);
 
-        Assert.assertArrayEquals(
-            EXPECTED_SERIALIZATION.getBytes(StandardCharsets.UTF_8), serializedBytes.toByteArray());
+        Assert.assertArrayEquals(EXPECTED_SERIALIZATION_V1.getBytes(StandardCharsets.UTF_8),
+            serializedBytes.toByteArray());
     }
 
-    public void testDeserializationIsBackwardsCompatible() throws Exception {
-        final SerialReader serialReader =
-            serializerFramework.readByteArray(EXPECTED_SERIALIZATION.getBytes(StandardCharsets.UTF_8));
+    public void testSerializationIsBackwardsCompatibleV2() throws Exception {
+        final RowKey rowKey = new RowKey(seriesResource, 1);
 
-        final RowKey rowKey = serializer.deserialize(serialReader);
+        final ByteString serializedBytes = serializer.serializeFull(rowKey);
+
+        Assert.assertArrayEquals(EXPECTED_SERIALIZATION_V2.getBytes(StandardCharsets.UTF_8),
+            serializedBytes.toByteArray());
+    }
+
+    public void testDeserializationIsBackwardsCompatibleV1() throws Exception {
+        final ByteBuffer serializedBytes =
+            ByteBuffer.wrap(EXPECTED_SERIALIZATION_V1.getBytes(StandardCharsets.UTF_8));
+
+        final RowKey rowKey = serializer.deserializeFull(serializedBytes);
 
         assertEquals(rowKey, new RowKey(series, 1));
+    }
+
+    public void testDeserializationIsBackwardsCompatibleV2() throws Exception {
+        final ByteBuffer serializedBytes =
+            ByteBuffer.wrap(EXPECTED_SERIALIZATION_V2.getBytes(StandardCharsets.UTF_8));
+
+        final RowKey rowKey = serializer.deserializeFull(serializedBytes);
+
+        assertEquals(rowKey, new RowKey(seriesResource, 1));
     }
 }

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxBackend.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxBackend.java
@@ -46,6 +46,7 @@ import com.spotify.heroic.metric.FetchData;
 import com.spotify.heroic.metric.FetchQuotaWatcher;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.MetricType;
+import com.spotify.heroic.metric.MetricReadResult;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.QueryError;
 import com.spotify.heroic.metric.QueryTrace;
@@ -135,7 +136,7 @@ public class DatastaxBackend extends AbstractMetricBackend implements LifeCycles
     @Override
     public AsyncFuture<FetchData.Result> fetch(
         final FetchData.Request request, final FetchQuotaWatcher watcher,
-        final Consumer<MetricCollection> metricsConsumer
+        final Consumer<MetricReadResult> metricsConsumer
     ) {
         if (!watcher.mayReadData()) {
             throw new IllegalArgumentException("query violated data limit");
@@ -155,7 +156,9 @@ public class DatastaxBackend extends AbstractMetricBackend implements LifeCycles
 
                 final List<AsyncFuture<FetchData.Result>> results =
                     Lists.transform(fetches, fetch -> fetch.directTransform(fetchData -> {
-                        fetchData.getGroups().forEach(metricsConsumer::accept);
+                        fetchData
+                            .getGroups()
+                            .forEach(mc -> metricsConsumer.accept(MetricReadResult.create(mc)));
                         return fetchData.getResult();
                     }));
                 return async.collect(results, FetchData.collectResult(FETCH));
@@ -732,8 +735,7 @@ public class DatastaxBackend extends AbstractMetricBackend implements LifeCycles
     /**
      * Custom event fetcher based on the one available in
      * {@link com.datastax.driver.core.QueryTrace}.
-     * <p>
-     * We roll our own since the one available is blocking :(.
+     * <p> We roll our own since the one available is blocking :(.
      */
     private AsyncFuture<List<Event>> getEvents(final Connection c, final UUID id) {
         final ResolvableFuture<List<Event>> future = async.future();

--- a/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryBackend.java
+++ b/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryBackend.java
@@ -37,6 +37,7 @@ import com.spotify.heroic.metric.FetchQuotaWatcher;
 import com.spotify.heroic.metric.Metric;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.MetricType;
+import com.spotify.heroic.metric.MetricReadResult;
 import com.spotify.heroic.metric.QueryTrace;
 import com.spotify.heroic.metric.WriteMetric;
 import eu.toolchain.async.AsyncFramework;
@@ -118,12 +119,12 @@ public class MemoryBackend extends AbstractMetricBackend {
     @Override
     public AsyncFuture<FetchData.Result> fetch(
         FetchData.Request request, FetchQuotaWatcher watcher,
-        Consumer<MetricCollection> metricsConsumer
+        Consumer<MetricReadResult> metricsConsumer
     ) {
         final QueryTrace.NamedWatch w = QueryTrace.watch(FETCH);
         final MemoryKey key = new MemoryKey(request.getType(), request.getSeries());
         final MetricCollection metrics = doFetch(key, request.getRange(), watcher);
-        metricsConsumer.accept(metrics);
+        metricsConsumer.accept(MetricReadResult.create(metrics));
         return async.resolved(FetchData.result(w.end()));
     }
 

--- a/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryBackend.java
+++ b/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryBackend.java
@@ -26,9 +26,7 @@ import com.spotify.heroic.QueryOptions;
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Groups;
 import com.spotify.heroic.common.RequestTimer;
-import com.spotify.heroic.common.Series;
 import com.spotify.heroic.common.Statistics;
-import com.spotify.heroic.lifecycle.LifeCycleRegistry;
 import com.spotify.heroic.metric.AbstractMetricBackend;
 import com.spotify.heroic.metric.BackendEntry;
 import com.spotify.heroic.metric.BackendKey;
@@ -36,62 +34,80 @@ import com.spotify.heroic.metric.FetchData;
 import com.spotify.heroic.metric.FetchQuotaWatcher;
 import com.spotify.heroic.metric.Metric;
 import com.spotify.heroic.metric.MetricCollection;
-import com.spotify.heroic.metric.MetricType;
 import com.spotify.heroic.metric.MetricReadResult;
+import com.spotify.heroic.metric.MetricType;
 import com.spotify.heroic.metric.QueryTrace;
 import com.spotify.heroic.metric.WriteMetric;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableMap;
-import java.util.TreeMap;
+import java.util.SortedMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Consumer;
 import javax.inject.Inject;
-import javax.inject.Named;
 import lombok.Data;
 import lombok.ToString;
 
 /**
  * MetricBackend for Heroic cassandra datastore.
  */
-@ToString(exclude = {"storage", "async", "createLock"})
+@ToString(exclude = {"storage", "async"})
 public class MemoryBackend extends AbstractMetricBackend {
     public static final String MEMORY_KEYS = "memory-keys";
 
     public static final QueryTrace.Identifier FETCH =
         QueryTrace.identifier(MemoryBackend.class, "fetch");
 
+    public static final Comparator<Map.Entry<String, String>> ENTRY_COMPARATOR =
+        Comparator.<Map.Entry<String, String>, String>comparing(Map.Entry::getKey).thenComparing(
+            Map.Entry::getValue);
+
     static final List<BackendEntry> EMPTY_ENTRIES = new ArrayList<>();
 
-    static final Comparator<MemoryKey> COMPARATOR = (a, b) -> {
-        final int t = a.getSource().compareTo(b.getSource());
+    static final Comparator<SortedMap<String, String>> MAP_COMPARATOR = (a, b) -> {
+        final Iterator<Map.Entry<String, String>> aIter = a.entrySet().iterator();
+        final Iterator<Map.Entry<String, String>> bIter = b.entrySet().iterator();
 
-        if (t != 0) {
-            return t;
+        while (aIter.hasNext()) {
+            if (!bIter.hasNext()) {
+                return 1;
+            }
+
+            final int n = ENTRY_COMPARATOR.compare(aIter.next(), bIter.next());
+
+            if (n != 0) {
+                return n;
+            }
         }
 
-        return a.getSeries().compareTo(b.getSeries());
+        if (bIter.hasNext()) {
+            return -1;
+        }
+
+        return 0;
     };
 
-    private final Object createLock = new Object();
+    static final Comparator<MemoryKey> COMPARATOR = Comparator
+        .comparing(MemoryKey::getSource)
+        .thenComparing(Comparator.comparing(MemoryKey::getTags, MAP_COMPARATOR));
 
     private final AsyncFramework async;
     private final Groups groups;
-    private final Map<MemoryKey, NavigableMap<Long, Metric>> storage;
+    private final ConcurrentMap<MemoryKey, MemoryCell> storage;
 
     @Inject
-    public MemoryBackend(
-        final AsyncFramework async, final Groups groups,
-        @Named("storage") final Map<MemoryKey, NavigableMap<Long, Metric>> storage,
-        LifeCycleRegistry registry
-    ) {
+    public MemoryBackend(final AsyncFramework async, final Groups groups) {
         super(async);
         this.async = async;
         this.groups = groups;
-        this.storage = storage;
+        this.storage = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -122,9 +138,8 @@ public class MemoryBackend extends AbstractMetricBackend {
         Consumer<MetricReadResult> metricsConsumer
     ) {
         final QueryTrace.NamedWatch w = QueryTrace.watch(FETCH);
-        final MemoryKey key = new MemoryKey(request.getType(), request.getSeries());
-        final MetricCollection metrics = doFetch(key, request.getRange(), watcher);
-        metricsConsumer.accept(MetricReadResult.create(metrics));
+        final MemoryKey key = new MemoryKey(request.getType(), request.getSeries().getTags());
+        doFetch(key, request.getRange(), watcher, metricsConsumer);
         return async.resolved(FetchData.result(w.end()));
     }
 
@@ -140,70 +155,64 @@ public class MemoryBackend extends AbstractMetricBackend {
 
     @Override
     public AsyncFuture<Void> deleteKey(BackendKey key, QueryOptions options) {
-        storage.remove(new MemoryKey(key.getType(), key.getSeries()));
+        storage.remove(new MemoryKey(key.getType(), key.getSeries().getTags()));
         return async.resolved();
-    }
-
-    @Data
-    public static final class MemoryKey {
-        private final MetricType source;
-        private final Series series;
     }
 
     private void writeOne(final WriteMetric.Request request) {
         final MetricCollection g = request.getData();
 
-        final MemoryKey key = new MemoryKey(g.getType(), request.getSeries());
-        final NavigableMap<Long, Metric> tree = getOrCreate(key);
+        final MemoryKey key = new MemoryKey(g.getType(), request.getSeries().getTags());
 
-        synchronized (tree) {
-            for (final Metric d : g.getData()) {
-                tree.put(d.getTimestamp(), d);
-            }
+        final MemoryCell cell =
+            storage.computeIfAbsent(key, k -> new MemoryCell(new ConcurrentHashMap<>()));
+
+        final ConcurrentSkipListMap<Long, Metric> metrics = cell.entries
+            .computeIfAbsent(request.getSeries().getResource(),
+                k -> new MemoryEntry(new ConcurrentSkipListMap<>()))
+            .getMetrics();
+
+        for (final Metric d : g.getData()) {
+            metrics.put(d.getTimestamp(), d);
         }
     }
 
-    private MetricCollection doFetch(
-        final MemoryKey key, final DateRange range, final FetchQuotaWatcher watcher
+    private void doFetch(
+        final MemoryKey key, final DateRange range, final FetchQuotaWatcher watcher,
+        final Consumer<MetricReadResult> metricsConsumer
     ) {
-        final NavigableMap<Long, Metric> tree = storage.get(key);
+        final MemoryCell cell = storage.get(key);
 
-        if (tree == null) {
-            return MetricCollection.build(key.getSource(), ImmutableList.of());
+        // empty
+        if (cell == null) {
+            return;
         }
 
-        synchronized (tree) {
-            final Iterable<Metric> metrics =
-                tree.subMap(range.getStart(), false, range.getEnd(), true).values();
+        for (final Map.Entry<SortedMap<String, String>, MemoryEntry> e : cell.entries.entrySet()) {
+            final Collection<Metric> metrics =
+                e.getValue().metrics.subMap(range.getStart(), false, range.getEnd(), true).values();
+
+            watcher.readData(metrics.size());
+
             final List<Metric> data = ImmutableList.copyOf(metrics);
-            watcher.readData(data.size());
-            return MetricCollection.build(key.getSource(), data);
+            final MetricCollection collection = MetricCollection.build(key.getSource(), data);
+            metricsConsumer.accept(MetricReadResult.create(collection, e.getKey()));
         }
     }
 
-    /**
-     * Get or create a new navigable map to store time data.
-     *
-     * @param key The key to create the map under.
-     * @return An existing, or a newly created navigable map for the given key.
-     */
-    private NavigableMap<Long, Metric> getOrCreate(final MemoryKey key) {
-        final NavigableMap<Long, Metric> tree = storage.get(key);
+    @Data
+    public static final class MemoryKey {
+        private final MetricType source;
+        private final SortedMap<String, String> tags;
+    }
 
-        if (tree != null) {
-            return tree;
-        }
+    @Data
+    public static final class MemoryEntry {
+        private final ConcurrentSkipListMap<Long, Metric> metrics;
+    }
 
-        synchronized (createLock) {
-            final NavigableMap<Long, Metric> checked = storage.get(key);
-
-            if (checked != null) {
-                return checked;
-            }
-
-            final NavigableMap<Long, Metric> created = new TreeMap<>();
-            storage.put(key, created);
-            return created;
-        }
+    @Data
+    public static final class MemoryCell {
+        private final ConcurrentMap<SortedMap<String, String>, MemoryEntry> entries;
     }
 }

--- a/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryMetricModule.java
+++ b/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryMetricModule.java
@@ -21,30 +21,21 @@
 
 package com.spotify.heroic.metric.memory;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.heroic.common.DynamicModuleId;
 import com.spotify.heroic.common.Groups;
 import com.spotify.heroic.common.ModuleId;
 import com.spotify.heroic.dagger.PrimaryComponent;
-import com.spotify.heroic.metric.Metric;
 import com.spotify.heroic.metric.MetricModule;
 import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
-import eu.toolchain.async.AsyncFramework;
-import lombok.Data;
-
-import javax.inject.Named;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.NavigableMap;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentSkipListMap;
-
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
+import lombok.Data;
 
 @Data
 @ModuleId("memory")
@@ -88,19 +79,6 @@ public final class MemoryMetricModule implements MetricModule, DynamicModuleId {
         @MemoryScope
         public Groups groups() {
             return groups;
-        }
-
-        @Provides
-        @MemoryScope
-        @Named("storage")
-        public Map<MemoryBackend.MemoryKey, NavigableMap<Long, Metric>> metricBackend(
-            final AsyncFramework async
-        ) {
-            if (synchronizedStorage) {
-                return Collections.synchronizedMap(new HashMap<>());
-            }
-
-            return new ConcurrentSkipListMap<>(MemoryBackend.COMPARATOR);
         }
     }
 

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
@@ -36,6 +36,7 @@ import com.spotify.heroic.metric.FetchData;
 import com.spotify.heroic.metric.FetchQuotaWatcher;
 import com.spotify.heroic.metric.MetricBackend;
 import com.spotify.heroic.metric.MetricCollection;
+import com.spotify.heroic.metric.MetricReadResult;
 import com.spotify.heroic.metric.WriteMetric;
 import com.spotify.heroic.statistics.DataInMemoryReporter;
 import com.spotify.heroic.statistics.FutureReporter;
@@ -227,7 +228,7 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
         @Override
         public AsyncFuture<FetchData.Result> fetch(
             final FetchData.Request request, final FetchQuotaWatcher watcher,
-            final Consumer<MetricCollection> metricsConsumer
+            final Consumer<MetricReadResult> metricsConsumer
         ) {
             return delegate.fetch(request, watcher, metricsConsumer).onDone(fetch.setup());
         }


### PR DESCRIPTION
Resource identifiers are metadata associated with time series that is not indexed in metadata storage. Instead, it is associated with metrics storage in a way that makes each time series distinct by their `tags` + `resource` instead of just `tags`.

This permits presenting users with a volatile set of "tags", which can change rapidly without needing to be re-indexed. It's crucial to support environments where tags change quickly like in Kubernetes.

This actually provides the majority of support needed for the RFC titled "meaningful metrics" (https://github.com/spotify/heroic/issues/174). Any tag which is not a resource identifier is used to discriminate the _meaning_ of a time series.