### PR TITLE
[elasticsearch-utils] enable dynamic lookup of nodes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 branches:
   only:

--- a/docs/content/_docs/config/elasticsearch_connection.html
+++ b/docs/content/_docs/config/elasticsearch_connection.html
@@ -144,6 +144,8 @@ index: metadata
 <pre><code class="language-yaml">
 type: transport
 clusterName: heroic
+sniff: false
+nodeSamplerInterval: 30s
 seeds:
   - localhost
 </code></pre>
@@ -151,11 +153,19 @@ seeds:
 <table class="table">
   <tr>
     <td><code>type</code></td>
-    <td><b>node</b></td>
+    <td><b>transport</b></td>
   </tr>
   <tr>
     <td><code>clusterName</code></td>
     <td>The name of the cluster to setup.</td>
+  </tr>
+  <tr>
+    <td><code><b>optional</b>sniff</code></td>
+    <td>Dynamically sniff for new Elasticsearch nodes. Useful to have masters that rarely change as seeds.</td>
+  </tr>
+  <tr>
+    <td><code><b>optional</b> nodeSamplerInterval</code></td>
+    <td>How often to poll for new Elasticsearch nodes. Must include a unit, like "s" for seconds</td>
   </tr>
   <tr>
     <td><code>seeds</code></td>

--- a/example/heroic.example.yml
+++ b/example/heroic.example.yml
@@ -91,9 +91,10 @@ metadata:
         # Random seed, set if you want consistency.
         # @default Randomly generated.
         seed: 0
+
     ## ElasticSearch-based metadata.
-    # - backendType: kv
-    #   # deprecated but useful as a descriptor
+    # - type: elasticsearch
+    #   backendType: kv
     #   type: elasticsearch
     #   # Backend id, if not specified it will be generated.
     #   # @default null
@@ -105,6 +106,13 @@ metadata:
     #     clusterName: elasticsearch
     #     # ElasticSearch index.
     #     # @default "heroic"
+    #
+    #     # Dynamically sniff new nodes. Defaults false
+    #     sniff: false
+    #
+    #     How often to sniff for new nodes. Defaults 30 seconds
+    #     nodeSamplerInterval: 30s
+    #
     #     index:
     #       # Index mapping to use
     #       # @default "single": only operates on a single index.

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/ConnectionModule.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/ConnectionModule.java
@@ -46,20 +46,29 @@ public class ConnectionModule {
 
     private final String clusterName;
     private final List<String> seeds;
-    private final boolean nodeClient;
+    private final Boolean sniff;
+    private final String nodeSamplerInterval;
+    private final Boolean nodeClient;
     private final IndexMapping index;
     private final String templateName;
     private final ClientSetup clientSetup;
 
     @JsonCreator
     public ConnectionModule(
-        @JsonProperty("clusterName") String clusterName, @JsonProperty("seeds") List<String> seeds,
-        @JsonProperty("nodeClient") Boolean nodeClient, @JsonProperty("index") IndexMapping index,
+        @JsonProperty("clusterName") String clusterName,
+        @JsonProperty("seeds") List<String> seeds,
+        @JsonProperty("sniff") Boolean sniff,
+        @JsonProperty("nodeSamplerInterval") String nodeSamplerInterval,
+        @JsonProperty("nodeClient") Boolean nodeClient,
+        @JsonProperty("index") IndexMapping index,
         @JsonProperty("templateName") String templateName,
         @JsonProperty("client") ClientSetup clientSetup
     ) {
         this.clusterName = ofNullable(clusterName).orElse(DEFAULT_CLUSTER_NAME);
         this.seeds = ofNullable(seeds).orElse(DEFAULT_SEEDS);
+        this.sniff = ofNullable(sniff).orElse(TransportClientSetup.DEFAULT_SNIFF);
+        this.nodeSamplerInterval = ofNullable(nodeSamplerInterval).orElse(
+            TransportClientSetup.DEFAULT_NODE_SAMPLER_INTERVAL);
         this.nodeClient = ofNullable(nodeClient).orElse(false);
         this.index = ofNullable(index).orElseGet(RotatingIndexMapping.builder()::build);
         this.templateName = templateName;
@@ -74,11 +83,11 @@ public class ConnectionModule {
             return new NodeClientSetup(clusterName, seeds);
         }
 
-        return new TransportClientSetup(clusterName, seeds);
+        return new TransportClientSetup(clusterName, seeds, sniff, nodeSamplerInterval);
     }
 
     public static ConnectionModule buildDefault() {
-        return new ConnectionModule(null, null, null, null, null, null);
+        return new ConnectionModule(null, null, null, null, null, null, null, null);
     }
 
     @Provides
@@ -121,6 +130,8 @@ public class ConnectionModule {
     public static final class Builder {
         private String clusterName;
         private List<String> seeds;
+        private Boolean sniff;
+        private String nodeSamplerInterval;
         private Boolean nodeClient;
         private Integer concurrentBulkRequests;
         private Integer flushInterval;
@@ -136,6 +147,16 @@ public class ConnectionModule {
 
         public Builder seeds(List<String> seeds) {
             this.seeds = seeds;
+            return this;
+        }
+
+        public Builder sniff(Boolean sniff) {
+            this.sniff = sniff;
+            return this;
+        }
+
+        public Builder nodeSamplerInterval(String nodeSamplerInterval) {
+            this.nodeSamplerInterval = nodeSamplerInterval;
             return this;
         }
 
@@ -175,8 +196,8 @@ public class ConnectionModule {
         }
 
         public ConnectionModule build() {
-            return new ConnectionModule(clusterName, seeds, nodeClient, index, templateName,
-                clientSetup);
+            return new ConnectionModule(clusterName, seeds,
+              sniff, nodeSamplerInterval, nodeClient, index, templateName, clientSetup);
         }
     }
-};
+}


### PR DESCRIPTION
Currently, heroic is deployed internally with the list of seeds being all the data nodes.

During an incident when capacity was added to an already "red" cluster, puppet modified the heroic config with the new data nodes, and restarted the api. The API was never able to be successfully started bringing down everything.

This change will allow us to have the master nodes that rarely change become the seeds and the data nodes "sniffed" out. Sniffing is disabled by default and will have to be explicitly enabled. If enabled new nodes will be polled for by default every 30 seconds.

https://www.elastic.co/guide/en/elasticsearch/client/java-api/current/transport-client.html

@lmuhlha @hexedpackets @sjoeboo 