### PR TITLE
add protobuf schema; deprecate host field

### DIFF
--- a/heroic-core/pom.xml
+++ b/heroic-core/pom.xml
@@ -132,6 +132,13 @@
       <artifactId>folsom</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>3.5.1</version>
+    </dependency>
+
+
     <!-- used for testing -->
     <dependency>
       <groupId>com.spotify.heroic</groupId>
@@ -139,4 +146,34 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+
+  <build>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.5.0.Final</version>
+      </extension>
+    </extensions>
+
+    <plugins>
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.6.1</version>
+        <configuration>
+          <protocArtifact>com.google.protobuf:protoc:3.5.1:exe:${os.detected.classifier}</protocArtifact>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100.java
@@ -77,6 +77,7 @@ public class Spotify100 implements ConsumerSchema {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class JsonMetric {
         private final String key;
+        @Deprecated
         private final String host;
         private final Long time;
         @JsonDeserialize(using = TagsDeserializer.class)
@@ -87,7 +88,8 @@ public class Spotify100 implements ConsumerSchema {
 
         @JsonCreator
         public JsonMetric(
-            @JsonProperty("key") String key, @JsonProperty("host") Optional<String> host,
+            @JsonProperty("key") String key,
+            @JsonProperty("host") Optional<String> host,
             @JsonProperty("time") Long time,
             @JsonProperty("attributes") Map<String, String> attributes,
             @JsonProperty("resource") Map<String, String> resource,

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100Proto.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100Proto.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.consumer.schemas;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.spotify.heroic.common.Series;
+import com.spotify.heroic.consumer.ConsumerSchema;
+import com.spotify.heroic.consumer.ConsumerSchemaException;
+import com.spotify.heroic.consumer.ConsumerSchemaValidationException;
+import com.spotify.heroic.consumer.SchemaScope;
+import com.spotify.heroic.ingestion.Ingestion;
+import com.spotify.heroic.ingestion.IngestionGroup;
+import com.spotify.heroic.metric.MetricCollection;
+import com.spotify.heroic.metric.Point;
+import com.spotify.heroic.statistics.ConsumerReporter;
+import com.spotify.heroic.time.Clock;
+import com.spotify.proto.Spotify100;
+import dagger.Component;
+import eu.toolchain.async.AsyncFuture;
+import java.util.List;
+import javax.inject.Inject;
+/**
+ * Spotify100Proto is useful if you prefer not to batch and compress metrics with the
+ * Spotify100ProtoBatch serializer.
+ */
+public class Spotify100Proto implements ConsumerSchema {
+
+  @SchemaScope
+  public static class Consumer implements ConsumerSchema.Consumer {
+
+    private final Clock clock;
+    private final IngestionGroup ingestion;
+    private final ConsumerReporter reporter;
+
+    @Inject
+    public Consumer(Clock clock, IngestionGroup ingestion, ConsumerReporter reporter) {
+      this.clock = clock;
+      this.ingestion = ingestion;
+      this.reporter = reporter;
+    }
+
+    @Override
+    public AsyncFuture<Void> consume(final byte[] message) throws ConsumerSchemaException {
+      // With protobuf, scalars such as strings and longs will never be null.
+      final Spotify100.Metric metric;
+      try {
+         metric = Spotify100.Metric.parseFrom(message);
+      } catch (InvalidProtocolBufferException e) {
+        throw new ConsumerSchemaValidationException("Invalid metric", e);
+      }
+
+      if (metric.getTime() <= 0) {
+        throw new ConsumerSchemaValidationException(
+          "time: field must be a positive number: " + metric.toString());
+      }
+
+      if (metric.getKey().isEmpty()) {
+        throw new ConsumerSchemaValidationException(
+          "key: field must be defined: " + metric.toString());
+      }
+
+      final Series s = Series.of(metric.getKey(), metric.getTagsMap(), metric.getResourceMap());
+      final Point p = new Point(metric.getTime(), metric.getValue());
+      final List<Point> points = ImmutableList.of(p);
+
+      reporter.reportMessageDrift(clock.currentTimeMillis() - p.getTimestamp());
+
+      final AsyncFuture<Ingestion> ingestionFuture =
+        ingestion.write(new Ingestion.Request(s, MetricCollection.points(points)));
+
+      // Return Void future, to not leak unnecessary information from the backend but just
+      // allow monitoring of when the consumption is done.
+      return ingestionFuture.directTransform(future -> null);
+    }
+  }
+
+
+  @Override
+  public Exposed setup(final ConsumerSchema.Depends depends) {
+    return DaggerSpotify100Proto_C.builder().depends(depends).build();
+  }
+
+  @SchemaScope
+  @Component(dependencies = ConsumerSchema.Depends.class)
+  interface C extends ConsumerSchema.Exposed {
+    @Override
+    Spotify100Proto.Consumer consumer();
+  }
+}

--- a/heroic-core/src/main/proto/spotify_100.proto
+++ b/heroic-core/src/main/proto/spotify_100.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package spotify.metric;
+option java_package = "com.spotify.proto";
+
+option optimize_for = SPEED;
+
+message Metric {
+  // key of metric.
+  string key = 1;
+
+  // time in ms when metric was generated.
+  int64 time = 2;
+
+  // value of metric.
+  double value = 3;
+
+  // tags associated to a metric, used to be referred to as attributes.
+  map<string, string> tags = 4;
+
+  // resource "tags" associated to metric.
+  map<string, string> resource = 5;
+}

--- a/heroic-core/src/test/java/com/spotify/heroic/consumer/schemas/Spotify100ProtoTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/consumer/schemas/Spotify100ProtoTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.consumer.schemas;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.spotify.heroic.common.Series;
+import com.spotify.heroic.consumer.ConsumerSchemaValidationException;
+import com.spotify.heroic.ingestion.Ingestion;
+import com.spotify.heroic.ingestion.IngestionGroup;
+import com.spotify.heroic.metric.MetricCollection;
+import com.spotify.heroic.metric.Point;
+import com.spotify.heroic.statistics.ConsumerReporter;
+import com.spotify.heroic.time.Clock;
+import com.spotify.proto.Spotify100.Metric;
+import eu.toolchain.async.AsyncFuture;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class Spotify100ProtoTest {
+
+  @Mock
+  Clock clock;
+
+  @Mock
+  IngestionGroup ingestion;
+
+  @Mock
+  ConsumerReporter reporter;
+
+  @Mock
+  private AsyncFuture<Ingestion> resolved;
+
+  private Spotify100Proto.Consumer consumer;
+
+  @Before
+  public void setup() {
+    when(clock.currentTimeMillis()).thenReturn(1542830485000L);
+    when(ingestion.write(any(Ingestion.Request.class))).thenReturn(resolved);
+    consumer = new Spotify100Proto.Consumer(clock, ingestion, reporter);
+  }
+
+  @Test
+  public void testConsumeMetric() throws Exception {
+    final Metric metric = Metric.newBuilder()
+      .setKey("foo")
+      .setValue(1.0)
+      .setTime(1542830480000L)
+      .putTags("tag1", "foo")
+      .putResource("resource", "bar")
+      .build();
+
+    consumer.consume(metric.toByteArray());
+
+    final Series s = Series.of(metric.getKey(), metric.getTagsMap(), metric.getResourceMap());
+    final Point p = new Point(metric.getTime(), metric.getValue());
+    final List<Point> points = ImmutableList.of(p);
+
+    verify(reporter).reportMessageDrift(5000);
+    verify(ingestion).write(new Ingestion.Request(s, MetricCollection.points(points)));
+  }
+
+  @Test
+  public void testConsumeMetricBytes() throws Exception {
+    final Metric metric = Metric.parseFrom(
+      new byte[]{10, 3, 102, 111, 111, 16, -128, -75, -13, -66, -13, 44, 25, 0, 0, 0, 0, 0, 0, -16,
+                 63, 34, 11, 10, 4, 116, 97, 103, 49, 18, 3, 102, 111, 111, 42, 15, 10, 8, 114, 101,
+                 115, 111, 117, 114, 99, 101, 18, 3, 98, 97, 114});
+
+    consumer.consume(metric.toByteArray());
+
+    final Series s = Series.of(metric.getKey(), metric.getTagsMap(), metric.getResourceMap());
+    final Point p = new Point(metric.getTime(), metric.getValue());
+    final List<Point> points = ImmutableList.of(p);
+
+    verify(reporter).reportMessageDrift(5000);
+    verify(ingestion).write(new Ingestion.Request(s, MetricCollection.points(points)));
+  }
+
+
+  @Test(expected = ConsumerSchemaValidationException.class)
+  public void testTimeValidationError() throws Exception {
+    final Metric metric = Metric.newBuilder().setTime(-1542830480000L).build();
+
+    consumer.consume(metric.toByteArray());
+  }
+
+  @Test(expected = ConsumerSchemaValidationException.class)
+  public void testKeyDefinedValidationError() throws Exception {
+    final Metric metric = Metric.newBuilder().setTime(1000L).build();
+
+    consumer.consume(metric.toByteArray());
+  }
+
+}


### PR DESCRIPTION
Two commits.

1. Add protobuf schema for ingesting metrics.
2. deprecate host field in json schema since host is now just another tag in heroic. 

@jsferrei @lmuhlha @sjoeboo 