### PR TITLE
[heroic-elasticsearch-utils] add metrics to DisabledRateLimitedCache

### DIFF
--- a/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/DefaultRateLimitedCacheTest.java
+++ b/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/DefaultRateLimitedCacheTest.java
@@ -1,4 +1,4 @@
-package com.spotify.heroic.elasticsearch.index;
+package com.spotify.heroic.elasticsearch;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;
@@ -6,8 +6,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.util.concurrent.RateLimiter;
-import com.spotify.heroic.elasticsearch.DefaultRateLimitedCache;
-import com.spotify.heroic.elasticsearch.RateLimitExceededException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;

--- a/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/DisabledRateLimitedCacheTest.java
+++ b/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/DisabledRateLimitedCacheTest.java
@@ -2,7 +2,7 @@ package com.spotify.heroic.elasticsearch;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -26,7 +26,7 @@ public class DisabledRateLimitedCacheTest {
         assertFalse(writeCache.acquire("key1", notifier));
         assertTrue(writeCache.acquire("key2", notifier));
 
-        verify(notifier, never()).run();
+        verify(notifier, atLeastOnce()).run();
     }
 
 

--- a/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/DisabledRateLimitedCacheTest.java
+++ b/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/DisabledRateLimitedCacheTest.java
@@ -1,0 +1,33 @@
+package com.spotify.heroic.elasticsearch;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DisabledRateLimitedCacheTest {
+    private ConcurrentMap<String, Boolean> cache = new ConcurrentHashMap<>();
+
+    @Mock
+    Runnable notifier;
+
+    @Test
+    public void testCache() {
+        final DisabledRateLimitedCache<String>  writeCache = new DisabledRateLimitedCache<>(cache);
+        assertTrue(writeCache.acquire("key1", notifier));
+        assertFalse(writeCache.acquire("key1", notifier));
+        assertTrue(writeCache.acquire("key2", notifier));
+
+        verify(notifier, never()).run();
+    }
+
+
+}

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/ElasticsearchMetadataModule.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/ElasticsearchMetadataModule.java
@@ -207,11 +207,11 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
                 .expireAfterWrite(writeCacheDurationMinutes, TimeUnit.MINUTES)
                 .build();
 
+            reporter.registerCacheSize("elasticsearch-metadata-write-through", cache::size);
+
             if (writesPerSecond <= 0d) {
                 return new DisabledRateLimitedCache<>(cache.asMap());
             }
-
-            reporter.registerCacheSize("elasticsearch-metadata-write-through", cache::size);
 
             return new DefaultRateLimitedCache<>(cache.asMap(),
                 RateLimiter.create(writesPerSecond, rateLimitSlowStartSeconds, TimeUnit.SECONDS));

--- a/suggest/elasticsearch/src/main/java/com/spotify/heroic/suggest/elasticsearch/ElasticsearchSuggestModule.java
+++ b/suggest/elasticsearch/src/main/java/com/spotify/heroic/suggest/elasticsearch/ElasticsearchSuggestModule.java
@@ -197,11 +197,11 @@ public final class ElasticsearchSuggestModule implements SuggestModule, DynamicM
                 .expireAfterWrite(writeCacheDurationMinutes, TimeUnit.MINUTES)
                 .build();
 
+            reporter.registerCacheSize("elasticsearch-suggest-write-through", cache::size);
+
             if (writesPerSecond <= 0d) {
                 return new DisabledRateLimitedCache<>(cache.asMap());
             }
-
-            reporter.registerCacheSize("elasticsearch-suggest-write-through", cache::size);
 
             return new DefaultRateLimitedCache<>(cache.asMap(),
                 RateLimiter.create(writesPerSecond, rateLimitSlowStartSeconds, TimeUnit.SECONDS));


### PR DESCRIPTION
The `DisabledRateLimitedCache` was missing metrics around how often it was being hit.

@hexedpackets @jsferrei 