### PR TITLE
[core] modify proto schema to accept compressed batches

### DIFF
--- a/docs/heroic_consumer_pubsub_local_debug.yml
+++ b/docs/heroic_consumer_pubsub_local_debug.yml
@@ -25,10 +25,11 @@ metrics:
 
 consumers:
   - type: pubsub
-    schema: com.spotify.heroic.consumer.schemas.Spotify100
+    schema: com.spotify.heroic.consumer.schemas.Spotify100Proto
     topic: test-topic
     project: google-test-project 
     subscription: test-subscription
+    maxOutstandingElementCount: 5000 # Default 20,000
 
 
 ingestion:

--- a/heroic-core/pom.xml
+++ b/heroic-core/pom.xml
@@ -33,6 +33,20 @@
     </dependency>
 
     <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>eu.toolchain.async</groupId>
+      <artifactId>tiny-async-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>eu.toolchain.async</groupId>
+      <artifactId>tiny-async-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100Proto.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100Proto.java
@@ -22,7 +22,6 @@
 package com.spotify.heroic.consumer.schemas;
 
 import com.google.common.collect.ImmutableList;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.consumer.ConsumerSchema;
 import com.spotify.heroic.consumer.ConsumerSchemaException;
@@ -36,12 +35,20 @@ import com.spotify.heroic.statistics.ConsumerReporter;
 import com.spotify.heroic.time.Clock;
 import com.spotify.proto.Spotify100;
 import dagger.Component;
+import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
+import org.xerial.snappy.Snappy;
+
 /**
- * Spotify100Proto is useful if you prefer not to batch and compress metrics with the
- * Spotify100ProtoBatch serializer.
+ * Spotify100Proto is intended to reduce the amount of data transferred between the publisher
+ * and the consumer. It useful when being used with Google Pubsub, because the client does not have
+ * native compression like Kafka.
+ *
+ * Compression is done with the snappy library via JNI.
  */
 public class Spotify100Proto implements ConsumerSchema {
 
@@ -51,58 +58,66 @@ public class Spotify100Proto implements ConsumerSchema {
     private final Clock clock;
     private final IngestionGroup ingestion;
     private final ConsumerReporter reporter;
+    private final AsyncFramework async;
 
     @Inject
-    public Consumer(Clock clock, IngestionGroup ingestion, ConsumerReporter reporter) {
+    public Consumer(
+      Clock clock,
+      IngestionGroup ingestion,
+      ConsumerReporter reporter,
+      AsyncFramework async
+    ) {
       this.clock = clock;
       this.ingestion = ingestion;
       this.reporter = reporter;
+      this.async = async;
     }
 
     @Override
     public AsyncFuture<Void> consume(final byte[] message) throws ConsumerSchemaException {
-      // With protobuf, scalars such as strings and longs will never be null.
-      final Spotify100.Metric metric;
+      final List<Spotify100.Metric> metrics;
       try {
-         metric = Spotify100.Metric.parseFrom(message);
-      } catch (InvalidProtocolBufferException e) {
-        throw new ConsumerSchemaValidationException("Invalid metric", e);
+        metrics = Spotify100.Batch.parseFrom(Snappy.uncompress(message)).getMetricList();
+      } catch (IOException e) {
+        throw new ConsumerSchemaValidationException("Invalid batch of metrics", e);
       }
 
-      if (metric.getTime() <= 0) {
-        throw new ConsumerSchemaValidationException(
-          "time: field must be a positive number: " + metric.toString());
+      final List<AsyncFuture<Ingestion>> ingestions = new ArrayList<>();
+      for (Spotify100.Metric metric : metrics) {
+
+        if (metric.getTime() <= 0) {
+          throw new ConsumerSchemaValidationException(
+            "time: field must be a positive number: " + metric.toString());
+        }
+
+        if (metric.getKey().isEmpty()) {
+          throw new ConsumerSchemaValidationException(
+            "key: field must be defined: " + metric.toString());
+        }
+
+        final Series s = Series.of(metric.getKey(), metric.getTagsMap(), metric.getResourceMap());
+        final Point p = new Point(metric.getTime(), metric.getValue());
+        final List<Point> points = ImmutableList.of(p);
+
+        reporter.reportMessageDrift(clock.currentTimeMillis() - p.getTimestamp());
+
+        ingestions.add(ingestion.write(new Ingestion.Request(s, MetricCollection.points(points))));
       }
-
-      if (metric.getKey().isEmpty()) {
-        throw new ConsumerSchemaValidationException(
-          "key: field must be defined: " + metric.toString());
-      }
-
-      final Series s = Series.of(metric.getKey(), metric.getTagsMap(), metric.getResourceMap());
-      final Point p = new Point(metric.getTime(), metric.getValue());
-      final List<Point> points = ImmutableList.of(p);
-
-      reporter.reportMessageDrift(clock.currentTimeMillis() - p.getTimestamp());
-
-      final AsyncFuture<Ingestion> ingestionFuture =
-        ingestion.write(new Ingestion.Request(s, MetricCollection.points(points)));
 
       // Return Void future, to not leak unnecessary information from the backend but just
       // allow monitoring of when the consumption is done.
-      return ingestionFuture.directTransform(future -> null);
+      return async.collectAndDiscard(ingestions);
     }
   }
 
-
   @Override
-  public Exposed setup(final ConsumerSchema.Depends depends) {
+  public Exposed setup(final Depends depends) {
     return DaggerSpotify100Proto_C.builder().depends(depends).build();
   }
 
   @SchemaScope
-  @Component(dependencies = ConsumerSchema.Depends.class)
-  interface C extends ConsumerSchema.Exposed {
+  @Component(dependencies = Depends.class)
+  interface C extends Exposed {
     @Override
     Spotify100Proto.Consumer consumer();
   }

--- a/heroic-core/src/main/proto/spotify_100.proto
+++ b/heroic-core/src/main/proto/spotify_100.proto
@@ -21,3 +21,7 @@ message Metric {
   // resource "tags" associated to metric.
   map<string, string> resource = 5;
 }
+
+message Batch {
+  repeated Metric metric = 1;
+}

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/DistributedRateLimitedCache.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/DistributedRateLimitedCache.java
@@ -94,7 +94,7 @@ public class DistributedRateLimitedCache<K> implements RateLimitedCache<K> {
       } catch (TimeoutException e) {
         span.setStatus(Status.INTERNAL.withDescription(e.getMessage()));
         memcachedReporter.reportMemcachedTimeout();
-        log.error("Failed to get key from memecached");
+        log.debug("Failed to get key from memecached");
       } catch (InterruptedException | ExecutionException e) {
         span.setStatus(Status.INTERNAL.withDescription(e.getMessage()));
         memcachedReporter.reportMemcachedError();

--- a/pom.xml
+++ b/pom.xml
@@ -530,6 +530,13 @@
         <version>${opencensus.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.xerial.snappy</groupId>
+        <artifactId>snappy-java</artifactId>
+        <version>1.1.7.2</version>
+        <type>jar</type>
+        <scope>compile</scope>
+      </dependency>
 
       <!-- useful collections and utilities -->
       <dependency>


### PR DESCRIPTION
When rolling this out we may need to tweak both the publisher (ffwd) and consumer (heroic) batch settings. With the consumer we may want to reduce the maxOutstandingElement count since a single pubsub message can now contain up to 10,000 metrics with the default ffwd batch settings.

This goes along with https://github.com/spotify/ffwd/pull/99.

@hexedpackets 