### PR TITLE
Upgrade surefire and failsafe plugins.

### DIFF
--- a/heroic-shell/src/main/java/com/spotify/heroic/shell/RemoteCoreInterface.java
+++ b/heroic-shell/src/main/java/com/spotify/heroic/shell/RemoteCoreInterface.java
@@ -171,7 +171,7 @@ public class RemoteCoreInterface implements CoreInterface {
 
             @Override
             public Optional<Message> visitFileWrite(FileWrite msg) throws Exception {
-                final byte[] data = msg.getData().getBytes();
+                final byte[] data = msg.getDataBytes().toByteArray();
                 writer(msg.getHandle()).write(data, 0, data.length);
                 return empty();
             }

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.19.1</version>
+            <version>3.0.0-M3</version>
             <configuration>
               <argLine>${failsafeArgLine}</argLine>
               <parallel>all</parallel>
@@ -860,7 +860,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>3.0.0-M3</version>
         <configuration>
           <argLine>${surefireArgLine}</argLine>
           <parallel>all</parallel>


### PR DESCRIPTION
There seems to be a bug in 2.19.1 of these plugins causing the integration-test phase to fail with a JVM crash, even with all tests passing. 