### PR TITLE
Update semantic-metrics and replace meters with counters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <jackson.version>2.8.11</jackson.version>
     <jetty.version>9.4.12.v20180830</jetty.version>
     <lucene.version>5.5.0</lucene.version>
-    <semantic-metrics.version>0.2.3</semantic-metrics.version>
+    <semantic-metrics.version>1.0.2</semantic-metrics.version>
     <netty.version>4.1.31.Final</netty.version>
     <tiny-async.version>1.11.0</tiny-async.version>
     <tiny-serializer.version>1.4.5</tiny-serializer.version>
@@ -802,6 +802,18 @@
         <artifactId>antlr4</artifactId>
         <version>${antlr.version}</version>
         <scope>compile</scope>
+      </dependency>
+
+      <!-- metrics -->
+      <dependency>
+        <groupId>com.spotify.metrics</groupId>
+        <artifactId>semantic-metrics-core</artifactId>
+        <version>${semantic-metrics.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.spotify.metrics</groupId>
+        <artifactId>semantic-metrics-ffwd-reporter</artifactId>
+        <version>${semantic-metrics.version}</version>
       </dependency>
 
       <!-- testing -->

--- a/statistics/semantic/pom.xml
+++ b/statistics/semantic/pom.xml
@@ -15,10 +15,6 @@
 
   <name>Heroic: Semantic Metrics Statistics</name>
 
-  <properties>
-    <semantic.version>0.5.0</semantic.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>com.spotify.heroic</groupId>
@@ -28,13 +24,10 @@
     <dependency>
       <groupId>com.spotify.metrics</groupId>
       <artifactId>semantic-metrics-core</artifactId>
-      <version>${semantic.version}</version>
     </dependency>
-
     <dependency>
       <groupId>com.spotify.metrics</groupId>
       <artifactId>semantic-metrics-ffwd-reporter</artifactId>
-      <version>${semantic.version}</version>
     </dependency>
 
     <dependency>

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/HistogramBuilder.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/HistogramBuilder.java
@@ -25,6 +25,7 @@ import com.codahale.metrics.Clock;
 import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Metric;
+import com.spotify.metrics.core.HistogramWithTtl;
 import com.spotify.metrics.core.SemanticMetricBuilder;
 import java.util.concurrent.TimeUnit;
 
@@ -32,6 +33,7 @@ public class HistogramBuilder {
     public static final SemanticMetricBuilder<Histogram> HISTOGRAM =
         new SemanticMetricBuilder<Histogram>() {
             public Histogram newMetric() {
+
                 return new Histogram(
                     // A min/max value will stay around for 2 * 30 seconds
                     new MinMaxSlidingTimeReservoir(Clock.defaultClock(), 2, 30, TimeUnit.SECONDS,

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/HistogramBuilder.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/HistogramBuilder.java
@@ -25,7 +25,6 @@ import com.codahale.metrics.Clock;
 import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Metric;
-import com.spotify.metrics.core.HistogramWithTtl;
 import com.spotify.metrics.core.SemanticMetricBuilder;
 import java.util.concurrent.TimeUnit;
 

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoir.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoir.java
@@ -24,6 +24,7 @@ package com.spotify.heroic.statistics.semantic;
 import com.codahale.metrics.Clock;
 import com.codahale.metrics.Reservoir;
 import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.UniformSnapshot;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -116,7 +117,7 @@ public class MinMaxSlidingTimeReservoir implements Reservoir {
 
         final Snapshot snapshot = delegate.getSnapshot();
 
-        return value.map(minMax -> {
+        final Optional<Snapshot> slidingSnapshot = value.map(minMax -> {
             final long[] values = snapshot.getValues();
 
             if (values.length > 0) {
@@ -124,8 +125,10 @@ public class MinMaxSlidingTimeReservoir implements Reservoir {
                 values[values.length - 1] = Math.max(minMax.max, values[values.length - 1]);
             }
 
-            return new Snapshot(values);
-        }).orElse(snapshot);
+            return new UniformSnapshot(values);
+        });
+
+        return slidingSnapshot.orElse(snapshot);
     }
 
     /**

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticAnalyticsReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticAnalyticsReporter.java
@@ -21,7 +21,7 @@
 
 package com.spotify.heroic.statistics.semantic;
 
-import com.codahale.metrics.Meter;
+import com.codahale.metrics.Counter;
 import com.spotify.heroic.statistics.AnalyticsReporter;
 import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricRegistry;
@@ -31,24 +31,25 @@ import lombok.ToString;
 public class SemanticAnalyticsReporter implements AnalyticsReporter {
     private static final String COMPONENT = "analytics";
 
-    private final Meter droppedFetchSeries;
-    private final Meter failedFetchSeries;
+    private final Counter droppedFetchSeries;
+    private final Counter failedFetchSeries;
 
     public SemanticAnalyticsReporter(SemanticMetricRegistry registry) {
         final MetricId id = MetricId.build().tagged("component", COMPONENT);
+
         this.droppedFetchSeries =
-            registry.meter(id.tagged("what", "dropped-fetch-series", "unit", Units.DROP));
+            registry.counter(id.tagged("what", "dropped-fetch-series", "unit", Units.DROP));
         this.failedFetchSeries =
-            registry.meter(id.tagged("what", "failed-fetch-series", "unit", Units.FAILURE));
+            registry.counter(id.tagged("what", "failed-fetch-series", "unit", Units.FAILURE));
     }
 
     @Override
     public void reportDroppedFetchSeries() {
-        droppedFetchSeries.mark();
+        droppedFetchSeries.inc();
     }
 
     @Override
     public void reportFailedFetchSeries() {
-        failedFetchSeries.mark();
+        failedFetchSeries.inc();
     }
 }

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticConsumerReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticConsumerReporter.java
@@ -21,8 +21,8 @@
 
 package com.spotify.heroic.statistics.semantic;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Meter;
 import com.spotify.heroic.statistics.ConsumerReporter;
 import com.spotify.heroic.statistics.FutureReporter;
 import com.spotify.heroic.statistics.HeroicTimer;
@@ -36,13 +36,12 @@ import lombok.ToString;
 public class SemanticConsumerReporter implements ConsumerReporter {
     private static final String COMPONENT = "consumer";
 
-    private final SemanticMetricRegistry registry;
     private final MetricId base;
 
-    private final Meter messageIn;
-    private final Meter messageError;
-    private final Meter messageRetry;
-    private final Meter consumerSchemaError;
+    private final Counter messageIn;
+    private final Counter messageError;
+    private final Counter messageRetry;
+    private final Counter consumerSchemaError;
     private final SemanticRatioGauge consumerThreadsLiveRatio;
     private final Histogram messageSize;
     private final Histogram messageDrift;
@@ -53,15 +52,13 @@ public class SemanticConsumerReporter implements ConsumerReporter {
     private final SemanticHeroicTimerGauge consumerCommitPhase2Timer;
 
     public SemanticConsumerReporter(SemanticMetricRegistry registry, String id) {
-        this.registry = registry;
-
         this.base = MetricId.build().tagged("component", COMPONENT, "id", id);
 
-        messageIn = registry.meter(base.tagged("what", "message-in", "unit", Units.MESSAGE));
-        messageError = registry.meter(base.tagged("what", "message-error", "unit", Units.FAILURE));
-        messageRetry = registry.meter(base.tagged("what", "message-retry", "unit", Units.COUNT));
+        messageIn = registry.counter(base.tagged("what", "message-in", "unit", Units.COUNT));
+        messageError = registry.counter(base.tagged("what", "message-error", "unit", Units.COUNT));
+        messageRetry = registry.counter(base.tagged("what", "message-retry", "unit", Units.COUNT));
         consumerSchemaError =
-            registry.meter(base.tagged("what", "consumer-schema-error", "unit", Units.FAILURE));
+            registry.counter(base.tagged("what", "consumer-schema-error", "unit", Units.COUNT));
         consumerThreadsLiveRatio = new SemanticRatioGauge();
         registry.register(base.tagged("what", "consumer-threads-live-ratio", "unit", Units.RATIO),
             consumerThreadsLiveRatio);
@@ -87,23 +84,23 @@ public class SemanticConsumerReporter implements ConsumerReporter {
 
     @Override
     public void reportMessageSize(int size) {
-        messageIn.mark();
+        messageIn.inc();
         messageSize.update(size);
     }
 
     @Override
     public void reportMessageError() {
-        messageError.mark();
+        messageError.inc();
     }
 
     @Override
     public void reportMessageRetry() {
-        messageRetry.mark();
+        messageRetry.inc();
     }
 
     @Override
     public void reportConsumerSchemaError() {
-        consumerSchemaError.mark();
+        consumerSchemaError.inc();
     }
 
     @Override

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticFutureReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticFutureReporter.java
@@ -22,7 +22,6 @@
 package com.spotify.heroic.statistics.semantic;
 
 import com.codahale.metrics.Counter;
-import com.codahale.metrics.Meter;
 import com.spotify.heroic.statistics.FutureReporter;
 import com.spotify.heroic.statistics.HeroicTimer;
 import com.spotify.metrics.core.MetricId;
@@ -33,9 +32,9 @@ import lombok.ToString;
 @ToString(of = {})
 public class SemanticFutureReporter implements FutureReporter {
     private final SemanticHeroicTimer timer;
-    private final Meter failed;
-    private final Meter resolved;
-    private final Meter cancelled;
+    private final Counter failed;
+    private final Counter resolved;
+    private final Counter cancelled;
     private final Counter pending;
 
     public SemanticFutureReporter(SemanticMetricRegistry registry, MetricId id) {
@@ -47,11 +46,11 @@ public class SemanticFutureReporter implements FutureReporter {
 
         this.timer = new SemanticHeroicTimer(registry.timer(id.tagged("what", what + "-latency")));
         this.failed =
-            registry.meter(id.tagged("what", what + "-failure-rate", "unit", Units.FAILURE));
+            registry.counter(id.tagged("what", what + "-failed", "unit", Units.COUNT));
         this.resolved =
-            registry.meter(id.tagged("what", what + "-resolve-rate", "unit", Units.RESOLVE));
+            registry.counter(id.tagged("what", what + "-resolved", "unit", Units.COUNT));
         this.cancelled =
-            registry.meter(id.tagged("what", what + "-cancel-rate", "unit", Units.CANCEL));
+            registry.counter(id.tagged("what", what + "-cancelled", "unit", Units.COUNT));
         this.pending =
             registry.counter(id.tagged("what", what + "-pending", "unit", Units.COUNT));
     }
@@ -69,21 +68,21 @@ public class SemanticFutureReporter implements FutureReporter {
         @Override
         public void failed(Throwable e) throws Exception {
             pending.dec();
-            failed.mark();
+            failed.inc();
             context.stop();
         }
 
         @Override
         public void resolved(Object result) throws Exception {
             pending.dec();
-            resolved.mark();
+            resolved.inc();
             context.stop();
         }
 
         @Override
         public void cancelled() throws Exception {
             pending.dec();
-            cancelled.mark();
+            cancelled.inc();
             context.stop();
         }
     }

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticIngestionManagerReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticIngestionManagerReporter.java
@@ -22,7 +22,6 @@
 package com.spotify.heroic.statistics.semantic;
 
 import com.codahale.metrics.Counter;
-import com.codahale.metrics.Meter;
 import com.spotify.heroic.statistics.IngestionManagerReporter;
 import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricRegistry;
@@ -33,19 +32,19 @@ public class SemanticIngestionManagerReporter implements IngestionManagerReporte
     private static final String COMPONENT = "ingestion-manager";
 
     private final Counter concurrentWritesCounter;
-    private final Meter droppedByFilter;
+    private final Counter droppedByFilter;
 
     public SemanticIngestionManagerReporter(SemanticMetricRegistry registry) {
         final MetricId id = MetricId.build().tagged("component", COMPONENT);
         this.concurrentWritesCounter =
             registry.counter(id.tagged("what", "concurrent-writes", "unit", Units.WRITE));
         this.droppedByFilter =
-            registry.meter(id.tagged("what", "dropped-by-filter", "unit", Units.DROP));
+            registry.counter(id.tagged("what", "dropped-by-filter", "unit", Units.COUNT));
     }
 
     @Override
     public void reportDroppedByFilter() {
-        droppedByFilter.mark();
+        droppedByFilter.inc();
     }
 
     @Override

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMemcachedReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMemcachedReporter.java
@@ -21,7 +21,7 @@
 
 package com.spotify.heroic.statistics.semantic;
 
-import com.codahale.metrics.Meter;
+import com.codahale.metrics.Counter;
 import com.spotify.heroic.statistics.MemcachedReporter;
 import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricRegistry;
@@ -32,22 +32,22 @@ public class SemanticMemcachedReporter implements MemcachedReporter {
 
   private static final String COMPONENT = "memcached";
 
-  private final Meter memcachedHit;
-  private final Meter memcachedMiss;
-  private final Meter memcachedTimeout;
-  private final Meter memcachedError;
+  private final Counter memcachedHit;
+  private final Counter memcachedMiss;
+  private final Counter memcachedTimeout;
+  private final Counter memcachedError;
 
   public SemanticMemcachedReporter(SemanticMetricRegistry registry, final String consumerType) {
     final MetricId id = MetricId.build().tagged("component", COMPONENT, "consumer", consumerType);
 
-    memcachedHit = registry.meter(id.tagged("what", "memcached-performance", "result",
+    memcachedHit = registry.counter(id.tagged("what", "memcached-performance", "result",
         "hit"));
-    memcachedMiss = registry.meter(id.tagged("what", "memcached-performance", "result",
+    memcachedMiss = registry.counter(id.tagged("what", "memcached-performance", "result",
         "miss"));
-    memcachedTimeout = registry.meter(id.tagged("what", "memcached-performance", "result",
+    memcachedTimeout = registry.counter(id.tagged("what", "memcached-performance", "result",
         "timeout"));
 
-    memcachedError = registry.meter(id.tagged("what", "memcached-performance", "result",
+    memcachedError = registry.counter(id.tagged("what", "memcached-performance", "result",
         "error"));
 
 
@@ -56,22 +56,22 @@ public class SemanticMemcachedReporter implements MemcachedReporter {
 
   @Override
   public void reportMemcachedHit() {
-    memcachedHit.mark();
+    memcachedHit.inc();
   }
 
   @Override
   public void reportMemcachedMiss() {
-    memcachedMiss.mark();
+    memcachedMiss.inc();
   }
 
   @Override
   public void reportMemcachedTimeout() {
-    memcachedTimeout.mark();
+    memcachedTimeout.inc();
   }
 
   @Override
   public void reportMemcachedError() {
-    memcachedError.mark();
+    memcachedError.inc();
   }
 }
 

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporter.java
@@ -83,10 +83,10 @@ public class SemanticMetadataBackendReporter implements MetadataBackendReporter 
             base.tagged("what", "backend-write", "unit", Units.WRITE));
         entries = registry.counter(base.tagged("what", "entries", "unit", Units.COUNT));
 
-        writesDroppedByCacheHit =
-            registry.counter(base.tagged("what", "writes-dropped-by-cache-hit", "unit", Units.COUNT));
-        writesDroppedByDuplicate =
-            registry.counter(base.tagged("what", "writes-dropped-by-duplicate", "unit", Units.COUNT));
+        writesDroppedByCacheHit = registry.counter(
+            base.tagged("what", "writes-dropped-by-cache-hit", "unit", Units.COUNT));
+        writesDroppedByDuplicate = registry.counter(
+            base.tagged("what", "writes-dropped-by-duplicate", "unit", Units.COUNT));
 
     }
 

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporter.java
@@ -21,7 +21,7 @@
 
 package com.spotify.heroic.statistics.semantic;
 
-import com.codahale.metrics.Meter;
+import com.codahale.metrics.Counter;
 import com.spotify.heroic.async.AsyncObservable;
 import com.spotify.heroic.common.Groups;
 import com.spotify.heroic.common.Statistics;
@@ -57,10 +57,9 @@ public class SemanticMetadataBackendReporter implements MetadataBackendReporter 
     private final FutureReporter write;
     private final FutureReporter backendWrite;
 
-    private final Meter entries;
-
-    private final Meter writesDroppedByCacheHit;
-    private final Meter writesDroppedByDuplicate;
+    private final Counter entries;
+    private final Counter writesDroppedByCacheHit;
+    private final Counter writesDroppedByDuplicate;
 
 
     public SemanticMetadataBackendReporter(SemanticMetricRegistry registry) {
@@ -82,12 +81,12 @@ public class SemanticMetadataBackendReporter implements MetadataBackendReporter 
             new SemanticFutureReporter(registry, base.tagged("what", "write", "unit", Units.WRITE));
         backendWrite = new SemanticFutureReporter(registry,
             base.tagged("what", "backend-write", "unit", Units.WRITE));
-        entries = registry.meter(base.tagged("what", "entries", "unit", Units.QUERY));
+        entries = registry.counter(base.tagged("what", "entries", "unit", Units.COUNT));
 
         writesDroppedByCacheHit =
-            registry.meter(base.tagged("what", "writes-dropped-by-cache-hit", "unit", Units.DROP));
+            registry.counter(base.tagged("what", "writes-dropped-by-cache-hit", "unit", Units.COUNT));
         writesDroppedByDuplicate =
-            registry.meter(base.tagged("what", "writes-dropped-by-duplicate", "unit", Units.DROP));
+            registry.counter(base.tagged("what", "writes-dropped-by-duplicate", "unit", Units.COUNT));
 
     }
 
@@ -105,12 +104,12 @@ public class SemanticMetadataBackendReporter implements MetadataBackendReporter 
 
     @Override
     public void reportWriteDroppedByCacheHit() {
-        writesDroppedByCacheHit.mark();
+        writesDroppedByCacheHit.inc();
     }
 
     @Override
     public void reportWriteDroppedByDuplicate() {
-        writesDroppedByDuplicate.mark();
+        writesDroppedByDuplicate.inc();
     }
 
     @RequiredArgsConstructor
@@ -129,7 +128,7 @@ public class SemanticMetadataBackendReporter implements MetadataBackendReporter 
 
         @Override
         public AsyncObservable<Entries> entries(final Entries.Request request) {
-            entries.mark();
+            entries.inc();
             return delegate.entries(request);
         }
 

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticQueryReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticQueryReporter.java
@@ -21,8 +21,8 @@
 
 package com.spotify.heroic.statistics.semantic;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Meter;
 import com.spotify.heroic.statistics.FutureReporter;
 import com.spotify.heroic.statistics.QueryReporter;
 import com.spotify.metrics.core.MetricId;
@@ -38,8 +38,8 @@ public class SemanticQueryReporter implements QueryReporter {
     private final FutureReporter query;
     private final Histogram smallQueryLatency;
     private final Histogram queryReadRate;
-    private final Meter rpcError;
-    private final Meter rpcCancellation;
+    private final Counter rpcError;
+    private final Counter rpcCancellation;
 
     public SemanticQueryReporter(final SemanticMetricRegistry registry) {
         final MetricId base = MetricId.build().tagged("component", COMPONENT);
@@ -51,9 +51,9 @@ public class SemanticQueryReporter implements QueryReporter {
         queryReadRate =
             registry.histogram(base.tagged("what", "query-read-rate", "unit", Units.COUNT));
 
-        rpcError = registry.meter(base.tagged("what", "cluster-rpc-error", "unit", Units.FAILURE));
+        rpcError = registry.counter(base.tagged("what", "cluster-rpc-error", "unit", Units.COUNT));
         rpcCancellation =
-            registry.meter(base.tagged("what", "cluster-rpc-cancellation", "unit", Units.CANCEL));
+            registry.counter(base.tagged("what", "cluster-rpc-cancellation", "unit", Units.COUNT));
     }
 
     @Override
@@ -78,11 +78,11 @@ public class SemanticQueryReporter implements QueryReporter {
 
     @Override
     public void reportClusterNodeRpcError() {
-        rpcError.mark();
+        rpcError.inc();
     }
 
     @Override
     public void reportClusterNodeRpcCancellation() {
-        rpcCancellation.mark();
+        rpcCancellation.inc();
     }
 }

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticSuggestBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticSuggestBackendReporter.java
@@ -21,7 +21,7 @@
 
 package com.spotify.heroic.statistics.semantic;
 
-import com.codahale.metrics.Meter;
+import com.codahale.metrics.Counter;
 import com.spotify.heroic.common.Groups;
 import com.spotify.heroic.common.Statistics;
 import com.spotify.heroic.statistics.FutureReporter;
@@ -55,8 +55,8 @@ public class SemanticSuggestBackendReporter implements SuggestBackendReporter {
     private final FutureReporter write;
     private final FutureReporter backendWrite;
 
-    private final Meter writesDroppedByCacheHit;
-    private final Meter writesDroppedByDuplicate;
+    private final Counter writesDroppedByCacheHit;
+    private final Counter writesDroppedByDuplicate;
 
     public SemanticSuggestBackendReporter(SemanticMetricRegistry registry) {
         final MetricId base = MetricId.build().tagged("component", COMPONENT);
@@ -77,9 +77,9 @@ public class SemanticSuggestBackendReporter implements SuggestBackendReporter {
             base.tagged("what", "backend-write", "unit", Units.WRITE));
 
         writesDroppedByCacheHit =
-            registry.meter(base.tagged("what", "writes-dropped-by-cache-hit", "unit", Units.DROP));
+            registry.counter(base.tagged("what", "writes-dropped-by-cache-hit", "unit", Units.COUNT));
         writesDroppedByDuplicate =
-            registry.meter(base.tagged("what", "writes-dropped-by-duplicate", "unit", Units.DROP));
+            registry.counter(base.tagged("what", "writes-dropped-by-duplicate", "unit", Units.COUNT));
     }
 
     @Override
@@ -91,12 +91,12 @@ public class SemanticSuggestBackendReporter implements SuggestBackendReporter {
 
     @Override
     public void reportWriteDroppedByCacheHit() {
-        writesDroppedByCacheHit.mark();
+        writesDroppedByCacheHit.inc();
     }
 
     @Override
     public void reportWriteDroppedByDuplicate() {
-        writesDroppedByDuplicate.mark();
+        writesDroppedByDuplicate.inc();
     }
 
     @Override

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticSuggestBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticSuggestBackendReporter.java
@@ -76,10 +76,10 @@ public class SemanticSuggestBackendReporter implements SuggestBackendReporter {
         backendWrite = new SemanticFutureReporter(registry,
             base.tagged("what", "backend-write", "unit", Units.WRITE));
 
-        writesDroppedByCacheHit =
-            registry.counter(base.tagged("what", "writes-dropped-by-cache-hit", "unit", Units.COUNT));
-        writesDroppedByDuplicate =
-            registry.counter(base.tagged("what", "writes-dropped-by-duplicate", "unit", Units.COUNT));
+        writesDroppedByCacheHit = registry.counter(
+            base.tagged("what", "writes-dropped-by-cache-hit", "unit", Units.COUNT));
+        writesDroppedByDuplicate = registry.counter(
+            base.tagged("what", "writes-dropped-by-duplicate", "unit", Units.COUNT));
     }
 
     @Override

--- a/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoirIT.java
+++ b/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoirIT.java
@@ -12,6 +12,7 @@ import com.codahale.metrics.Clock;
 import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.codahale.metrics.Reservoir;
 import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.UniformSnapshot;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Random;
@@ -28,7 +29,7 @@ import org.junit.Test;
 public class MinMaxSlidingTimeReservoirIT {
     private static final int SIZE = 10;
     private static final long STEP = TimeUnit.NANOSECONDS.convert(1, TimeUnit.SECONDS);
-    private static final Snapshot DELEGATE_SNAPSHOT = new Snapshot(new long[]{0, 1, 2});
+    private static final Snapshot DELEGATE_SNAPSHOT = new UniformSnapshot(new long[]{ 0, 1, 2});
     private static final int THREAD_COUNT = 4;
     private static final int SAMPLE_SIZE = 100_000;
     private static final int CLOCK_INTERVAL = 10000;

--- a/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoirTest.java
+++ b/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoirTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.spy;
 import com.codahale.metrics.Clock;
 import com.codahale.metrics.Reservoir;
 import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.UniformSnapshot;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Before;
@@ -17,7 +18,7 @@ import org.junit.Test;
 public class MinMaxSlidingTimeReservoirTest {
     private static final int SIZE = 10;
     private static final long STEP = TimeUnit.NANOSECONDS.convert(1, TimeUnit.SECONDS);
-    private static final Snapshot DELEGATE_SNAPSHOT = new Snapshot(new long[]{0, 1, 3});
+    private static final Snapshot DELEGATE_SNAPSHOT = new UniformSnapshot(new long[]{ 0, 1, 3});
 
     private final DeterministicClock clock = new DeterministicClock();
 


### PR DESCRIPTION
We've found meters to be difficult for people to understand, in particular the difficulties around aggregating the results tends to be hard to explain. Using counters and calculating aggregated rates from the raw counts is more aligned with how people intuitively understand the metrics.

This will be a breaking change as far as our graphs and monitoring go. I'd like to get it merged in but wait to release it until we're ready to cut a major version.