### PR TITLE
Enable Cassandra Driver Pooling option configuration

### DIFF
--- a/heroic-dist/src/test/java/com/spotify/heroic/HeroicConfigurationTest.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/HeroicConfigurationTest.java
@@ -141,6 +141,11 @@ public class HeroicConfigurationTest {
         });
     }
 
+    @Test
+    public void testDatastaxConfiguration() throws Exception {
+        testConfiguration("heroic-datastax.yml");
+    }
+
     /**
      * Test that conditional features from configuration can be parsed and used.
      */

--- a/heroic-dist/src/test/resources/heroic-datastax.yml
+++ b/heroic-dist/src/test/resources/heroic-datastax.yml
@@ -1,0 +1,25 @@
+metrics:
+  backends:
+    - type: datastax
+      consistencyLevel: LOCAL_ONE
+      poolingOptions:
+        maxQueueSize: 256
+        maxRequestsPerConnection:
+          LOCAL: 1024
+          REMOTE: 0
+        coreConnectionsPerHost:
+          LOCAL: 1
+          REMOTE: 0
+        maxConnectionsPerHost:
+          LOCAL: 1
+          REMOTE: 0
+      seeds:
+        - cassandra3
+      schema:
+        type: ng
+        keyspace: heroic
+  groupLimit: 10000
+  seriesLimit: 10000
+  dataLimit: 10000
+  aggregationLimit: 10000
+  failOnLimits: true

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxBackend.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxBackend.java
@@ -431,9 +431,14 @@ public class DatastaxBackend extends AbstractMetricBackend implements LifeCycles
                         .bind(async, c.session.executeAsync(stmt))
                         .onFailed(e -> {
                             // log series using a marker so they can be collected on their own file
-                            log.info(FAILED_METRICS, "{\"series\": \"" + request.getSeries().toString() + "\", \"timestamp\":" + d.toString() + "}");
-                            // log exceptions
-                            log.error("Failed to write metric", e);
+                            log.info(
+                                FAILED_METRICS,
+                                "{\"series\": \"{}\", \"timestamp\": {}}",
+                                request.getSeries().toString(),
+                                d.toString()
+                            );
+                            // log exceptions without a marker for
+                            log.debug("Failed to write metric", e);
                         })
                         .directTransform((r) -> System.nanoTime() - start);
                 });

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxMetricModule.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxMetricModule.java
@@ -92,6 +92,8 @@ public final class DatastaxMetricModule implements MetricModule, DynamicModuleId
     private final RetryPolicy retryPolicy;
     /* authentication to apply to builder */
     private final DatastaxAuthentication authentication;
+    /* client pooling options */
+    private final DatastaxPoolingOptions poolingOptions;
 
     @JsonCreator
     public DatastaxMetricModule(
@@ -103,7 +105,8 @@ public final class DatastaxMetricModule implements MetricModule, DynamicModuleId
         @JsonProperty("readTimeout") Optional<Duration> readTimeout,
         @JsonProperty("consistencyLevel") Optional<ConsistencyLevel> consistencyLevel,
         @JsonProperty("retryPolicy") Optional<RetryPolicy> retryPolicy,
-        @JsonProperty("authentication") Optional<DatastaxAuthentication> authentication
+        @JsonProperty("authentication") Optional<DatastaxAuthentication> authentication,
+        @JsonProperty("poolingOptions") Optional<DatastaxPoolingOptions> poolingOptions
     ) {
         this.id = id;
         this.groups = groups.orElseGet(Groups::empty).or("heroic");
@@ -115,6 +118,7 @@ public final class DatastaxMetricModule implements MetricModule, DynamicModuleId
         this.consistencyLevel = consistencyLevel.orElse(ConsistencyLevel.ONE);
         this.retryPolicy = retryPolicy.orElse(DefaultRetryPolicy.INSTANCE);
         this.authentication = authentication.orElseGet(DatastaxAuthentication.None::new);
+        this.poolingOptions = poolingOptions.orElseGet(DatastaxPoolingOptions::new);
     }
 
     private static List<InetSocketAddress> convert(Set<String> source) {
@@ -199,7 +203,7 @@ public final class DatastaxMetricModule implements MetricModule, DynamicModuleId
         ) {
             return async.managed(
                 new ManagedSetupConnection(async, seeds, schema, configure, fetchSize, readTimeout,
-                    consistencyLevel, retryPolicy, authentication));
+                    consistencyLevel, retryPolicy, authentication, poolingOptions));
         }
 
         @Provides
