### PR TITLE
add tag to trigger for docker hub

### DIFF
--- a/.scripts/trigger_docker_hub.sh
+++ b/.scripts/trigger_docker_hub.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl -H "Content-Type: application/json" --data "{\"source_type\": \"Tag\", \"source_name\": \"$TRAVIS_TAG\"}" -X POST https://registry.hub.docker.com/u/spotify/heroic/trigger/$DOCKER_TOKEN/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ jdk:
 branches:
   only:
     - master
+    - /^(?i:master)-.*$/
+    - /^[0-9]+.[0-9]+.[0-9]+$/
+
 
 cache:
   directories:
@@ -43,5 +46,7 @@ after_success:
 
 deploy:
   # trigger docker hub build
+  on:
+      tags: true
   provider: script
-  script: curl --data build=true -X POST https://registry.hub.docker.com/u/spotify/heroic/trigger/$DOCKER_TOKEN/
+  script: bash .scripts/trigger_docker_hub.sh


### PR DESCRIPTION
This change allows for a few things: 

* Travis will get triggered on tags matching master-* as well as master.
* Travis will trigger a Docker image build on Docker Hub *only* from tags (releases)
* Travis will send the tag to Docker Hub so the resulting image is tagged the same. 
