### PR TITLE
[heroic-elasticsearch-utils] add DistributedRateLimitedCache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ bin
 /reports/
 /assets/out/
 .meghanada
+
+# doc build artifacts
+bower_components
+node_modules
+output

--- a/heroic-elasticsearch-utils/pom.xml
+++ b/heroic-elasticsearch-utils/pom.xml
@@ -21,6 +21,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.spotify.heroic.repackaged</groupId>
+      <artifactId>folsom</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/DistributedRateLimitedCache.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/DistributedRateLimitedCache.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2018 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.elasticsearch;
+
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import com.google.common.util.concurrent.RateLimiter;
+import com.spotify.folsom.MemcacheClient;
+import io.opencensus.common.Scope;
+import io.opencensus.trace.Span;
+import io.opencensus.trace.Status;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
+import java.nio.charset.Charset;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A distributed cache that does not allow to be called more than a specific rate.
+ *
+ * Instead of having a cache that is local to each consumer this allows the cache
+ * to be distributed. This became necessary when migrating from Kafka -> Google PubSub as
+ * a consumer with PubSub will not have a stable partition of metrics.
+ *
+ * @author dmichel
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class DistributedRateLimitedCache<K> implements RateLimitedCache<K> {
+
+  private final ConcurrentMap<K, Boolean> cache;
+  private final RateLimiter rateLimiter;
+  private final MemcacheClient memcachedClient;
+  private final int memcachedTtlSeconds;
+
+  private static final HashFunction HASH_FUNCTION = Hashing.murmur3_128();
+  private final Tracer tracer = Tracing.getTracer();
+
+  /**
+   *
+   * @param key key to store/lookup in cache.
+   * @param cacheHit function to call when the cache is hit (usually a metric reporter)
+   * @return true - write to backend, false - do not write to backend
+   */
+  public boolean acquire(K key, final Runnable cacheHit) {
+    try (Scope ss = tracer.spanBuilder("DistributedRateLimitedCache").startScopedSpan()) {
+      Span span = tracer.getCurrentSpan();
+
+      if (cache.get(key) != null) {
+        span.addAnnotation("Found key in cache");
+        cacheHit.run();
+        return false;
+      }
+
+      final String cacheKey = buildKey(key);
+      try {
+        if (memcachedClient.get(
+          cacheKey).toCompletableFuture().get(100, TimeUnit.MILLISECONDS) != null) {
+          span.addAnnotation("Found key in memcached");
+          cache.putIfAbsent(key, true);
+          cacheHit.run();
+          return false;
+        }
+      } catch (TimeoutException | InterruptedException | ExecutionException e) {
+        span.setStatus(Status.INTERNAL.withDescription(e.getMessage()));
+        log.error("Failed to get key from memecached", e);
+      }
+
+      span.addAnnotation("Acquiring rate limiter");
+      rateLimiter.acquire();
+      span.addAnnotation("Acquired rate limiter");
+
+      if (cache.putIfAbsent(key, true) != null) {
+        cacheHit.run();
+        return false;
+      } else {
+        span.addAnnotation("Add key in memcached " + cacheKey);
+        memcachedClient.set(cacheKey, "true", memcachedTtlSeconds);
+      }
+
+      return true;
+    }
+  }
+
+  private String buildKey(final K key) {
+    final Hasher hasher = HASH_FUNCTION.newHasher();
+    return hasher.putString(key.toString(), Charset.defaultCharset()).hash().toString();
+  }
+
+  public int size() {
+    return cache.size();
+  }
+}

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/MemcachedConnection.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/MemcachedConnection.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.elasticsearch;
+
+import com.spotify.folsom.MemcacheClient;
+import com.spotify.folsom.MemcacheClientBuilder;
+
+public class MemcachedConnection {
+  public static MemcacheClient create(final String distributedCacheSrvRecord) {
+    final MemcacheClientBuilder<String> client = MemcacheClientBuilder.newStringClient();
+    if (distributedCacheSrvRecord.equals("localhost")) {
+      client.withAddress(distributedCacheSrvRecord);
+    } else {
+      client.withSRVRecord(distributedCacheSrvRecord);
+    }
+    return client.connectAscii();
+  }
+}

