### PR TITLE
Update ElasticSearch Templates to reflect deprecation of "string"

### DIFF
--- a/metadata/elasticsearch/src/main/resources/com.spotify.heroic.metadata.elasticsearch/kv/metadata.json
+++ b/metadata/elasticsearch/src/main/resources/com.spotify.heroic.metadata.elasticsearch/kv/metadata.json
@@ -1,23 +1,20 @@
 {
   "metadata": {
+    "_all": {
+        "enabled": false
+    },
     "properties": {
       "key": {
-        "index": "not_analyzed",
-        "type": "string",
-        "doc_values": true,
-        "include_in_all": false
+        "type": "keyword",
+        "doc_values": true
       },
       "tags": {
-        "type": "string",
-        "index": "not_analyzed",
-        "doc_values": true,
-        "include_in_all": false
+        "type": "keyword",
+        "doc_values": true
       },
       "tag_keys": {
-        "type": "string",
-        "index": "not_analyzed",
-        "doc_values": true,
-        "include_in_all": false
+        "type": "keyword",
+        "doc_values": true
       }
     }
   }

--- a/suggest/elasticsearch/src/main/resources/com.spotify.heroic.suggest.elasticsearch/kv/series.json
+++ b/suggest/elasticsearch/src/main/resources/com.spotify.heroic.suggest.elasticsearch/kv/series.json
@@ -1,39 +1,34 @@
 {
   "{{type}}": {
+    "_all": {
+      "enabled": false
+    },
     "properties": {
       "key": {
-        "type": "string",
-        "index": "not_analyzed",
+        "type": "keyword",
         "doc_values": true,
-        "include_in_all": false,
         "fields": {
           "analyzed": {
-            "type": "string",
+            "type": "text",
             "analyzer": "bag_analyzer"
           },
           "prefix": {
-            "type": "string",
+            "type": "text",
             "analyzer": "prefix_analyzer"
           }
         }
       },
       "tags": {
-        "type": "string",
-        "index": "not_analyzed",
-        "doc_values": true,
-        "include_in_all": false
+        "type": "keyword",
+        "doc_values": true
       },
       "tag_keys": {
-        "type": "string",
-        "index": "not_analyzed",
-        "doc_values": true,
-        "include_in_all": false
+        "type": "keyword",
+        "doc_values": true
       },
       "series_id": {
-        "type": "string",
-        "index": "not_analyzed",
-        "doc_values": true,
-        "include_in_all": false
+        "type": "keyword",
+        "doc_values": true
       }
     }
   }

--- a/suggest/elasticsearch/src/main/resources/com.spotify.heroic.suggest.elasticsearch/kv/tag.json
+++ b/suggest/elasticsearch/src/main/resources/com.spotify.heroic.suggest.elasticsearch/kv/tag.json
@@ -1,67 +1,56 @@
 {
   "{{type}}": {
+    "_all": {
+      "enabled": false
+    },
     "properties": {
       "key": {
-        "type": "string",
-        "index": "not_analyzed",
-        "doc_values": true,
-        "include_in_all": false
+        "type": "keyword",
+        "doc_values": true
       },
       "tags": {
-        "type": "string",
-        "index": "not_analyzed",
-        "doc_values": true,
-        "include_in_all": false
+        "type": "keyword",
+        "doc_values": true
       },
       "series_id": {
-        "type": "string",
-        "index": "not_analyzed",
-        "doc_values": true,
-        "include_in_all": false
+        "type": "keyword",
+        "doc_values": true
       },
       "tag_keys": {
-        "type": "string",
-        "index": "not_analyzed",
-        "doc_values": true,
-        "include_in_all": false
+        "type": "keyword",
+        "doc_values": true
       },
       "sval": {
-        "type": "string",
+        "type": "text",
         "analyzer": "bag_analyzer",
-        "include_in_all": false,
         "fields": {
           "raw": {
-            "index": "not_analyzed",
             "doc_values": true,
-            "type": "string"
+            "type": "keyword"
           },
           "prefix": {
-            "type": "string",
+            "type": "text",
             "analyzer": "prefix_analyzer"
           }
         }
       },
       "skey": {
-        "type": "string",
+        "type": "text",
         "analyzer": "bag_analyzer",
-        "include_in_all": false,
         "fields": {
           "raw": {
-            "type": "string",
-            "index": "not_analyzed",
+            "type": "keyword",
             "doc_values": true
           },
           "prefix": {
-            "type": "string",
+            "type": "text",
             "analyzer": "prefix_analyzer"
           }
         }
       },
       "kv": {
-        "index": "not_analyzed",
-        "type": "string",
-        "doc_values": true,
-        "include_in_all": false
+        "type": "keyword",
+        "doc_values": true
       }
     }
   }


### PR DESCRIPTION
As of ElasticSearch 5.0, elastic has expressed the intention to deprecate the `string` type in favor of two new data types `text` and `keyword`:  https://www.elastic.co/blog/strings-are-dead-long-live-strings

This PR reflects that change by replacing `not_analyzed` strings as `keyword` type, and `analyzed` strings with the `text` type.  It also simplifies the templates a little bit by disabling `_all` at the parent type level since all of the fields had the `include_in_all` parameter set to false.