@@ -229,6 +233,7 @@ public final class DatastaxMetricModule implements MetricModule, DynamicModuleId
         private Optional<ConsistencyLevel> consistencyLevel = empty();
         private Optional<RetryPolicy> retryPolicy = empty();
         private Optional<DatastaxAuthentication> authentication = empty();
+        private Optional<DatastaxPoolingOptions> poolingOptions = empty();
 
         public Builder id(String id) {
             this.id = of(id);
@@ -282,7 +287,7 @@ public final class DatastaxMetricModule implements MetricModule, DynamicModuleId
 
         public DatastaxMetricModule build() {
             return new DatastaxMetricModule(id, groups, seeds, schema, configure, fetchSize,
-                readTimeout, consistencyLevel, retryPolicy, authentication);
+                readTimeout, consistencyLevel, retryPolicy, authentication, poolingOptions);
         }
     }
 }

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxPoolingOptions.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxPoolingOptions.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.heroic.metric.datastax;
 
 import java.util.Optional;
@@ -28,15 +49,19 @@ public class DatastaxPoolingOptions {
 
     @JsonCreator
     public DatastaxPoolingOptions(
-        @JsonProperty("maxRequestsPerConnection") Optional<Map<HostDistance, Integer>> maxRequestsPerConnection,
-        @JsonProperty("coreConnectionsPerHost") Optional<Map<HostDistance, Integer>> coreConnectionsPerHost,
-        @JsonProperty("maxConnectionsPerHost") Optional<Map<HostDistance, Integer>> maxConnectionsPerHost,
-        @JsonProperty("newConnectionThreshold") Optional<Map<HostDistance, Integer>> newConnectionThreshold,
+        @JsonProperty("maxRequestsPerConnection")
+            Optional<Map<HostDistance, Integer>> maxRequestsPerConnection,
+        @JsonProperty("coreConnectionsPerHost")
+            Optional<Map<HostDistance, Integer>> coreConnectionsPerHost,
+        @JsonProperty("maxConnectionsPerHost")
+            Optional<Map<HostDistance, Integer>> maxConnectionsPerHost,
+        @JsonProperty("newConnectionThreshold")
+            Optional<Map<HostDistance, Integer>> newConnectionThreshold,
         @JsonProperty("maxQueueSize") Optional<Integer> maxQueueSize,
         @JsonProperty("poolTimeoutMillis") Optional<Integer> poolTimeoutMillis,
         @JsonProperty("idleTimeoutSeconds") Optional<Integer> idleTimeoutSeconds,
         @JsonProperty("heartbeatIntervalSeconds") Optional<Integer> heartbeatIntervalSeconds
-    ){
+    ) {
         this.maxRequestsPerConnection = maxRequestsPerConnection;
         this.coreConnectionsPerHost = coreConnectionsPerHost;
         this.maxConnectionsPerHost = maxConnectionsPerHost;
@@ -49,26 +74,26 @@ public class DatastaxPoolingOptions {
 
     public void apply(final Builder builder) {
         final PoolingOptions pooling = new PoolingOptions();
-        this.maxRequestsPerConnection.ifPresent( x -> {
-            for (Map.Entry<HostDistance, Integer> entry : x.entrySet())
+        this.maxRequestsPerConnection.ifPresent(x -> {
+            for (Map.Entry<HostDistance, Integer> entry : x.entrySet()) {
                 pooling.setMaxRequestsPerConnection(entry.getKey(), entry.getValue());
             }
-        );
-        this.coreConnectionsPerHost.ifPresent( x -> {
-            for (Map.Entry<HostDistance, Integer> entry : x.entrySet())
+        });
+        this.coreConnectionsPerHost.ifPresent(x -> {
+            for (Map.Entry<HostDistance, Integer> entry : x.entrySet()) {
                 pooling.setCoreConnectionsPerHost(entry.getKey(), entry.getValue());
             }
-        );
-        this.maxConnectionsPerHost.ifPresent( x -> {
-            for (Map.Entry<HostDistance, Integer> entry : x.entrySet())
+        });
+        this.maxConnectionsPerHost.ifPresent(x -> {
+            for (Map.Entry<HostDistance, Integer> entry : x.entrySet()) {
                 pooling.setMaxConnectionsPerHost(entry.getKey(), entry.getValue());
             }
-        );
-        this.newConnectionThreshold.ifPresent( x -> {
-                for (Map.Entry<HostDistance, Integer> entry : x.entrySet())
-                    pooling.setNewConnectionThreshold(entry.getKey(), entry.getValue());
+        });
+        this.newConnectionThreshold.ifPresent(x -> {
+            for (Map.Entry<HostDistance, Integer> entry : x.entrySet()) {
+                pooling.setNewConnectionThreshold(entry.getKey(), entry.getValue());
             }
-        );
+        });
 
         this.maxQueueSize.ifPresent(pooling::setMaxQueueSize);
         this.poolTimeoutMillis.ifPresent(pooling::setPoolTimeoutMillis);

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxPoolingOptions.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxPoolingOptions.java
@@ -1,0 +1,71 @@
+package com.spotify.heroic.metric.datastax;
+
+import java.util.Optional;
+import com.datastax.driver.core.Cluster.Builder;
+import com.datastax.driver.core.HostDistance;
+import com.datastax.driver.core.PoolingOptions;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Optional.empty;
+
+
+public class DatastaxPoolingOptions {
+
+    private final Optional<Integer> maxRequestsPerConnectionLocal;
+    private final Optional<Integer> maxRequestsPerConnectionRemote;
+    private final Optional<Integer> coreConnectionsPerHostLocal;
+    private final Optional<Integer> coreConnectionsPerHostRemote;
+    private final Optional<Integer> maxConnectionsPerHostLocal;
+    private final Optional<Integer> maxConnectionsPerHostRemote;
+    private final Optional<Integer> maxQueueSize;
+    private final Optional<Integer> poolTimeoutMillis;
+    private final Optional<Integer> idleTimeoutSeconds;
+    private final Optional<Integer> heartbeatIntervalSeconds;
+
+    public DatastaxPoolingOptions() {
+        this(empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty());
+    }
+
+    @JsonCreator
+    public DatastaxPoolingOptions(
+        @JsonProperty("maxRequestsPerConnection.LOCAL") Optional<Integer> maxRequestsPerConnectionLocal,
+        @JsonProperty("maxRequestsPerConnection.REMOTE") Optional<Integer> maxRequestsPerConnectionRemote,
+        @JsonProperty("coreConnectionsPerHost.LOCAL") Optional<Integer> coreConnectionsPerHostLocal,
+        @JsonProperty("coreConnectionsPerHost.REMOTE") Optional<Integer> coreConnectionsPerHostRemote,
+        @JsonProperty("maxConnectionsPerHost.LOCAL") Optional<Integer> maxConnectionsPerHostLocal,
+        @JsonProperty("maxConnectionsPerHost.REMOTE") Optional<Integer> maxConnectionsPerHostRemote,
+        @JsonProperty("maxQueueSize") Optional<Integer> maxQueueSize,
+        @JsonProperty("poolTimeoutMillis") Optional<Integer> poolTimeoutMillis,
+        @JsonProperty("idleTimeoutSeconds") Optional<Integer> idleTimeoutSeconds,
+        @JsonProperty("heartbeatIntervalSeconds") Optional<Integer> heartbeatIntervalSeconds
+    ){
+        this.maxRequestsPerConnectionLocal = maxRequestsPerConnectionLocal;
+        this.maxRequestsPerConnectionRemote = maxRequestsPerConnectionRemote;
+        this.coreConnectionsPerHostLocal = coreConnectionsPerHostLocal;
+        this.coreConnectionsPerHostRemote = coreConnectionsPerHostRemote;
+        this.maxConnectionsPerHostLocal = maxConnectionsPerHostLocal;
+        this.maxConnectionsPerHostRemote = maxConnectionsPerHostRemote;
+        this.maxQueueSize = maxQueueSize;
+        this.poolTimeoutMillis = poolTimeoutMillis;
+        this.idleTimeoutSeconds = idleTimeoutSeconds;
+        this.heartbeatIntervalSeconds = heartbeatIntervalSeconds;
+    }
+
+    public void apply(final Builder builder) {
+        final PoolingOptions pooling = new PoolingOptions();
+        this.maxRequestsPerConnectionLocal.ifPresent(x -> pooling.setMaxConnectionsPerHost(HostDistance.LOCAL, x));
+        this.maxRequestsPerConnectionRemote.ifPresent(x -> pooling.setMaxConnectionsPerHost(HostDistance.REMOTE, x));
+        this.coreConnectionsPerHostLocal.ifPresent(x -> pooling.setCoreConnectionsPerHost(HostDistance.LOCAL, x));
+        this.coreConnectionsPerHostRemote.ifPresent(x -> pooling.setCoreConnectionsPerHost(HostDistance.REMOTE, x));
+        this.maxConnectionsPerHostLocal.ifPresent(x -> pooling.setMaxConnectionsPerHost(HostDistance.LOCAL, x));
+        this.maxConnectionsPerHostRemote.ifPresent(x -> pooling.setMaxConnectionsPerHost(HostDistance.REMOTE, x));
+        this.maxQueueSize.ifPresent(pooling::setMaxQueueSize);
+        this.poolTimeoutMillis.ifPresent(pooling::setPoolTimeoutMillis);
+        this.idleTimeoutSeconds.ifPresent(pooling::setIdleTimeoutSeconds);
+        this.heartbeatIntervalSeconds.ifPresent(pooling::setHeartbeatIntervalSeconds);
+        builder.withPoolingOptions(pooling);
+    }
+
+
+}

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxPoolingOptions.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxPoolingOptions.java
@@ -1,6 +1,7 @@
 package com.spotify.heroic.metric.datastax;
 
 import java.util.Optional;
+import java.util.Map;
 import com.datastax.driver.core.Cluster.Builder;
 import com.datastax.driver.core.HostDistance;
 import com.datastax.driver.core.PoolingOptions;
@@ -12,40 +13,34 @@ import static java.util.Optional.empty;
 
 public class DatastaxPoolingOptions {
 
-    private final Optional<Integer> maxRequestsPerConnectionLocal;
-    private final Optional<Integer> maxRequestsPerConnectionRemote;
-    private final Optional<Integer> coreConnectionsPerHostLocal;
-    private final Optional<Integer> coreConnectionsPerHostRemote;
-    private final Optional<Integer> maxConnectionsPerHostLocal;
-    private final Optional<Integer> maxConnectionsPerHostRemote;
+    private final Optional<Map<HostDistance, Integer>> maxRequestsPerConnection;
+    private final Optional<Map<HostDistance, Integer>> coreConnectionsPerHost;
+    private final Optional<Map<HostDistance, Integer>> maxConnectionsPerHost;
+    private final Optional<Map<HostDistance, Integer>> newConnectionThreshold;
     private final Optional<Integer> maxQueueSize;
     private final Optional<Integer> poolTimeoutMillis;
     private final Optional<Integer> idleTimeoutSeconds;
     private final Optional<Integer> heartbeatIntervalSeconds;
 
     public DatastaxPoolingOptions() {
-        this(empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty());
+        this(empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty());
     }
 
     @JsonCreator
     public DatastaxPoolingOptions(
-        @JsonProperty("maxRequestsPerConnection.LOCAL") Optional<Integer> maxRequestsPerConnectionLocal,
-        @JsonProperty("maxRequestsPerConnection.REMOTE") Optional<Integer> maxRequestsPerConnectionRemote,
-        @JsonProperty("coreConnectionsPerHost.LOCAL") Optional<Integer> coreConnectionsPerHostLocal,
-        @JsonProperty("coreConnectionsPerHost.REMOTE") Optional<Integer> coreConnectionsPerHostRemote,
-        @JsonProperty("maxConnectionsPerHost.LOCAL") Optional<Integer> maxConnectionsPerHostLocal,
-        @JsonProperty("maxConnectionsPerHost.REMOTE") Optional<Integer> maxConnectionsPerHostRemote,
+        @JsonProperty("maxRequestsPerConnection") Optional<Map<HostDistance, Integer>> maxRequestsPerConnection,
+        @JsonProperty("coreConnectionsPerHost") Optional<Map<HostDistance, Integer>> coreConnectionsPerHost,
+        @JsonProperty("maxConnectionsPerHost") Optional<Map<HostDistance, Integer>> maxConnectionsPerHost,
+        @JsonProperty("newConnectionThreshold") Optional<Map<HostDistance, Integer>> newConnectionThreshold,
         @JsonProperty("maxQueueSize") Optional<Integer> maxQueueSize,
         @JsonProperty("poolTimeoutMillis") Optional<Integer> poolTimeoutMillis,
         @JsonProperty("idleTimeoutSeconds") Optional<Integer> idleTimeoutSeconds,
         @JsonProperty("heartbeatIntervalSeconds") Optional<Integer> heartbeatIntervalSeconds
     ){
-        this.maxRequestsPerConnectionLocal = maxRequestsPerConnectionLocal;
-        this.maxRequestsPerConnectionRemote = maxRequestsPerConnectionRemote;
-        this.coreConnectionsPerHostLocal = coreConnectionsPerHostLocal;
-        this.coreConnectionsPerHostRemote = coreConnectionsPerHostRemote;
-        this.maxConnectionsPerHostLocal = maxConnectionsPerHostLocal;
-        this.maxConnectionsPerHostRemote = maxConnectionsPerHostRemote;
+        this.maxRequestsPerConnection = maxRequestsPerConnection;
+        this.coreConnectionsPerHost = coreConnectionsPerHost;
+        this.maxConnectionsPerHost = maxConnectionsPerHost;
+        this.newConnectionThreshold = newConnectionThreshold;
         this.maxQueueSize = maxQueueSize;
         this.poolTimeoutMillis = poolTimeoutMillis;
         this.idleTimeoutSeconds = idleTimeoutSeconds;
@@ -54,12 +49,27 @@ public class DatastaxPoolingOptions {
 
     public void apply(final Builder builder) {
         final PoolingOptions pooling = new PoolingOptions();
-        this.maxRequestsPerConnectionLocal.ifPresent(x -> pooling.setMaxConnectionsPerHost(HostDistance.LOCAL, x));
-        this.maxRequestsPerConnectionRemote.ifPresent(x -> pooling.setMaxConnectionsPerHost(HostDistance.REMOTE, x));
-        this.coreConnectionsPerHostLocal.ifPresent(x -> pooling.setCoreConnectionsPerHost(HostDistance.LOCAL, x));
-        this.coreConnectionsPerHostRemote.ifPresent(x -> pooling.setCoreConnectionsPerHost(HostDistance.REMOTE, x));
-        this.maxConnectionsPerHostLocal.ifPresent(x -> pooling.setMaxConnectionsPerHost(HostDistance.LOCAL, x));
-        this.maxConnectionsPerHostRemote.ifPresent(x -> pooling.setMaxConnectionsPerHost(HostDistance.REMOTE, x));
+        this.maxRequestsPerConnection.ifPresent( x -> {
+            for (Map.Entry<HostDistance, Integer> entry : x.entrySet())
+                pooling.setMaxRequestsPerConnection(entry.getKey(), entry.getValue());
+            }
+        );
+        this.coreConnectionsPerHost.ifPresent( x -> {
+            for (Map.Entry<HostDistance, Integer> entry : x.entrySet())
+                pooling.setCoreConnectionsPerHost(entry.getKey(), entry.getValue());
+            }
+        );
+        this.maxConnectionsPerHost.ifPresent( x -> {
+            for (Map.Entry<HostDistance, Integer> entry : x.entrySet())
+                pooling.setMaxConnectionsPerHost(entry.getKey(), entry.getValue());
+            }
+        );
+        this.newConnectionThreshold.ifPresent( x -> {
+                for (Map.Entry<HostDistance, Integer> entry : x.entrySet())
+                    pooling.setNewConnectionThreshold(entry.getKey(), entry.getValue());
+            }
+        );
+
         this.maxQueueSize.ifPresent(pooling::setMaxQueueSize);
         this.poolTimeoutMillis.ifPresent(pooling::setPoolTimeoutMillis);
         this.idleTimeoutSeconds.ifPresent(pooling::setIdleTimeoutSeconds);

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/ManagedSetupConnection.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/ManagedSetupConnection.java
@@ -23,7 +23,6 @@ package com.spotify.heroic.metric.datastax;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ConsistencyLevel;
-import com.datastax.driver.core.PoolingOptions;
 import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SocketOptions;

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/ManagedSetupConnection.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/ManagedSetupConnection.java
@@ -53,11 +53,11 @@ public class ManagedSetupConnection implements ManagedSetup<Connection> {
     private final ConsistencyLevel consistencyLevel;
     private final RetryPolicy retryPolicy;
     private final DatastaxAuthentication authentication;
+    private final DatastaxPoolingOptions poolingOptions;
 
     public AsyncFuture<Connection> construct() {
         AsyncFuture<Session> session = async.call(() -> {
-            // @formatter:off
-            final PoolingOptions pooling = new PoolingOptions();
+
 
             final QueryOptions queryOptions = new QueryOptions()
                 .setFetchSize(fetchSize)
@@ -69,13 +69,14 @@ public class ManagedSetupConnection implements ManagedSetup<Connection> {
             final Cluster.Builder cluster = Cluster.builder()
                 .addContactPointsWithPorts(seeds)
                 .withRetryPolicy(retryPolicy)
-                .withPoolingOptions(pooling)
                 .withQueryOptions(queryOptions)
                 .withSocketOptions(socketOptions)
                 .withLoadBalancingPolicy(new TokenAwarePolicy(new RoundRobinPolicy()));
             // @formatter:on
 
             authentication.accept(cluster);
+            poolingOptions.apply(cluster);
+
             return cluster.build().connect();
         });
 


### PR DESCRIPTION
This change set enables the configuration of the [java driver pooling options](https://docs.datastax.com/en/developer/java-driver/3.2/manual/pooling/) during startup.  

A couple of notes: 

- In our case we are very sensitive to data loss, so we wanted to set up a separate logging file that we can parse for alerting/resubmission, hence the additional logging on `DatastaxBackend.java`. We are totally open (and appreciate recommendations) to different approaches for this.

- I will also submit a separate PR to the `site` branch with documentation updates.