--- a/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/DistributedRateLimitedCacheTest.java
+++ b/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/DistributedRateLimitedCacheTest.java
@@ -1,0 +1,98 @@
+package com.spotify.heroic.elasticsearch;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.util.concurrent.RateLimiter;
+import com.spotify.folsom.MemcacheClient;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DistributedRateLimitedCacheTest {
+    private DistributedRateLimitedCache<String> writeCache;
+    private ConcurrentMap<String, Boolean> cache;
+    private String key1 = "key1";
+    private int MEMCACHED_TTL_SECONDS = 60;
+
+    @Mock
+    RateLimiter rateLimiter;
+
+
+    @Mock
+    MemcacheClient memcacheClient;
+
+    @Mock
+    Runnable cacheHit;
+
+    @Before
+    public void setUp() {
+       cache = new ConcurrentHashMap<>();
+       writeCache = new DistributedRateLimitedCache<>(
+         cache, rateLimiter, memcacheClient, MEMCACHED_TTL_SECONDS);
+    }
+
+
+    @Test
+    public void localCacheHit(){
+        cache.putIfAbsent("key1", true);
+
+        assertFalse(writeCache.acquire("key1", cacheHit));
+
+        verify(cacheHit, atLeastOnce()).run();
+        verify(rateLimiter, never()).acquire();
+    }
+
+    @Test
+    public void memcachedCacheHit() throws
+                                   ExecutionException, InterruptedException, TimeoutException {
+        doReturn(setupMockedMemcachedGet(key1)).when(memcacheClient).get(Matchers.anyString());
+        assertFalse(writeCache.acquire(key1, cacheHit));
+
+        verify(cacheHit, atLeastOnce()).run();
+        verify(rateLimiter, never()).acquire();
+    }
+
+    @Test
+    public void noCacheHit() throws InterruptedException, ExecutionException, TimeoutException {
+        doReturn(setupMockedMemcachedGet(null)).when(memcacheClient).get(Matchers.anyString());
+        doReturn(1D).when(rateLimiter).acquire();
+
+        assertTrue(writeCache.acquire(key1, cacheHit));
+        assertTrue(cache.get("key1"));
+        assertEquals(1, writeCache.size());
+
+        verify(cacheHit, never()).run();
+        verify(rateLimiter, atLeastOnce()).acquire();
+        verify(memcacheClient).set(
+          Matchers.anyString(), Matchers.eq("true"), Matchers.eq(MEMCACHED_TTL_SECONDS));
+    }
+
+
+    public CompletionStage setupMockedMemcachedGet(final String key)
+      throws InterruptedException, ExecutionException, TimeoutException {
+        final CompletableFuture completableFuture = Mockito.mock(CompletableFuture.class);
+        doReturn(key).when(completableFuture).get(Matchers.anyLong(), Matchers.anyObject());
+
+        final CompletionStage completionStage = Mockito.mock(CompletionStage.class);
+        doReturn(completableFuture).when(completionStage).toCompletableFuture();
+
+        return completionStage;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <slf4j.version>1.7.21</slf4j.version>
     <junit.version>4.12</junit.version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
-    <folsom.version>0.7.3</folsom.version>
+    <folsom.version>1.1.1</folsom.version>
     <opencensus.version>0.15.0</opencensus.version>
   </properties>
 

--- a/repackaged/folsom/pom.xml
+++ b/repackaged/folsom/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.spotify.heroic.repackaged</groupId>
   <artifactId>folsom</artifactId>
   <packaging>jar</packaging>
-  <version>0.7.3</version>
+  <version>1.1.1</version>
 
   <name>Heroic: Re-Packaging of Folsom</name>
 


### PR DESCRIPTION
A distributed cache that does not allow to be called more than a specific rate.

Instead of having a cache that is local to each consumer this allows the cache to be distributed to all the instances. This became necessary when migrating from Kafka -> Google PubSub as a consumer with PubSub will not have a stable partition of metrics.

Reads from the distributed cache are stored locally to reduce the load on the distributed cache cluster.


There is a separate commit that updates folsom to the latest stable version.

@hexedpackets @jsferrei @sjoeboo 