### PR TITLE
Add HTTP tracing in jersey for incoming requests.

### DIFF
--- a/heroic-core/pom.xml
+++ b/heroic-core/pom.xml
@@ -61,6 +61,10 @@
       <artifactId>jetty-rewrite</artifactId>
     </dependency>
     <dependency>
+    <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet-core</artifactId>
     </dependency>
@@ -75,6 +79,10 @@
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
     </dependency>
 
     <dependency>

--- a/heroic-core/src/main/java/com/spotify/heroic/http/HttpServer.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/HttpServer.java
@@ -251,11 +251,11 @@ public class HttpServer implements LifeCycles {
     }
 
     private ResourceConfig setupResourceConfig() throws Exception {
-        final ResourceConfig c = new ResourceConfig();
+        final ResourceConfig config = new ResourceConfig();
 
         int count = 0;
 
-        for (final Function<CoreComponent, List<Object>> resource : config.getResources()) {
+        for (final Function<CoreComponent, List<Object>> resource : this.config.getResources()) {
             if (log.isTraceEnabled()) {
                 log.trace("Loading resource: {}", resource);
             }
@@ -263,7 +263,7 @@ public class HttpServer implements LifeCycles {
             final List<Object> resources = instance.inject(resource::apply);
 
             for (final Object r : resources) {
-                c.register(r);
+                config.register(r);
             }
 
             count += resources.size();
@@ -271,10 +271,11 @@ public class HttpServer implements LifeCycles {
 
         // Resources.
         if (enableCors) {
-            c.register(new CorsResponseFilter(corsAllowOrigin.orElse(DEFAULT_CORS_ALLOW_ORIGIN)));
+            config.register(
+                new CorsResponseFilter(corsAllowOrigin.orElse(DEFAULT_CORS_ALLOW_ORIGIN)));
         }
 
         log.info("Loaded {} resource(s)", count);
-        return c;
+        return config;
     }
 }

--- a/heroic-core/src/main/java/com/spotify/heroic/http/HttpServer.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/HttpServer.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.spotify.heroic.HeroicConfigurationContext;
 import com.spotify.heroic.HeroicCoreInstance;
 import com.spotify.heroic.dagger.CoreComponent;
+import com.spotify.heroic.http.tracing.OpenCensusFeature;
 import com.spotify.heroic.jetty.JettyJSONErrorHandler;
 import com.spotify.heroic.jetty.JettyServerConnector;
 import com.spotify.heroic.lifecycle.LifeCycleRegistry;
@@ -252,6 +253,7 @@ public class HttpServer implements LifeCycles {
 
     private ResourceConfig setupResourceConfig() throws Exception {
         final ResourceConfig config = new ResourceConfig();
+        config.register(OpenCensusFeature.class);
 
         int count = 0;
 

--- a/heroic-core/src/main/java/com/spotify/heroic/http/tracing/OpenCensusApplicationEventListener.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/tracing/OpenCensusApplicationEventListener.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2018 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.http.tracing;
+
+import static java.text.MessageFormat.format;
+
+import io.opencensus.trace.AttributeValue;
+import io.opencensus.trace.Span;
+import io.opencensus.trace.Status;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseFilter;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ContainerResponse;
+import org.glassfish.jersey.server.model.Invocable;
+import org.glassfish.jersey.server.monitoring.ApplicationEvent;
+import org.glassfish.jersey.server.monitoring.ApplicationEventListener;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+import org.glassfish.jersey.server.monitoring.RequestEventListener;
+
+
+class OpenCensusApplicationEventListener implements ApplicationEventListener {
+    private final Tracer globalTracer = Tracing.getTracer();
+    private final OpenCensusFeature.Verbosity verbosity;
+
+    /**
+     * Creates event listener instance with given
+     * {@link com.spotify.heroic.http.tracing.OpenCensusFeature.Verbosity}.
+     *
+     * @param verbosity desired verbosity level
+     */
+    public OpenCensusApplicationEventListener(OpenCensusFeature.Verbosity verbosity) {
+        this.verbosity = verbosity;
+    }
+
+    @Override
+    public void onEvent(ApplicationEvent event) {
+        // we don't care about the server lifecycle
+    }
+
+    @Override
+    public RequestEventListener onRequest(RequestEvent requestEvent) {
+        if (requestEvent.getType() == RequestEvent.Type.START) {
+            Span requestSpan = handleRequestStart(requestEvent.getContainerRequest());
+            return new OpenCensusRequestEventListener(requestSpan);
+        }
+        return null;
+    }
+
+    private Span handleRequestStart(ContainerRequest request) {
+
+        final Map<String, String> mappedHeaders = request
+            .getHeaders()
+            .entrySet()
+            .stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                (entry) -> OpenCensusUtils.formatList(entry.getValue())));
+
+        // TODO: extract headers from the request to determine if this is a child span
+        final Span span = globalTracer
+            .spanBuilder(request.getRequestUri().getPath())
+            .startSpan();
+
+        span.putAttribute("span.kind", AttributeValue.stringAttributeValue("server"));
+        span.putAttribute("http.method", AttributeValue.stringAttributeValue(request.getMethod()));
+        span.putAttribute("http.url", AttributeValue.stringAttributeValue(
+            request.getRequestUri().toASCIIString()));
+        span.putAttribute("http.request_headers", AttributeValue.stringAttributeValue(
+            OpenCensusUtils.headersAsString(request.getHeaders())));
+        span.putAttribute("http.has_request_entity", AttributeValue.booleanAttributeValue(
+            request.hasEntity()));
+
+        request.setProperty(OpenCensusFeature.SPAN_CONTEXT_PROPERTY, span);
+        span.addAnnotation("Request started.");
+        return span;
+    }
+
+    class OpenCensusRequestEventListener implements RequestEventListener {
+        private Span requestSpan;
+        private Span resourceSpan = null;
+
+        OpenCensusRequestEventListener(final Span requestSpan) {
+            this.requestSpan = requestSpan;
+        }
+
+        @Override
+        public void onEvent(RequestEvent event) {
+
+            switch (event.getType()) {
+                case MATCHING_START:
+                    logVerbose("Resource matching started.");
+                    break;
+
+                case LOCATOR_MATCHED:
+                    logVerbose(format("Locator matched. Matched locators: {0}",
+                        OpenCensusUtils.formatList(
+                            event.getUriInfo().getMatchedResourceLocators())));
+                    break;
+
+                case SUBRESOURCE_LOCATED:
+                    logVerbose(format("Subresource located: {0}",
+                        OpenCensusUtils.formatList(event.getUriInfo().getLocatorSubResources())));
+                    break;
+
+
+                case REQUEST_MATCHED:
+                    logVerbose(format("Request matched, method: {0}",
+                        event.getUriInfo()
+                            .getMatchedResourceMethod()
+                            .getInvocable()
+                            .getDefinitionMethod()));
+                    log("Request filtering started.");
+                    break;
+
+                case REQUEST_FILTERED:
+                    List<ContainerRequestFilter> requestFilters = new ArrayList<>();
+                    event.getContainerRequestFilters().forEach(requestFilters::add);
+
+                    logVerbose(format("Request filtering finished, {0} filter(s) applied.",
+                        requestFilters.size()));
+                    if (requestFilters.size() > 0) {
+                        log(format("Applied request filters: {0}.",
+                            OpenCensusUtils.formatProviders(requestFilters)));
+                    }
+                    break;
+
+                case RESOURCE_METHOD_START:
+                    final Invocable invocable =
+                        event.getUriInfo().getMatchedResourceMethod().getInvocable();
+                    logVerbose(format("Resource method {0} started.",
+                        invocable.getDefinitionMethod()));
+
+                    final String spanName = invocable.getHandler().getHandlerClass().getName();
+                    resourceSpan = globalTracer
+                        .spanBuilderWithExplicitParent(spanName, requestSpan)
+                        .startSpan();
+
+                    event.getContainerRequest()
+                        .setProperty(OpenCensusFeature.SPAN_CONTEXT_PROPERTY, resourceSpan);
+                    break;
+
+                case RESOURCE_METHOD_FINISHED:
+                    log("Resource method finished.");
+                    break;
+
+                case RESP_FILTERS_START:
+                    // this is the first event after resource method is guaranteed to have finished,
+                    // even for asynchronous processing; resourceSpan will be finished and the span
+                    // in the context will be switched back to the resource span before any further
+                    // tracing can occur.
+                    event.getContainerRequest().setProperty(
+                        OpenCensusFeature.SPAN_CONTEXT_PROPERTY, requestSpan);
+                    resourceSpan.end();
+                    logVerbose("Response filtering started.");
+                    break;
+
+                case RESP_FILTERS_FINISHED:
+                    List<ContainerResponseFilter> responseFilters = new ArrayList<>();
+                    event.getContainerResponseFilters().forEach(responseFilters::add);
+                    logVerbose(format("Response filtering finished, {0} filter(s) applied.",
+                        responseFilters.size()));
+                    if (responseFilters.size() > 0) {
+                        log(format("Applied reqsponse filters: {0}.",
+                            OpenCensusUtils.formatProviders(responseFilters)));
+                    }
+                    break;
+
+                case ON_EXCEPTION:
+                    if (resourceSpan != null) {
+                        resourceSpan.putAttribute("error",
+                            AttributeValue.booleanAttributeValue(true));
+                        resourceSpan.end();
+                    }
+                    requestSpan.putAttribute("error", AttributeValue.booleanAttributeValue(true));
+                    logError(event.getException());
+                    break;
+
+                case EXCEPTION_MAPPER_FOUND:
+                    log(format("Exception mapper found: {0}.",
+                        event.getExceptionMapper().getClass().getName()));
+                    break;
+
+                case EXCEPTION_MAPPING_FINISHED:
+                    log("Exception mapping finished: "
+                        + (event.isResponseSuccessfullyMapped()
+                           ? "successfully mapped"
+                           : "no exception or mapping failed."));
+
+                    break;
+
+                case FINISHED:
+                    if (requestSpan != null) {
+                        ContainerResponse response = event.getContainerResponse();
+                        if (response != null) {
+                            int status = response.getStatus();
+                            requestSpan.putAttribute("http.status_code",
+                                AttributeValue.longAttributeValue(status));
+                            requestSpan.putAttribute("http.has_response_entity",
+                                AttributeValue.booleanAttributeValue(response.hasEntity()));
+                            requestSpan.putAttribute("http.response_length",
+                                AttributeValue.longAttributeValue(response.getLength()));
+                            requestSpan.setStatus(OpenCensusUtils.mapStatusCode(status));
+
+                            if (status >= 400) {
+                                requestSpan.putAttribute("error",
+                                    AttributeValue.booleanAttributeValue(true));
+                            }
+                        }
+                        requestSpan.end();
+                    }
+                    break;
+
+                default:
+                    // This can't happen.
+                    break;
+            }
+        }
+
+        /**
+         * Adds a {@link OpenCensusFeature.Verbosity#TRACE}-level log entry into the request span.
+         * @param s log message
+         */
+        private void logVerbose(String s) {
+            log(OpenCensusFeature.Verbosity.TRACE, s);
+        }
+
+        /**
+         * Adds a {@link OpenCensusFeature.Verbosity#INFO}-level log entry into the request span.
+         * @param s log message
+         */
+        private void log(String s) {
+            log(OpenCensusFeature.Verbosity.INFO, s);
+        }
+
+        /**
+         * Adds a log entry with given
+         * {@link com.spotify.heroic.http.tracing.OpenCensusFeature.Verbosity}-level into the
+         * request span.
+         *
+         * @param level desired verbosity level
+         * @param s log message
+         */
+        private void log(OpenCensusFeature.Verbosity level, String s) {
+            if (level.ordinal() <= verbosity.ordinal()) {
+                requestSpan.addAnnotation(s);
+            }
+        }
+
+        /**
+         * Adds an error log into the request span.
+         * @param t exception to be logged.
+         */
+        private void logError(final Throwable t) {
+            requestSpan.setStatus(Status.INTERNAL);
+            requestSpan.putAttribute("event", AttributeValue.stringAttributeValue("error"));
+            requestSpan.addAnnotation(t.toString());
+        }
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/http/tracing/OpenCensusFeature.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/tracing/OpenCensusFeature.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.http.tracing;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import org.apache.commons.lang3.NotImplementedException;
+
+
+public class OpenCensusFeature implements Feature {
+    private final Verbosity verbosity;
+
+    /**
+     * Creates feature instance with default ({@link Verbosity#INFO} verbosity level.
+     */
+    public OpenCensusFeature() {
+        verbosity = Verbosity.INFO;
+    }
+
+    /**
+     * Creates feature instance with given ({@link Verbosity} level.
+     * @param verbosity desired level of logging verbosity
+     */
+    public OpenCensusFeature(Verbosity verbosity) {
+        this.verbosity = verbosity;
+    }
+
+    /**
+     * Stored span's {@link ContainerRequestContext} property key.
+     */
+    public static final String SPAN_CONTEXT_PROPERTY = "span";
+
+    @Override
+    public boolean configure(FeatureContext context) {
+
+        switch (context.getConfiguration().getRuntimeType()) {
+            case CLIENT:
+                throw new NotImplementedException("Client tracing not implemented");
+            case SERVER:
+                context.register(new OpenCensusApplicationEventListener(verbosity));
+            default:
+                // This can't happen.
+        }
+        return true;
+    }
+
+    /**
+     * OpenCencsus Jersey event logging verbosity.
+     */
+    public enum Verbosity {
+        /**
+         * Only logs basic Jersey processing related events.
+         */
+        INFO,
+
+        /**
+         * Logs more fine grained events related to Jersey processing.
+         */
+        TRACE
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/http/tracing/OpenCensusUtils.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/tracing/OpenCensusUtils.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.http.tracing;
+
+import io.opencensus.trace.Status;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import javax.ws.rs.core.MultivaluedMap;
+
+class OpenCensusUtils {
+    private OpenCensusUtils() {
+    }
+
+    /**
+     * Convert request/response headers from {@link MultivaluedMap} into printable form.
+     *
+     * @param headers multi-valued map of request or response headers
+     * @return {@code String} representation, e.g. "[header1=foo]; [header2=bar, baz]"
+     */
+    static String headersAsString(final MultivaluedMap<String, ?> headers) {
+        return headers.entrySet()
+            .stream()
+            .map((entry) -> "["
+                            + entry.getKey() + "="
+                            + entry.getValue()
+                                .stream()
+                                .map(Object::toString)
+                                .collect(Collectors.joining(", "))
+                            + "]")
+            .collect(Collectors.joining("; "));
+    }
+
+    static String formatList(List<?> list) {
+        return list.stream().map(Object::toString).collect(Collectors.joining(", "));
+    }
+
+    static String formatProviders(Iterable<?> providers) {
+        return StreamSupport.stream(providers.spliterator(), false)
+            .map((provider) -> provider.getClass().getName())
+            .collect(Collectors.joining(", "));
+    }
+
+    static Status mapStatusCode(int status) {
+        // @formatter:off
+        //
+        // Mapping from:
+        // https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/HTTP.md#mapping-from-http-status-codes-to-trace-status-codes
+        //
+        // @formatter:on
+        final Status traceStatus;
+        if (status < 200) {
+            traceStatus = Status.UNKNOWN;
+        } else if (status < 400) {
+            traceStatus = Status.OK;
+        } else if (status == 400) {
+            traceStatus = Status.INVALID_ARGUMENT;
+        } else if (status == 404) {
+            traceStatus = Status.NOT_FOUND;
+        } else if (status == 403) {
+            traceStatus = Status.PERMISSION_DENIED;
+        } else if (status == 401) {
+            traceStatus = Status.UNAUTHENTICATED;
+        } else if (status == 429) {
+            traceStatus = Status.RESOURCE_EXHAUSTED;
+        } else if (status == 501) {
+            traceStatus = Status.UNIMPLEMENTED;
+        } else if (status == 503) {
+            traceStatus = Status.UNAVAILABLE;
+        } else if (status == 504) {
+            traceStatus = Status.DEADLINE_EXCEEDED;
+        } else if (status < 600) {
+            traceStatus = Status.INTERNAL;
+        } else {
+            traceStatus = Status.UNKNOWN;
+        }
+
+        return traceStatus;
+    }
+}

--- a/heroic-shell/src/main/java/com/spotify/heroic/shell/QuoteParser.java
+++ b/heroic-shell/src/main/java/com/spotify/heroic/shell/QuoteParser.java
@@ -22,8 +22,7 @@
 package com.spotify.heroic.shell;
 
 import com.google.common.collect.ImmutableList;
-import jersey.repackaged.com.google.common.collect.ImmutableMap;
-
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/pom.xml
+++ b/pom.xml
@@ -52,10 +52,9 @@
     <threadCount>1</threadCount>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <jersey.version>2.13</jersey.version>
+    <jersey.version>2.27</jersey.version>
     <jackson.version>2.7.4</jackson.version>
-    <hk2.version>2.3.0</hk2.version>
-    <jetty.version>9.3.7.v20160115</jetty.version>
+    <jetty.version>9.4.12.v20180830</jetty.version>
     <lucene.version>5.5.0</lucene.version>
     <semantic-metrics.version>0.2.3</semantic-metrics.version>
     <netty.version>4.1.25.Final</netty.version>
@@ -610,6 +609,11 @@
         <artifactId>jersey-client</artifactId>
         <version>${jersey.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.glassfish.jersey.inject</groupId>
+        <artifactId>jersey-hk2</artifactId>
+        <version>${jersey.version}</version>
+      </dependency>
       <!-- jetty -->
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
@@ -627,6 +631,11 @@
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-util</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
         <version>3.1.0</version>
@@ -639,7 +648,7 @@
       <dependency>
         <groupId>javax.ws.rs</groupId>
         <artifactId>javax.ws.rs-api</artifactId>
-        <version>2.0.1</version>
+        <version>2.1</version>
       </dependency>
       <!-- netty -->
       <dependency>


### PR DESCRIPTION
Based on the existing Jersey OpenTracing implementation: https://github.com/eclipse-ee4j/jersey/tree/master/incubator/open-tracing/src/main/java/org/glassfish/jersey/opentracing