### PR TITLE
[metadata|suggest] set a default max size on cache

### DIFF
--- a/suggest/elasticsearch/src/main/java/com/spotify/heroic/suggest/elasticsearch/ElasticsearchSuggestModule.java
+++ b/suggest/elasticsearch/src/main/java/com/spotify/heroic/suggest/elasticsearch/ElasticsearchSuggestModule.java
@@ -77,7 +77,11 @@ public final class ElasticsearchSuggestModule implements SuggestModule, DynamicM
 
     private static final double DEFAULT_WRITES_PER_SECOND = 3000d;
     private static final long DEFAULT_RATE_LIMIT_SLOW_START_SECONDS = 0L;
+
     private static final long DEFAULT_WRITES_CACHE_DURATION_MINUTES = 240L;
+    private static final int DEFAULT_WRITE_CACHE_CONCURRENCY = 4;
+    private static final long DEFAULT_WRITE_CACHE_MAX_SIZE = 30_000_000L;
+
     public static final String DEFAULT_GROUP = "elasticsearch";
     public static final String DEFAULT_TEMPLATE_NAME = "heroic-suggest";
     public static final String DEFAULT_BACKEND_TYPE = "default";
@@ -89,6 +93,8 @@ public final class ElasticsearchSuggestModule implements SuggestModule, DynamicM
     private final double writesPerSecond;
     private final Long rateLimitSlowStartSeconds;
     private final long writeCacheDurationMinutes;
+    private final Integer writeCacheConcurrency;
+    private final Long writeCacheMaxSize;
     private final String distributedCacheSrvRecord;
     private final String templateName;
     private final String backendType;
@@ -117,6 +123,8 @@ public final class ElasticsearchSuggestModule implements SuggestModule, DynamicM
         @JsonProperty("writesPerSecond") Optional<Double> writesPerSecond,
         @JsonProperty("rateLimitSlowStartSeconds") Optional<Long> rateLimitSlowStartSeconds,
         @JsonProperty("writeCacheDurationMinutes") Optional<Long> writeCacheDurationMinutes,
+        @JsonProperty("writeCacheConcurrency") Optional<Integer> writeCacheConcurrency,
+        @JsonProperty("writeCacheMaxSize") Optional<Long> writeCacheMaxSize,
         @JsonProperty("distributedCacheSrvRecord") Optional<String> distributedCacheSrvRecord,
         @JsonProperty("templateName") Optional<String> templateName,
         @JsonProperty("backendType") Optional<String> backendType,
@@ -128,9 +136,14 @@ public final class ElasticsearchSuggestModule implements SuggestModule, DynamicM
         this.writesPerSecond = writesPerSecond.orElse(DEFAULT_WRITES_PER_SECOND);
         this.rateLimitSlowStartSeconds =
             rateLimitSlowStartSeconds.orElse(DEFAULT_RATE_LIMIT_SLOW_START_SECONDS);
+
         this.writeCacheDurationMinutes =
             writeCacheDurationMinutes.orElse(DEFAULT_WRITES_CACHE_DURATION_MINUTES);
+        this.writeCacheConcurrency = writeCacheConcurrency.orElse(DEFAULT_WRITE_CACHE_CONCURRENCY);
+        this.writeCacheMaxSize = writeCacheMaxSize.orElse(DEFAULT_WRITE_CACHE_MAX_SIZE);
+
         this.distributedCacheSrvRecord = distributedCacheSrvRecord.orElse("");
+
         this.templateName = templateName.orElse(DEFAULT_TEMPLATE_NAME);
         this.backendType = backendType.orElse(DEFAULT_BACKEND_TYPE);
         this.type = backendType.map(this::lookupBackendType).orElse(defaultSetup);
@@ -202,7 +215,8 @@ public final class ElasticsearchSuggestModule implements SuggestModule, DynamicM
         public RateLimitedCache<Pair<String, HashCode>> writeCache(final HeroicReporter reporter) {
             final Cache<Pair<String, HashCode>, Boolean> cache = CacheBuilder
                 .newBuilder()
-                .concurrencyLevel(4)
+                .concurrencyLevel(writeCacheConcurrency)
+                .maximumSize(writeCacheMaxSize)
                 .expireAfterWrite(writeCacheDurationMinutes, MINUTES)
                 .build();
 
@@ -258,6 +272,8 @@ public final class ElasticsearchSuggestModule implements SuggestModule, DynamicM
         private Optional<Double> writesPerSecond = empty();
         private Optional<Long> rateLimitSlowStartSeconds = empty();
         private Optional<Long> writeCacheDurationMinutes = empty();
+        private Optional<Integer> writeCacheConcurrency = empty();
+        private Optional<Long> writeCacheMaxSize = empty();
         private Optional<String> distributedCacheSrvRecord = empty();
         private Optional<String> templateName = empty();
         private Optional<String> backendType = empty();
@@ -298,6 +314,17 @@ public final class ElasticsearchSuggestModule implements SuggestModule, DynamicM
             this.writeCacheDurationMinutes = of(writeCacheDurationMinutes);
             return this;
         }
+
+        public Builder writeCacheConcurrency(final int writeCacheConcurrency) {
+            this.writeCacheConcurrency = of(writeCacheConcurrency);
+            return this;
+        }
+
+        public Builder writeCacheMaxSize(final long writeCacheMaxSize) {
+            this.writeCacheMaxSize = of(writeCacheMaxSize);
+            return this;
+        }
+
         public Builder distributedCacheSrvRecord(final String distributedCacheSrvRecord) {
             checkNotNull(distributedCacheSrvRecord, "distributedCacheSrvRecord");
             this.distributedCacheSrvRecord = of(distributedCacheSrvRecord);
@@ -322,9 +349,20 @@ public final class ElasticsearchSuggestModule implements SuggestModule, DynamicM
         }
 
         public ElasticsearchSuggestModule build() {
-            return new ElasticsearchSuggestModule(id, groups, connection, writesPerSecond,
-                rateLimitSlowStartSeconds, writeCacheDurationMinutes, distributedCacheSrvRecord,
-                templateName, backendType, configure);
+            return new ElasticsearchSuggestModule(
+              id,
+              groups,
+              connection,
+              writesPerSecond,
+              rateLimitSlowStartSeconds,
+              writeCacheDurationMinutes,
+              writeCacheConcurrency,
+              writeCacheMaxSize,
+              distributedCacheSrvRecord,
+              templateName,
+              backendType,
+              configure
+            );
         }
     }
 }


### PR DESCRIPTION
Allows for the configuration of a max size for the guava cache. Also allows for changing the default concurrency level for the same cache.

* distributedCacheMaxSize (defaults to 30,000,000)
* distributedCacheConcurrency (defaults to 4)