### PR TITLE
[pubsub] consume more messages

### DIFF
--- a/consumer/pubsub/src/main/java/com/spotify/heroic/consumer/pubsub/Connection.java
+++ b/consumer/pubsub/src/main/java/com/spotify/heroic/consumer/pubsub/Connection.java
@@ -124,6 +124,7 @@ public class Connection {
         subscriber = Subscriber
             .newBuilder(subscriptionName, receiver)
             .setFlowControlSettings(flowControlSettings)
+            .setParallelPullCount(threads)
             .setExecutorProvider(executorProvider)
             .setChannelProvider(channelProvider)
             .setCredentialsProvider(credentialsProvider)

--- a/consumer/pubsub/src/main/java/com/spotify/heroic/consumer/pubsub/PubSubConsumerModule.java
+++ b/consumer/pubsub/src/main/java/com/spotify/heroic/consumer/pubsub/PubSubConsumerModule.java
@@ -56,7 +56,7 @@ import lombok.extern.slf4j.Slf4j;
 @Data
 public class PubSubConsumerModule implements ConsumerModule {
     private static final int DEFAULT_THREADS_PER_SUBSCRIPTION = 8;
-    private static final Long DEFAULT_MAX_OUTSTANDING_ELEMENT_COUNT = 10_000L;
+    private static final Long DEFAULT_MAX_OUTSTANDING_ELEMENT_COUNT = 20_000L;
     private static final Long DEFAULT_MAX_OUTSTANDING_REQUEST_BYTES = 1_000_000_000L;
     // 20MB API maximum message size.
     private static final int DEFAULT_MAX_INBOUND_MESSAGE_SIZE = 20 * 1024 * 1024;


### PR DESCRIPTION
* Change the default number of outstanding messages to 20k.
* Set parallel pull count to the number of configured threads.

throughput improvements of a consumer compared to its peers. 
![throughput improvement](https://user-images.githubusercontent.com/677960/45710310-4be8e000-bb54-11e8-9b28-5b805849fe3e.png)

@sjoeboo @hexedpackets 