### PR TITLE
Delombokify constructor annotations.

### DIFF
--- a/aggregation/cardinality/src/main/java/com/spotify/heroic/aggregation/cardinality/ExactCardinalityBucket.java
+++ b/aggregation/cardinality/src/main/java/com/spotify/heroic/aggregation/cardinality/ExactCardinalityBucket.java
@@ -28,8 +28,6 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import com.spotify.heroic.metric.Metric;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -41,7 +39,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @author udoprog
  */
-@RequiredArgsConstructor
 public class ExactCardinalityBucket implements CardinalityBucket {
     private static final HashFunction HASH_FUNCTION = Hashing.goodFastHash(128);
     private static final Ordering<String> KEY_ORDER = Ordering.from(String::compareTo);
@@ -51,6 +48,12 @@ public class ExactCardinalityBucket implements CardinalityBucket {
 
     private final AtomicInteger count = new AtomicInteger(0);
     private final Set<HashCode> seen = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    @java.beans.ConstructorProperties({ "timestamp", "includeKey" })
+    public ExactCardinalityBucket(final long timestamp, final boolean includeKey) {
+        this.timestamp = timestamp;
+        this.includeKey = includeKey;
+    }
 
     public long timestamp() {
         return timestamp;

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/AboveK.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/AboveK.java
@@ -21,19 +21,15 @@
 
 package com.spotify.heroic.aggregation.simple;
 
-import com.spotify.heroic.aggregation.Aggregation;
-import com.spotify.heroic.aggregation.AggregationContext;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
-import java.beans.ConstructorProperties;
-import java.util.Optional;
-
 import static com.spotify.heroic.aggregation.simple.Aggregations.verifyNoChild;
 
+import com.spotify.heroic.aggregation.Aggregation;
+import com.spotify.heroic.aggregation.AggregationContext;
+import java.beans.ConstructorProperties;
+import java.util.Optional;
+import lombok.Data;
+
 @Data
-@RequiredArgsConstructor(access = AccessLevel.NONE)
 public class AboveK implements Aggregation {
     public static final String NAME = "abovek";
 

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/BelowK.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/BelowK.java
@@ -21,19 +21,15 @@
 
 package com.spotify.heroic.aggregation.simple;
 
-import com.spotify.heroic.aggregation.Aggregation;
-import com.spotify.heroic.aggregation.AggregationContext;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
-import java.beans.ConstructorProperties;
-import java.util.Optional;
-
 import static com.spotify.heroic.aggregation.simple.Aggregations.verifyNoChild;
 
+import com.spotify.heroic.aggregation.Aggregation;
+import com.spotify.heroic.aggregation.AggregationContext;
+import java.beans.ConstructorProperties;
+import java.util.Optional;
+import lombok.Data;
+
 @Data
-@RequiredArgsConstructor(access = AccessLevel.NONE)
 public class BelowK implements Aggregation {
     public static final String NAME = "belowk";
 

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/BottomK.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/BottomK.java
@@ -21,19 +21,15 @@
 
 package com.spotify.heroic.aggregation.simple;
 
-import com.spotify.heroic.aggregation.Aggregation;
-import com.spotify.heroic.aggregation.AggregationContext;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
-import java.beans.ConstructorProperties;
-import java.util.Optional;
-
 import static com.spotify.heroic.aggregation.simple.Aggregations.verifyNoChild;
 
+import com.spotify.heroic.aggregation.Aggregation;
+import com.spotify.heroic.aggregation.AggregationContext;
+import java.beans.ConstructorProperties;
+import java.util.Optional;
+import lombok.Data;
+
 @Data
-@RequiredArgsConstructor(access = AccessLevel.NONE)
 public class BottomK implements Aggregation {
     public static final String NAME = "bottomk";
 

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/CountBucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/CountBucket.java
@@ -23,8 +23,6 @@ package com.spotify.heroic.aggregation.simple;
 
 import com.spotify.heroic.aggregation.AnyBucket;
 import com.spotify.heroic.metric.Metric;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -33,11 +31,15 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * @author udoprog
  */
-@RequiredArgsConstructor
 public class CountBucket implements AnyBucket {
     private final long timestamp;
 
     private final AtomicLong count = new AtomicLong();
+
+    @java.beans.ConstructorProperties({ "timestamp" })
+    public CountBucket(final long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     public long timestamp() {
         return timestamp;

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/GroupUniqueBucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/GroupUniqueBucket.java
@@ -30,14 +30,11 @@ import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.MetricGroup;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-import lombok.RequiredArgsConstructor;
-
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.concurrent.ConcurrentSkipListSet;
 
-@RequiredArgsConstructor
 public class GroupUniqueBucket extends AbstractBucket implements Bucket {
     final SortedSet<Point> points = new ConcurrentSkipListSet<>(Metric.comparator());
     final SortedSet<Event> events = new ConcurrentSkipListSet<>(Metric.comparator());
@@ -45,6 +42,11 @@ public class GroupUniqueBucket extends AbstractBucket implements Bucket {
     final SortedSet<MetricGroup> groups = new ConcurrentSkipListSet<>(Metric.comparator());
 
     final long timestamp;
+
+    @java.beans.ConstructorProperties({ "timestamp" })
+    public GroupUniqueBucket(final long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     public List<MetricCollection> groups() {
         final ImmutableList.Builder<MetricCollection> result = ImmutableList.builder();

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/MaxBucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/MaxBucket.java
@@ -26,8 +26,6 @@ import com.spotify.heroic.aggregation.AbstractBucket;
 import com.spotify.heroic.aggregation.DoubleBucket;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Map;
 
 /**
@@ -35,11 +33,15 @@ import java.util.Map;
  *
  * @author udoprog
  */
-@RequiredArgsConstructor
 public class MaxBucket extends AbstractBucket implements DoubleBucket {
     private final long timestamp;
 
     private final AtomicDouble value = new AtomicDouble(Double.NEGATIVE_INFINITY);
+
+    @java.beans.ConstructorProperties({ "timestamp" })
+    public MaxBucket(final long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     public long timestamp() {
         return timestamp;

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/MinBucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/MinBucket.java
@@ -26,8 +26,6 @@ import com.spotify.heroic.aggregation.AbstractBucket;
 import com.spotify.heroic.aggregation.DoubleBucket;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Map;
 
 /**
@@ -35,11 +33,15 @@ import java.util.Map;
  *
  * @author udoprog
  */
-@RequiredArgsConstructor
 public class MinBucket extends AbstractBucket implements DoubleBucket {
     private final long timestamp;
 
     private final AtomicDouble value = new AtomicDouble(Double.POSITIVE_INFINITY);
+
+    @java.beans.ConstructorProperties({ "timestamp" })
+    public MinBucket(final long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     public long timestamp() {
         return timestamp;

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/QuantileBucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/QuantileBucket.java
@@ -39,9 +39,6 @@ package com.spotify.heroic.aggregation.simple;
 
 import com.spotify.heroic.aggregation.AbstractBucket;
 import com.spotify.heroic.metric.Point;
-import lombok.AllArgsConstructor;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.ListIterator;
@@ -60,7 +57,6 @@ import java.util.Map;
  * <p>
  * Greenwald and Khanna, "Space-efficient online computation of quantile summaries" in SIGMOD 2001
  */
-@RequiredArgsConstructor
 public class QuantileBucket extends AbstractBucket {
     private final long timestamp;
     private final double quantile;
@@ -81,6 +77,13 @@ public class QuantileBucket extends AbstractBucket {
      */
     private double[] batch = new double[500];
     private int index = 0;
+
+    @java.beans.ConstructorProperties({ "timestamp", "quantile", "error" })
+    public QuantileBucket(final long timestamp, final double quantile, final double error) {
+        this.timestamp = timestamp;
+        this.quantile = quantile;
+        this.error = error;
+    }
 
     /**
      * Add a new data point from the stream.
@@ -274,10 +277,16 @@ public class QuantileBucket extends AbstractBucket {
         return samples.get(samples.size() - 1).value;
     }
 
-    @AllArgsConstructor
     private static class SampleItem {
         public final double value;
         public final int delta;
         public int g;
+
+        @java.beans.ConstructorProperties({ "value", "delta", "g" })
+        public SampleItem(final double value, final int delta, final int g) {
+            this.value = value;
+            this.delta = delta;
+            this.g = g;
+        }
     }
 }

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/SpreadBucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/SpreadBucket.java
@@ -25,8 +25,6 @@ import com.spotify.heroic.aggregation.AbstractBucket;
 import com.spotify.heroic.metric.Metric;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Map;
 import java.util.concurrent.atomic.DoubleAccumulator;
 import java.util.concurrent.atomic.DoubleAdder;
@@ -42,7 +40,6 @@ import java.util.function.DoubleBinaryOperator;
  *
  * @author udoprog
  */
-@RequiredArgsConstructor
 public class SpreadBucket extends AbstractBucket {
     static final DoubleBinaryOperator minFn = (left, right) -> Math.min(left, right);
     static final DoubleBinaryOperator maxFn = (left, right) -> Math.max(left, right);
@@ -54,6 +51,11 @@ public class SpreadBucket extends AbstractBucket {
     final DoubleAdder sum2 = new DoubleAdder();
     final DoubleAccumulator max = new DoubleAccumulator(maxFn, Double.NEGATIVE_INFINITY);
     final DoubleAccumulator min = new DoubleAccumulator(minFn, Double.POSITIVE_INFINITY);
+
+    @java.beans.ConstructorProperties({ "timestamp" })
+    public SpreadBucket(final long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     public long timestamp() {
         return timestamp;

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StdDevBucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StdDevBucket.java
@@ -24,8 +24,6 @@ package com.spotify.heroic.aggregation.simple;
 import com.spotify.heroic.aggregation.AbstractBucket;
 import com.spotify.heroic.aggregation.DoubleBucket;
 import com.spotify.heroic.metric.Point;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -36,12 +34,16 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * @author udoprog
  */
-@RequiredArgsConstructor
 public class StdDevBucket extends AbstractBucket implements DoubleBucket {
     private static final Cell ZERO = new Cell(0.0, 0.0, 0);
 
     private final long timestamp;
     private AtomicReference<Cell> cell = new AtomicReference<>(ZERO);
+
+    @java.beans.ConstructorProperties({ "timestamp" })
+    public StdDevBucket(final long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     @Override
     public void updatePoint(Map<String, String> key, Point d) {
@@ -79,10 +81,16 @@ public class StdDevBucket extends AbstractBucket implements DoubleBucket {
         return Math.sqrt(c.s / (c.count - 1));
     }
 
-    @RequiredArgsConstructor
     private static class Cell {
         private final double mean;
         private final double s;
         private final long count;
+
+        @java.beans.ConstructorProperties({ "mean", "s", "count" })
+        public Cell(final double mean, final double s, final long count) {
+            this.mean = mean;
+            this.s = s;
+            this.count = count;
+        }
     }
 }

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StripedAverageBucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StripedAverageBucket.java
@@ -25,8 +25,6 @@ import com.spotify.heroic.aggregation.AbstractBucket;
 import com.spotify.heroic.aggregation.DoubleBucket;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Map;
 import java.util.concurrent.atomic.DoubleAdder;
 import java.util.concurrent.atomic.LongAdder;
@@ -36,12 +34,16 @@ import java.util.concurrent.atomic.LongAdder;
  *
  * @author udoprog
  */
-@RequiredArgsConstructor
 public class StripedAverageBucket extends AbstractBucket implements DoubleBucket {
     private final long timestamp;
 
     private final DoubleAdder value = new DoubleAdder();
     private final LongAdder count = new LongAdder();
+
+    @java.beans.ConstructorProperties({ "timestamp" })
+    public StripedAverageBucket(final long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     public long timestamp() {
         return timestamp;

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StripedCountBucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StripedCountBucket.java
@@ -23,8 +23,6 @@ package com.spotify.heroic.aggregation.simple;
 
 import com.spotify.heroic.aggregation.AnyBucket;
 import com.spotify.heroic.metric.Metric;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Map;
 import java.util.concurrent.atomic.LongAdder;
 
@@ -35,11 +33,15 @@ import java.util.concurrent.atomic.LongAdder;
  *
  * @author udoprog
  */
-@RequiredArgsConstructor
 public class StripedCountBucket implements AnyBucket {
     private final long timestamp;
 
     private final LongAdder count = new LongAdder();
+
+    @java.beans.ConstructorProperties({ "timestamp" })
+    public StripedCountBucket(final long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     public long timestamp() {
         return timestamp;

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StripedMaxBucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StripedMaxBucket.java
@@ -25,8 +25,6 @@ import com.spotify.heroic.aggregation.AbstractBucket;
 import com.spotify.heroic.aggregation.DoubleBucket;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Map;
 import java.util.concurrent.atomic.DoubleAccumulator;
 import java.util.function.DoubleBinaryOperator;
@@ -38,13 +36,17 @@ import java.util.function.DoubleBinaryOperator;
  *
  * @author udoprog
  */
-@RequiredArgsConstructor
 public class StripedMaxBucket extends AbstractBucket implements DoubleBucket {
     private static final DoubleBinaryOperator maxFn = (left, right) -> Math.max(left, right);
 
     private final long timestamp;
 
     private final DoubleAccumulator max = new DoubleAccumulator(maxFn, Double.NEGATIVE_INFINITY);
+
+    @java.beans.ConstructorProperties({ "timestamp" })
+    public StripedMaxBucket(final long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     public long timestamp() {
         return timestamp;

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StripedMinBucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StripedMinBucket.java
@@ -25,8 +25,6 @@ import com.spotify.heroic.aggregation.AbstractBucket;
 import com.spotify.heroic.aggregation.DoubleBucket;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Map;
 import java.util.concurrent.atomic.DoubleAccumulator;
 import java.util.function.DoubleBinaryOperator;
@@ -38,13 +36,17 @@ import java.util.function.DoubleBinaryOperator;
  *
  * @author udoprog
  */
-@RequiredArgsConstructor
 public class StripedMinBucket extends AbstractBucket implements DoubleBucket {
     private static final DoubleBinaryOperator minFn = (left, right) -> Math.min(left, right);
 
     private final long timestamp;
 
     private final DoubleAccumulator min = new DoubleAccumulator(minFn, Double.POSITIVE_INFINITY);
+
+    @java.beans.ConstructorProperties({ "timestamp" })
+    public StripedMinBucket(final long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     public long timestamp() {
         return timestamp;

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StripedStdDevBucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StripedStdDevBucket.java
@@ -25,8 +25,6 @@ import com.spotify.heroic.aggregation.AbstractBucket;
 import com.spotify.heroic.aggregation.DoubleBucket;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Map;
 import java.util.concurrent.atomic.DoubleAdder;
 import java.util.concurrent.atomic.LongAdder;
@@ -38,13 +36,16 @@ import java.util.concurrent.atomic.LongAdder;
  *
  * @author udoprog
  */
-@RequiredArgsConstructor
 public class StripedStdDevBucket extends AbstractBucket implements DoubleBucket {
     private final DoubleAdder sum = new DoubleAdder();
     private final DoubleAdder sum2 = new DoubleAdder();
     private final LongAdder count = new LongAdder();
 
     private final long timestamp;
+
+    public StripedStdDevBucket(final long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     @Override
     public void updateSpread(Map<String, String> key, Spread d) {

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StripedSum2Bucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StripedSum2Bucket.java
@@ -25,8 +25,6 @@ import com.spotify.heroic.aggregation.AbstractBucket;
 import com.spotify.heroic.aggregation.DoubleBucket;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Map;
 import java.util.concurrent.atomic.DoubleAdder;
 
@@ -37,7 +35,6 @@ import java.util.concurrent.atomic.DoubleAdder;
  *
  * @author udoprog
  */
-@RequiredArgsConstructor
 public class StripedSum2Bucket extends AbstractBucket implements DoubleBucket {
     private final long timestamp;
 
@@ -45,6 +42,11 @@ public class StripedSum2Bucket extends AbstractBucket implements DoubleBucket {
     private final DoubleAdder sum2 = new DoubleAdder();
     /* if the sum is valid (e.g. has at least one value) */
     private volatile boolean valid = false;
+
+    @java.beans.ConstructorProperties({ "timestamp" })
+    public StripedSum2Bucket(final long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     public long timestamp() {
         return timestamp;

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StripedSumBucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/StripedSumBucket.java
@@ -25,8 +25,6 @@ import com.spotify.heroic.aggregation.AbstractBucket;
 import com.spotify.heroic.aggregation.DoubleBucket;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Map;
 import java.util.concurrent.atomic.DoubleAdder;
 
@@ -37,7 +35,6 @@ import java.util.concurrent.atomic.DoubleAdder;
  *
  * @author udoprog
  */
-@RequiredArgsConstructor
 public class StripedSumBucket extends AbstractBucket implements DoubleBucket {
     private final long timestamp;
 
@@ -45,6 +42,11 @@ public class StripedSumBucket extends AbstractBucket implements DoubleBucket {
     private final DoubleAdder sum = new DoubleAdder();
     /* if the sum is valid (e.g. has at least one value) */
     private volatile boolean valid = false;
+
+    @java.beans.ConstructorProperties({ "timestamp" })
+    public StripedSumBucket(final long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     public long timestamp() {
         return timestamp;

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Sum2Bucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Sum2Bucket.java
@@ -26,8 +26,6 @@ import com.spotify.heroic.aggregation.AbstractBucket;
 import com.spotify.heroic.aggregation.DoubleBucket;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Map;
 
 /**
@@ -39,7 +37,6 @@ import java.util.Map;
  *
  * @author udoprog
  */
-@RequiredArgsConstructor
 public class Sum2Bucket extends AbstractBucket implements DoubleBucket {
     private final long timestamp;
 
@@ -47,6 +44,11 @@ public class Sum2Bucket extends AbstractBucket implements DoubleBucket {
     private final AtomicDouble sum2 = new AtomicDouble();
     /* if the sum is valid (e.g. has at least one value) */
     private volatile boolean valid = false;
+
+    @java.beans.ConstructorProperties({ "timestamp" })
+    public Sum2Bucket(final long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     public long timestamp() {
         return timestamp;

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/SumBucket.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/SumBucket.java
@@ -26,8 +26,6 @@ import com.spotify.heroic.aggregation.AbstractBucket;
 import com.spotify.heroic.aggregation.DoubleBucket;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.Spread;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Map;
 
 /**
@@ -39,7 +37,6 @@ import java.util.Map;
  *
  * @author udoprog
  */
-@RequiredArgsConstructor
 public class SumBucket extends AbstractBucket implements DoubleBucket {
     private final long timestamp;
 
@@ -47,6 +44,11 @@ public class SumBucket extends AbstractBucket implements DoubleBucket {
     private final AtomicDouble sum = new AtomicDouble();
     /* if the sum is valid (e.g. has at least one value) */
     private volatile boolean valid = false;
+
+    @java.beans.ConstructorProperties({ "timestamp" })
+    public SumBucket(final long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     public long timestamp() {
         return timestamp;

--- a/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/ValueBucketIntegrationTest.java
+++ b/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/ValueBucketIntegrationTest.java
@@ -1,13 +1,10 @@
 package com.spotify.heroic.aggregation.simple;
 
+import static org.junit.Assert.assertEquals;
+
 import com.google.common.collect.ImmutableMap;
 import com.spotify.heroic.aggregation.DoubleBucket;
 import com.spotify.heroic.metric.Point;
-import lombok.RequiredArgsConstructor;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -19,10 +16,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.DoubleBinaryOperator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-
-@RequiredArgsConstructor
 public abstract class ValueBucketIntegrationTest {
     private static final int NCPU = Runtime.getRuntime().availableProcessors();
 
@@ -40,6 +37,19 @@ public abstract class ValueBucketIntegrationTest {
     }
 
     private ExecutorService service;
+
+    @java.beans.ConstructorProperties({ "initial", "fn", "threadCount", "count", "range",
+                                        "iterations" })
+    public ValueBucketIntegrationTest(final double initial, final DoubleBinaryOperator fn,
+                                      final int threadCount, final long count, final double range,
+                                      final int iterations) {
+        this.initial = initial;
+        this.fn = fn;
+        this.threadCount = threadCount;
+        this.count = count;
+        this.range = range;
+        this.iterations = iterations;
+    }
 
     @Before
     public void setup() {

--- a/consumer/collectd/src/main/java/com/spotify/heroic/consumer/collectd/CollectdChannelHandler.java
+++ b/consumer/collectd/src/main/java/com/spotify/heroic/consumer/collectd/CollectdChannelHandler.java
@@ -32,22 +32,29 @@ import eu.toolchain.async.AsyncFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramPacket;
-import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.tuple.Pair;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
 
-@RequiredArgsConstructor
 public class CollectdChannelHandler extends SimpleChannelInboundHandler<DatagramPacket> {
     private final AsyncFramework async;
     private final IngestionGroup ingestion;
     private final Optional<GrokProcessor> hostProcessor;
     private final CollectdTypes types;
+
+    @java.beans.ConstructorProperties({ "async", "ingestion", "hostProcessor", "types" })
+    public CollectdChannelHandler(final AsyncFramework async, final IngestionGroup ingestion,
+                                  final Optional<GrokProcessor> hostProcessor,
+                                  final CollectdTypes types) {
+        this.async = async;
+        this.ingestion = ingestion;
+        this.hostProcessor = hostProcessor;
+        this.types = types;
+    }
 
     @Override
     protected void channelRead0(final ChannelHandlerContext ctx, final DatagramPacket msg)

--- a/consumer/collectd/src/main/java/com/spotify/heroic/consumer/collectd/CollectdConsumerModule.java
+++ b/consumer/collectd/src/main/java/com/spotify/heroic/consumer/collectd/CollectdConsumerModule.java
@@ -38,17 +38,14 @@ import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.Managed;
 import eu.toolchain.async.ManagedSetup;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-import javax.inject.Named;
 import java.net.InetAddress;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
+import javax.inject.Named;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Data
@@ -176,7 +173,6 @@ public class CollectdConsumerModule implements ConsumerModule {
         }
     }
 
-    @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Builder implements ConsumerModule.Builder {
         private Optional<String> id = Optional.empty();
         private Optional<String> host = Optional.empty();
@@ -196,6 +192,9 @@ public class CollectdConsumerModule implements ConsumerModule {
             this.port = port;
             this.hostProcessor = hostPattern;
             this.types = types;
+        }
+
+        private Builder() {
         }
 
         public Builder id(String id) {

--- a/consumer/collectd/src/main/java/com/spotify/heroic/consumer/collectd/CollectdTypes.java
+++ b/consumer/collectd/src/main/java/com/spotify/heroic/consumer/collectd/CollectdTypes.java
@@ -30,14 +30,12 @@ import com.spotify.heroic.common.Series;
 import com.spotify.heroic.ingestion.Ingestion;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.Point;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class CollectdTypes {
@@ -250,10 +248,15 @@ public class CollectdTypes {
         }
     }
 
-    @RequiredArgsConstructor
     static class Field {
         private final double lower;
         private final double upper;
+
+        @java.beans.ConstructorProperties({ "lower", "upper" })
+        public Field(final double lower, final double upper) {
+            this.lower = lower;
+            this.upper = upper;
+        }
 
         public double convertCounter(long counter) {
             return Long.valueOf(counter).doubleValue();

--- a/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/KafkaConsumerModule.java
+++ b/consumer/kafka/src/main/java/com/spotify/heroic/consumer/kafka/KafkaConsumerModule.java
@@ -60,10 +60,7 @@ import javax.inject.Named;
 import kafka.consumer.Consumer;
 import kafka.consumer.ConsumerConfig;
 import kafka.javaapi.consumer.ConsumerConnector;
-import lombok.AccessLevel;
 import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -109,11 +106,16 @@ public class KafkaConsumerModule implements ConsumerModule {
         LifeCycle consumerLife();
     }
 
-    @RequiredArgsConstructor
     @Module
     class M {
         private final PrimaryComponent primary;
         private final ConsumerModule.Depends depends;
+
+        @java.beans.ConstructorProperties({ "primary", "depends" })
+        public M(final PrimaryComponent primary, final Depends depends) {
+            this.primary = primary;
+            this.depends = depends;
+        }
 
         @Provides
         @Named("consuming")
@@ -349,7 +351,6 @@ public class KafkaConsumerModule implements ConsumerModule {
         return new Builder();
     }
 
-    @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Builder implements ConsumerModule.Builder {
         private Optional<String> id = Optional.empty();
         private Optional<List<String>> topics = Optional.empty();
@@ -377,6 +378,9 @@ public class KafkaConsumerModule implements ConsumerModule {
             this.schema = schema.map(s -> ReflectionUtils.buildInstance(s, ConsumerSchema.class));
             this.transactional = transactional;
             this.transactionCommitInterval = transactionCommitInterval;
+        }
+
+        private Builder() {
         }
 
         public Builder id(String id) {

--- a/consumer/pubsub/src/main/java/com/spotify/heroic/consumer/pubsub/PubSubConsumerModule.java
+++ b/consumer/pubsub/src/main/java/com/spotify/heroic/consumer/pubsub/PubSubConsumerModule.java
@@ -46,10 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 import javax.inject.Named;
-import lombok.AccessLevel;
 import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -98,11 +95,16 @@ public class PubSubConsumerModule implements ConsumerModule {
         LifeCycle consumerLife();
     }
 
-    @RequiredArgsConstructor
     @Module
     class M {
         private final PrimaryComponent primary;
         private final ConsumerModule.Depends depends;
+
+        @java.beans.ConstructorProperties({ "primary", "depends" })
+        public M(final PrimaryComponent primary, final Depends depends) {
+            this.primary = primary;
+            this.depends = depends;
+        }
 
         @Provides
         @Named("consuming")
@@ -267,7 +269,6 @@ public class PubSubConsumerModule implements ConsumerModule {
         return new Builder();
     }
 
-    @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Builder implements ConsumerModule.Builder {
         private Optional<String> id = Optional.empty();
         private Optional<ConsumerSchema> schema = Optional.empty();
@@ -303,6 +304,9 @@ public class PubSubConsumerModule implements ConsumerModule {
             this.maxOutstandingRequestBytes = maxOutstandingRequestBytes;
             this.maxInboundMessageSize = maxInboundMessageSize;
             this.keepAlive = keepAlive;
+        }
+
+        private Builder() {
         }
 
         public Builder id(String id) {

--- a/heroic-component-test/src/main/java/com/spotify/heroic/test/FakeValueProvider.java
+++ b/heroic-component-test/src/main/java/com/spotify/heroic/test/FakeValueProvider.java
@@ -28,9 +28,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
-import lombok.RequiredArgsConstructor;
-import org.mockito.Mockito;
-
 import java.beans.ConstructorProperties;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -42,11 +39,11 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.UUID;
+import org.mockito.Mockito;
 
 /**
  * Provides mock values for test classes.
  */
-@RequiredArgsConstructor
 public class FakeValueProvider {
     private final ValueSuppliers suppliers;
 
@@ -63,6 +60,11 @@ public class FakeValueProvider {
         0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
         0x01
     });
+
+    @ConstructorProperties({ "suppliers" })
+    public FakeValueProvider(final ValueSuppliers suppliers) {
+        this.suppliers = suppliers;
+    }
 
     public Object lookup(final Type type, final boolean secondary, final String name) {
         final Optional<Object> supplied = suppliers.lookup(type, secondary, name);

--- a/heroic-component-test/src/main/java/com/spotify/heroic/test/TestProperties.java
+++ b/heroic-component-test/src/main/java/com/spotify/heroic/test/TestProperties.java
@@ -21,15 +21,16 @@
 
 package com.spotify.heroic.test;
 
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Optional;
 import java.util.function.Supplier;
 
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class TestProperties {
     private final String prefix;
+
+    @java.beans.ConstructorProperties({ "prefix" })
+    private TestProperties(final String prefix) {
+        this.prefix = prefix;
+    }
 
     public Optional<String> getOptionalString(final String key) {
         final String property = property(key);

--- a/heroic-component-test/src/main/java/com/spotify/heroic/test/ValueSuppliers.java
+++ b/heroic-component-test/src/main/java/com/spotify/heroic/test/ValueSuppliers.java
@@ -22,16 +22,19 @@
 package com.spotify.heroic.test;
 
 import com.google.common.collect.ImmutableList;
-import lombok.RequiredArgsConstructor;
-
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-@RequiredArgsConstructor
 public class ValueSuppliers {
     private final List<ValueSupplier> suppliers;
+
+    @java.beans.ConstructorProperties({ "suppliers" })
+    public ValueSuppliers(
+        final List<ValueSupplier> suppliers) {
+        this.suppliers = suppliers;
+    }
 
     public Optional<Object> lookup(
         final Type type, final boolean secondary, final String name

--- a/heroic-component/src/main/java/com/spotify/heroic/QueryDateRange.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/QueryDateRange.java
@@ -21,6 +21,8 @@
 
 package com.spotify.heroic;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -30,12 +32,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Duration;
 import com.spotify.heroic.common.TimeUtils;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
 import java.util.concurrent.TimeUnit;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.Data;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({
@@ -44,7 +42,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 })
 public interface QueryDateRange {
     @Data
-    @RequiredArgsConstructor
     @JsonTypeName("absolute")
     public static class Absolute implements QueryDateRange {
         private final long start;
@@ -54,6 +51,12 @@ public interface QueryDateRange {
         public Absolute(@JsonProperty("start") Long start, @JsonProperty("end") Long end) {
             this.start = checkNotNull(start, "start");
             this.end = checkNotNull(end, "end");
+        }
+
+        @java.beans.ConstructorProperties({ "start", "end" })
+        public Absolute(final long start, final long end) {
+            this.start = start;
+            this.end = end;
         }
 
         @Override
@@ -77,7 +80,6 @@ public interface QueryDateRange {
     }
 
     @Data
-    @RequiredArgsConstructor
     @JsonTypeName("relative")
     public static class Relative implements QueryDateRange {
         public static final TimeUnit DEFAULT_UNIT = TimeUnit.DAYS;
@@ -89,6 +91,12 @@ public interface QueryDateRange {
         public Relative(@JsonProperty("unit") String unit, @JsonProperty("value") Long value) {
             this.unit = TimeUtils.parseTimeUnit(unit).orElse(DEFAULT_UNIT);
             this.value = checkNotNull(value, "value");
+        }
+
+        @java.beans.ConstructorProperties({ "unit", "value" })
+        public Relative(final TimeUnit unit, final long value) {
+            this.unit = unit;
+            this.value = value;
         }
 
         @Override

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/AbstractAggregationDSL.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/AbstractAggregationDSL.java
@@ -22,11 +22,14 @@
 package com.spotify.heroic.aggregation;
 
 import com.spotify.heroic.grammar.FunctionExpression;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public abstract class AbstractAggregationDSL implements AggregationDSL {
     private final AggregationFactory factory;
+
+    @java.beans.ConstructorProperties({ "factory" })
+    public AbstractAggregationDSL(final AggregationFactory factory) {
+        this.factory = factory;
+    }
 
     protected Aggregation asAggregation(final FunctionExpression value) {
         return factory.build(value.getName(), value.getArguments(), value.getKeywords());

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/AggregationContext.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/AggregationContext.java
@@ -21,22 +21,31 @@
 
 package com.spotify.heroic.aggregation;
 
+import static com.spotify.heroic.common.Optionals.firstPresent;
+
 import com.google.common.collect.ImmutableSet;
 import com.spotify.heroic.common.Duration;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Optional;
 import java.util.Set;
 
-import static com.spotify.heroic.common.Optionals.firstPresent;
-
-@RequiredArgsConstructor
 public class AggregationContext {
     private final Optional<Duration> size;
     private final Optional<Duration> extent;
     private final Duration defaultSize;
     private final Duration defaultExtent;
     private final Set<String> requiredTags;
+
+    @java.beans.ConstructorProperties({ "size", "extent", "defaultSize", "defaultExtent",
+                                        "requiredTags" })
+    public AggregationContext(final Optional<Duration> size, final Optional<Duration> extent,
+                              final Duration defaultSize, final Duration defaultExtent,
+                              final Set<String> requiredTags) {
+        this.size = size;
+        this.extent = extent;
+        this.defaultSize = defaultSize;
+        this.defaultExtent = defaultExtent;
+        this.requiredTags = requiredTags;
+    }
 
     /**
      * Get the size that is currently configured in the context.

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/BucketStrategy.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/BucketStrategy.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.spotify.heroic.ObjectHasher;
 import com.spotify.heroic.common.DateRange;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 
 public interface BucketStrategy {
     long MAX_BUCKET_COUNT = 100000L;
@@ -73,13 +72,23 @@ public interface BucketStrategy {
             hasher.putObject(getClass());
         }
 
-        @RequiredArgsConstructor
         private static class StartMapping implements Mapping {
             private final long start;
             private final long offset;
             private final long size;
             private final long extent;
             private final int buckets;
+
+            @java.beans.ConstructorProperties({ "start", "offset", "size", "extent", "buckets" })
+            public StartMapping(final long start, final long offset, final long size,
+                                final long extent,
+                                final int buckets) {
+                this.start = start;
+                this.offset = offset;
+                this.size = size;
+                this.extent = extent;
+                this.buckets = buckets;
+            }
 
             /**
              * Calculate the start and end index of the buckets that should be seeded for the given
@@ -137,13 +146,23 @@ public interface BucketStrategy {
             hasher.putObject(getClass());
         }
 
-        @RequiredArgsConstructor
         private static class EndMapping implements Mapping {
             private final long start;
             private final long offset;
             private final long size;
             private final long extent;
             private final int buckets;
+
+            @java.beans.ConstructorProperties({ "start", "offset", "size", "extent", "buckets" })
+            public EndMapping(final long start, final long offset, final long size,
+                              final long extent,
+                              final int buckets) {
+                this.start = start;
+                this.offset = offset;
+                this.size = size;
+                this.extent = extent;
+                this.buckets = buckets;
+            }
 
             /**
              * Calculate the start and end index of the buckets that should be seeded for the given

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/ChainInstance.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/ChainInstance.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 
 /**
  * A special aggregation method that is a chain of other aggregation methods.
@@ -203,10 +202,15 @@ public class ChainInstance implements AggregationInstance {
         return child.build();
     }
 
-    @RequiredArgsConstructor
     private static final class Session implements AggregationSession {
         private final AggregationSession first;
         private final Iterable<AggregationSession> rest;
+
+        @java.beans.ConstructorProperties({ "first", "rest" })
+        public Session(final AggregationSession first, final Iterable<AggregationSession> rest) {
+            this.first = first;
+            this.rest = rest;
+        }
 
         @Override
         public void updatePoints(

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/GroupingAggregation.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/GroupingAggregation.java
@@ -42,7 +42,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @Data
@@ -115,7 +114,6 @@ public abstract class GroupingAggregation implements AggregationInstance {
     }
 
     @ToString
-    @RequiredArgsConstructor
     private final class GroupSession implements AggregationSession {
         private final ConcurrentMap<Map<String, String>, AggregationSession> sessions =
             new ConcurrentHashMap<>();
@@ -124,6 +122,13 @@ public abstract class GroupingAggregation implements AggregationInstance {
         private final DateRange range;
         private final RetainQuotaWatcher quotaWatcher;
         private final BucketStrategy bucketStrategy;
+
+        public GroupSession(final DateRange range, final RetainQuotaWatcher quotaWatcher,
+                            final BucketStrategy bucketStrategy) {
+            this.range = range;
+            this.quotaWatcher = quotaWatcher;
+            this.bucketStrategy = bucketStrategy;
+        }
 
         @Override
         public void updatePoints(

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/GroupingAggregationSerializer.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/GroupingAggregationSerializer.java
@@ -24,17 +24,21 @@ package com.spotify.heroic.aggregation;
 import eu.toolchain.serializer.SerialReader;
 import eu.toolchain.serializer.SerialWriter;
 import eu.toolchain.serializer.Serializer;
-import lombok.RequiredArgsConstructor;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
-@RequiredArgsConstructor
 public abstract class GroupingAggregationSerializer<T extends GroupingAggregation>
     implements Serializer<T> {
     private final Serializer<Optional<List<String>>> list;
     private final Serializer<AggregationInstance> aggregation;
+
+    @java.beans.ConstructorProperties({ "list", "aggregation" })
+    public GroupingAggregationSerializer(final Serializer<Optional<List<String>>> list,
+                                         final Serializer<AggregationInstance> aggregation) {
+        this.list = list;
+        this.aggregation = aggregation;
+    }
 
     @Override
     public void serialize(SerialWriter buffer, T value) throws IOException {

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/SamplingQuery.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/SamplingQuery.java
@@ -24,15 +24,12 @@ package com.spotify.heroic.aggregation;
 import com.spotify.heroic.common.Duration;
 import com.spotify.heroic.common.Optionals;
 import com.spotify.heroic.common.TimeUtils;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
 import java.beans.ConstructorProperties;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import lombok.Data;
 
 @Data
-@AllArgsConstructor(suppressConstructorProperties = true)
 public class SamplingQuery {
     private final Optional<Duration> size;
     private final Optional<Duration> extent;
@@ -49,5 +46,10 @@ public class SamplingQuery {
             this.size = Optional.ofNullable(size);
             this.extent = Optionals.firstPresent(Optional.ofNullable(extent), this.size);
         }
+    }
+
+    public SamplingQuery(final Optional<Duration> size, final Optional<Duration> extent) {
+        this.size = size;
+        this.extent = extent;
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/common/RequestTimer.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/RequestTimer.java
@@ -22,15 +22,17 @@
 package com.spotify.heroic.common;
 
 import com.google.common.base.Stopwatch;
-import lombok.RequiredArgsConstructor;
-
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-@RequiredArgsConstructor
 public class RequestTimer<T> {
     private final Stopwatch watch = Stopwatch.createStarted();
     private final Function<Long, T> builder;
+
+    @java.beans.ConstructorProperties({ "builder" })
+    public RequestTimer(final Function<Long, T> builder) {
+        this.builder = builder;
+    }
 
     public T end() {
         return builder.apply(watch.elapsed(TimeUnit.MICROSECONDS));

--- a/heroic-component/src/main/java/com/spotify/heroic/consumer/ConsumerSchema.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/consumer/ConsumerSchema.java
@@ -28,7 +28,6 @@ import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
 import eu.toolchain.async.AsyncFuture;
-import lombok.RequiredArgsConstructor;
 
 public interface ConsumerSchema {
     Exposed setup(Depends depends);
@@ -52,10 +51,14 @@ public interface ConsumerSchema {
         }
     }
 
-    @RequiredArgsConstructor
     @Module
     class DependsModule {
         private final IngestionGroup group;
+
+        @java.beans.ConstructorProperties({ "group" })
+        public DependsModule(final IngestionGroup group) {
+            this.group = group;
+        }
 
         @Provides
         @ConsumerSchemaScope

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/AbstractMetricBackend.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/AbstractMetricBackend.java
@@ -29,14 +29,15 @@ import com.spotify.heroic.common.OptionalLimit;
 import com.spotify.heroic.common.Statistics;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.RequiredArgsConstructor;
-
 import java.util.List;
 import java.util.Optional;
 
-@RequiredArgsConstructor
 public abstract class AbstractMetricBackend implements MetricBackend {
     private final AsyncFramework async;
+
+    public AbstractMetricBackend(final AsyncFramework async) {
+        this.async = async;
+    }
 
     @Override
     public Statistics getStatistics() {

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/BackendKey.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/BackendKey.java
@@ -22,13 +22,10 @@
 package com.spotify.heroic.metric;
 
 import com.spotify.heroic.common.Series;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Optional;
+import lombok.Data;
 
 @Data
-@RequiredArgsConstructor
 public class BackendKey {
     private final Series series;
     private final long base;
@@ -37,5 +34,14 @@ public class BackendKey {
 
     public BackendKey(final Series series, final long base) {
         this(series, base, MetricType.POINT, Optional.empty());
+    }
+
+    @java.beans.ConstructorProperties({ "series", "base", "type", "token" })
+    public BackendKey(final Series series, final long base, final MetricType type,
+                      final Optional<Long> token) {
+        this.series = series;
+        this.base = base;
+        this.type = type;
+        this.token = token;
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/suggest/MatchOptions.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/suggest/MatchOptions.java
@@ -21,11 +21,8 @@
 
 package com.spotify.heroic.suggest;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.util.Optional;
+import lombok.Data;
 
 @Data
 public class MatchOptions {
@@ -38,8 +35,6 @@ public class MatchOptions {
         return new Builder();
     }
 
-    @AllArgsConstructor
-    @NoArgsConstructor
     public static class Builder {
         public static final boolean DEFAULT_FUZZY = false;
         public static final int DEFAULT_FUZZY_PREFIX_LENGTH = 2;
@@ -50,6 +45,20 @@ public class MatchOptions {
         private Optional<Integer> fuzzyPrefixLength = Optional.empty();
         private Optional<Integer> fuzzyMaxExpansions = Optional.empty();
         private Optional<Boolean> tokenize = Optional.empty();
+
+        @java.beans.ConstructorProperties({ "fuzzy", "fuzzyPrefixLength", "fuzzyMaxExpansions",
+                                            "tokenize" })
+        public Builder(final Optional<Boolean> fuzzy, final Optional<Integer> fuzzyPrefixLength,
+                       final Optional<Integer> fuzzyMaxExpansions,
+                       final Optional<Boolean> tokenize) {
+            this.fuzzy = fuzzy;
+            this.fuzzyPrefixLength = fuzzyPrefixLength;
+            this.fuzzyMaxExpansions = fuzzyMaxExpansions;
+            this.tokenize = tokenize;
+        }
+
+        public Builder() {
+        }
 
         public Builder fuzzy(boolean fuzzy) {
             this.fuzzy = Optional.of(fuzzy);

--- a/heroic-core/src/main/java/com/spotify/heroic/CoreShellTasks.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/CoreShellTasks.java
@@ -31,7 +31,6 @@ import com.spotify.heroic.shell.ShellTaskDefinition;
 import com.spotify.heroic.shell.TaskParameters;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.RequiredArgsConstructor;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 
@@ -47,13 +46,22 @@ import java.util.List;
 import java.util.SortedMap;
 import java.util.zip.GZIPOutputStream;
 
-@RequiredArgsConstructor
 public class CoreShellTasks implements ShellTasks {
     public static final Joiner joiner = Joiner.on(", ");
 
     final List<ShellTaskDefinition> available;
     final SortedMap<String, ShellTask> tasks;
     final AsyncFramework async;
+
+    public CoreShellTasks(
+        final List<ShellTaskDefinition> available,
+        final SortedMap<String, ShellTask> tasks,
+        final AsyncFramework async
+    ) {
+        this.available = available;
+        this.tasks = tasks;
+        this.async = async;
+    }
 
     @Override
     public List<CommandDefinition> commands() {

--- a/heroic-core/src/main/java/com/spotify/heroic/cache/memcached/MemcachedCacheModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/cache/memcached/MemcachedCacheModule.java
@@ -46,16 +46,18 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.inject.Named;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 @Module
-@RequiredArgsConstructor
 public class MemcachedCacheModule implements CacheModule {
     public static final String DEFAULT_ADDRESS = "localhost:11211";
 
     private final List<String> addresses;
     private final Optional<Duration> maxTtl;
+
+    public MemcachedCacheModule(final List<String> addresses, final Optional<Duration> maxTtl) {
+        this.addresses = addresses;
+        this.maxTtl = maxTtl;
+    }
 
     @Override
     public CacheComponent module(PrimaryComponent primary) {
@@ -137,10 +139,12 @@ public class MemcachedCacheModule implements CacheModule {
         return new Builder();
     }
 
-    @NoArgsConstructor
     public static class Builder implements CacheModule.Builder {
         private Optional<List<String>> addresses = Optional.empty();
         private Optional<Duration> maxTtl = Optional.empty();
+
+        public Builder() {
+        }
 
         @JsonCreator
         public Builder(

--- a/heroic-core/src/main/java/com/spotify/heroic/cluster/ClusterManagerModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/cluster/ClusterManagerModule.java
@@ -49,10 +49,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import javax.inject.Named;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
 
 /**
@@ -181,8 +178,6 @@ public class ClusterManagerModule {
         return new Builder();
     }
 
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Builder {
         private Optional<UUID> id = empty();
         private Optional<Map<String, String>> tags = empty();
@@ -207,6 +202,27 @@ public class ClusterManagerModule {
             this.discovery = discovery;
             this.protocols = protocols;
             this.topology = topology;
+        }
+
+        private Builder(
+            final Optional<UUID> id,
+            final Optional<Map<String, String>> tags,
+            final Optional<Boolean> useLocal,
+            final Optional<ClusterDiscoveryModule> discovery,
+            final Optional<List<RpcProtocolModule>> protocols,
+            final Optional<Set<Map<String, String>>> topology,
+            final Optional<NodeMetadataFactory> metadataFactory
+        ) {
+            this.id = id;
+            this.tags = tags;
+            this.useLocal = useLocal;
+            this.discovery = discovery;
+            this.protocols = protocols;
+            this.topology = topology;
+            this.metadataFactory = metadataFactory;
+        }
+
+        private Builder() {
         }
 
         public Builder id(UUID id) {

--- a/heroic-core/src/main/java/com/spotify/heroic/cluster/LocalClusterNode.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/cluster/LocalClusterNode.java
@@ -42,11 +42,9 @@ import com.spotify.heroic.suggest.TagValueSuggest;
 import com.spotify.heroic.suggest.TagValuesSuggest;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
-
-import javax.inject.Inject;
 import java.util.Optional;
+import javax.inject.Inject;
+import lombok.ToString;
 
 @ClusterScope
 @ToString(exclude = {"async", "metrics", "metadata", "suggest"})
@@ -89,9 +87,13 @@ public class LocalClusterNode implements ClusterNode {
         return new LocalGroup(group);
     }
 
-    @RequiredArgsConstructor
     private final class LocalGroup implements Group {
         private final Optional<String> group;
+
+        @java.beans.ConstructorProperties({ "group" })
+        public LocalGroup(final Optional<String> group) {
+            this.group = group;
+        }
 
         @Override
         public ClusterNode node() {

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/CoreConsumersModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/CoreConsumersModule.java
@@ -28,22 +28,29 @@ import com.spotify.heroic.statistics.ConsumerReporter;
 import com.spotify.heroic.statistics.HeroicReporter;
 import dagger.Module;
 import dagger.Provides;
-import lombok.RequiredArgsConstructor;
-
-import javax.inject.Named;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.inject.Named;
 
-@RequiredArgsConstructor
 @Module
 public class CoreConsumersModule {
     private final HeroicReporter reporter;
     private final List<ConsumerModule> consumers;
     private final CorePrimaryComponent primary;
     private final IngestionComponent ingestion;
+
+    @java.beans.ConstructorProperties({ "reporter", "consumers", "primary", "ingestion" })
+    public CoreConsumersModule(final HeroicReporter reporter, final List<ConsumerModule> consumers,
+                               final CorePrimaryComponent primary,
+                               final IngestionComponent ingestion) {
+        this.reporter = reporter;
+        this.consumers = consumers;
+        this.primary = primary;
+        this.ingestion = ingestion;
+    }
 
     @Provides
     @ConsumersScope
@@ -63,9 +70,13 @@ public class CoreConsumersModule {
         return consumers;
     }
 
-    @RequiredArgsConstructor
     public static class Depends implements ConsumerModule.Depends {
         private final ConsumerReporter consumerReporter;
+
+        @java.beans.ConstructorProperties({ "consumerReporter" })
+        public Depends(final ConsumerReporter consumerReporter) {
+            this.consumerReporter = consumerReporter;
+        }
 
         @Override
         public ConsumerReporter consumerReporter() {

--- a/heroic-core/src/main/java/com/spotify/heroic/dagger/EarlyModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/dagger/EarlyModule.java
@@ -29,19 +29,21 @@ import com.spotify.heroic.lifecycle.CoreLifeCycleRegistry;
 import com.spotify.heroic.lifecycle.LifeCycleRegistry;
 import dagger.Module;
 import dagger.Provides;
-import lombok.RequiredArgsConstructor;
-
-import javax.inject.Named;
 import java.util.Optional;
 import java.util.function.Supplier;
+import javax.inject.Named;
 
-@RequiredArgsConstructor
 @Module
 public class EarlyModule {
     private final HeroicConfig config;
     private final Optional<String> id;
 
     private volatile boolean stopping = false;
+
+    public EarlyModule(final HeroicConfig config, final Optional<String> id) {
+        this.config = config;
+        this.id = id;
+    }
 
     @Provides
     @EarlyScope

--- a/heroic-core/src/main/java/com/spotify/heroic/dagger/PrimaryModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/dagger/PrimaryModule.java
@@ -45,21 +45,28 @@ import com.spotify.heroic.statistics.HeroicReporter;
 import dagger.Module;
 import dagger.Provides;
 import eu.toolchain.async.AsyncFramework;
-import java.util.Optional;
-import lombok.RequiredArgsConstructor;
-
-import javax.inject.Named;
 import java.util.List;
+import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import javax.inject.Named;
 
-@RequiredArgsConstructor
 @Module
 public class PrimaryModule {
     private final HeroicCoreInstance instance;
     private final FeatureSet features;
     private final HeroicReporter reporter;
     private final Optional<ConditionalFeatures> conditionalFeatures;
+
+    public PrimaryModule(final HeroicCoreInstance instance,
+                         final FeatureSet features,
+                         final HeroicReporter reporter,
+                         final Optional<ConditionalFeatures> conditionalFeatures) {
+        this.instance = instance;
+        this.features = features;
+        this.reporter = reporter;
+        this.conditionalFeatures = conditionalFeatures;
+    }
 
     @Provides
     @PrimaryScope

--- a/heroic-core/src/main/java/com/spotify/heroic/dagger/StartupPingerModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/dagger/StartupPingerModule.java
@@ -27,18 +27,22 @@ import com.spotify.heroic.lifecycle.LifeCycle;
 import com.spotify.heroic.lifecycle.LifeCycleManager;
 import dagger.Module;
 import dagger.Provides;
-import lombok.RequiredArgsConstructor;
-
-import javax.inject.Named;
 import java.net.URI;
 import java.util.Optional;
+import javax.inject.Named;
 
-@RequiredArgsConstructor
 @Module
 public class StartupPingerModule {
     private final URI ping;
     private final String id;
     private final Optional<HttpServer> server;
+
+    public StartupPingerModule(final URI ping, final String id,
+                               final Optional<HttpServer> server) {
+        this.ping = ping;
+        this.id = id;
+        this.server = server;
+    }
 
     @Provides
     @StartupPingerScope

--- a/heroic-core/src/main/java/com/spotify/heroic/generator/CoreGeneratorModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/generator/CoreGeneratorModule.java
@@ -21,6 +21,10 @@
 
 package com.spotify.heroic.generator;
 
+import static com.spotify.heroic.common.Optionals.mergeOptionalList;
+import static com.spotify.heroic.common.Optionals.pickOptional;
+import static java.util.Optional.empty;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -31,23 +35,22 @@ import com.spotify.heroic.generator.sine.SineMetricGeneratorModule;
 import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.spotify.heroic.common.Optionals.mergeOptionalList;
-import static com.spotify.heroic.common.Optionals.pickOptional;
-import static java.util.Optional.empty;
-
-@RequiredArgsConstructor
 @Module
 public class CoreGeneratorModule {
     private final List<MetricGeneratorModule> modules;
     private final MetadataGenerator metadata;
+
+    public CoreGeneratorModule(
+        final List<MetricGeneratorModule> modules,
+        final MetadataGenerator metadata) {
+        this.modules = modules;
+        this.metadata = metadata;
+    }
 
     public GeneratorComponent module(final PrimaryComponent primary) {
         return DaggerCoreGeneratorModule_C.builder().m(new M(primary)).build();
@@ -60,10 +63,13 @@ public class CoreGeneratorModule {
         CoreGeneratorManager generatorManager();
     }
 
-    @RequiredArgsConstructor
     @Module
     class M {
         private final PrimaryComponent primary;
+
+        M(final PrimaryComponent primary) {
+            this.primary = primary;
+        }
 
         @Provides
         @GeneratorScope
@@ -98,10 +104,12 @@ public class CoreGeneratorModule {
         return new Builder();
     }
 
-    @NoArgsConstructor
     public static class Builder {
         private Optional<List<MetricGeneratorModule>> metrics = empty();
         private Optional<MetadataGenerator> metadata = empty();
+
+        private Builder() {
+        }
 
         @JsonCreator
         public Builder(

--- a/heroic-core/src/main/java/com/spotify/heroic/http/HttpServerModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/HttpServerModule.java
@@ -25,20 +25,27 @@ import com.spotify.heroic.jetty.JettyServerConnector;
 import com.spotify.heroic.lifecycle.LifeCycle;
 import com.spotify.heroic.lifecycle.LifeCycleManager;
 import dagger.Provides;
-import lombok.RequiredArgsConstructor;
-
-import javax.inject.Named;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Optional;
+import javax.inject.Named;
 
-@RequiredArgsConstructor
 @dagger.Module
 public class HttpServerModule {
     private final InetSocketAddress bind;
     private final boolean enableCors;
     private final Optional<String> corsAllowOrigin;
     private final List<JettyServerConnector> connectors;
+
+    @java.beans.ConstructorProperties({ "bind", "enableCors", "corsAllowOrigin", "connectors" })
+    public HttpServerModule(final InetSocketAddress bind, final boolean enableCors,
+                            final Optional<String> corsAllowOrigin,
+                            final List<JettyServerConnector> connectors) {
+        this.bind = bind;
+        this.enableCors = enableCors;
+        this.corsAllowOrigin = corsAllowOrigin;
+        this.connectors = connectors;
+    }
 
     @Provides
     @Named("bind")

--- a/heroic-core/src/main/java/com/spotify/heroic/ingestion/CoreIngestionGroup.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/ingestion/CoreIngestionGroup.java
@@ -49,9 +49,7 @@ import java.util.Optional;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Supplier;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public class CoreIngestionGroup implements IngestionGroup {
     private final Tracer tracer = Tracing.getTracer();
 
@@ -64,6 +62,24 @@ public class CoreIngestionGroup implements IngestionGroup {
     private final Optional<MetricBackend> metric;
     private final Optional<MetadataBackend> metadata;
     private final Optional<SuggestBackend> suggest;
+
+    public CoreIngestionGroup(final AsyncFramework async,
+                              final Supplier<Filter> filter,
+                              final Semaphore writePermits,
+                              final IngestionManagerReporter reporter,
+                              final LongAdder ingested,
+                              final Optional<MetricBackend> metric,
+                              final Optional<MetadataBackend> metadata,
+                              final Optional<SuggestBackend> suggest) {
+        this.async = async;
+        this.filter = filter;
+        this.writePermits = writePermits;
+        this.reporter = reporter;
+        this.ingested = ingested;
+        this.metric = metric;
+        this.metadata = metadata;
+        this.suggest = suggest;
+    }
 
     @Override
     public Groups groups() {

--- a/heroic-core/src/main/java/com/spotify/heroic/ingestion/IngestionModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/ingestion/IngestionModule.java
@@ -21,6 +21,10 @@
 
 package com.spotify.heroic.ingestion;
 
+import static com.spotify.heroic.common.Optionals.pickOptional;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
 import com.spotify.heroic.ExtraParameters;
 import com.spotify.heroic.common.Optionals;
 import com.spotify.heroic.dagger.PrimaryComponent;
@@ -35,19 +39,9 @@ import com.spotify.heroic.suggest.SuggestComponent;
 import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
-
-import javax.inject.Named;
 import java.util.Optional;
+import javax.inject.Named;
 
-import static com.spotify.heroic.common.Optionals.pickOptional;
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
-
-@RequiredArgsConstructor
 public class IngestionModule {
     private static final String INGESTION_FILTER_PARAM = "ingestion.filter";
 
@@ -61,6 +55,20 @@ public class IngestionModule {
     private final boolean updateSuggestions;
     private final int maxConcurrentWrites;
     private final Optional<String> filter;
+
+    public IngestionModule(
+        final boolean updateMetrics,
+        final boolean updateMetadata,
+        final boolean updateSuggestions,
+        final int maxConcurrentWrites,
+        final Optional<String> filter
+    ) {
+        this.updateMetrics = updateMetrics;
+        this.updateMetadata = updateMetadata;
+        this.updateSuggestions = updateSuggestions;
+        this.maxConcurrentWrites = maxConcurrentWrites;
+        this.filter = filter;
+    }
 
     public IngestionComponent module(
         PrimaryComponent primary, SuggestComponent suggest, MetadataComponent metadata,
@@ -139,14 +147,29 @@ public class IngestionModule {
         return new Builder();
     }
 
-    @NoArgsConstructor(access = AccessLevel.PRIVATE)
-    @AllArgsConstructor
     public static class Builder {
         private Optional<Boolean> updateMetrics = empty();
         private Optional<Boolean> updateMetadata = empty();
         private Optional<Boolean> updateSuggestions = empty();
         private Optional<Integer> maxConcurrentWrites = empty();
         private Optional<String> filter = empty();
+
+        private Builder() {
+        }
+
+        public Builder(
+            final Optional<Boolean> updateMetrics,
+            final Optional<Boolean> updateMetadata,
+            final Optional<Boolean> updateSuggestions,
+            final Optional<Integer> maxConcurrentWrites,
+            final Optional<String> filter
+        ) {
+            this.updateMetrics = updateMetrics;
+            this.updateMetadata = updateMetadata;
+            this.updateSuggestions = updateSuggestions;
+            this.maxConcurrentWrites = maxConcurrentWrites;
+            this.filter = filter;
+        }
 
         public Builder updateAll() {
             this.updateMetrics = of(true);

--- a/heroic-core/src/main/java/com/spotify/heroic/jetty/Http2CJettyConnectionFactory.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/jetty/Http2CJettyConnectionFactory.java
@@ -22,13 +22,15 @@
 package com.spotify.heroic.jetty;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import lombok.RequiredArgsConstructor;
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.HttpConfiguration;
 
-@RequiredArgsConstructor
 public class Http2CJettyConnectionFactory implements JettyConnectionFactory {
+
+    public Http2CJettyConnectionFactory() {
+    }
+
     @Override
     public ConnectionFactory setup(final HttpConfiguration config) {
         return new HTTP2CServerConnectionFactory(config);

--- a/heroic-core/src/main/java/com/spotify/heroic/jetty/Http2JettyConnectionFactory.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/jetty/Http2JettyConnectionFactory.java
@@ -22,13 +22,15 @@
 package com.spotify.heroic.jetty;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import lombok.RequiredArgsConstructor;
 import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.HttpConfiguration;
 
-@RequiredArgsConstructor
 public class Http2JettyConnectionFactory implements JettyConnectionFactory {
+
+    public Http2JettyConnectionFactory() {
+    }
+
     @Override
     public ConnectionFactory setup(final HttpConfiguration config) {
         return new HTTP2ServerConnectionFactory(config);

--- a/heroic-core/src/main/java/com/spotify/heroic/jetty/HttpJettyConnectionFactory.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/jetty/HttpJettyConnectionFactory.java
@@ -22,13 +22,15 @@
 package com.spotify.heroic.jetty;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import lombok.RequiredArgsConstructor;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 
-@RequiredArgsConstructor
 public class HttpJettyConnectionFactory implements JettyConnectionFactory {
+
+    public HttpJettyConnectionFactory() {
+    }
+
     @Override
     public ConnectionFactory setup(final HttpConfiguration config) {
         return new HttpConnectionFactory(config);

--- a/heroic-core/src/main/java/com/spotify/heroic/jetty/JettyHttpConfiguration.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/jetty/JettyHttpConfiguration.java
@@ -23,17 +23,18 @@ package com.spotify.heroic.jetty;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
+import java.util.Optional;
 import org.eclipse.jetty.server.HttpConfiguration;
 
-import java.util.Optional;
-
-@RequiredArgsConstructor
 public class JettyHttpConfiguration {
     public static final boolean DEFAULT_SEND_SERVER_VERSION = false;
 
     private final boolean sendServerVersion;
+
+    @java.beans.ConstructorProperties({ "sendServerVersion" })
+    public JettyHttpConfiguration(final boolean sendServerVersion) {
+        this.sendServerVersion = sendServerVersion;
+    }
 
     public HttpConfiguration build() {
         final HttpConfiguration c = new HttpConfiguration();
@@ -45,13 +46,15 @@ public class JettyHttpConfiguration {
         return new Builder();
     }
 
-    @NoArgsConstructor
     public static class Builder {
         private Optional<Boolean> sendServerVersion = Optional.empty();
 
         @JsonCreator
         public Builder(@JsonProperty("sendServerVersion") Optional<Boolean> sendServerVersion) {
             this.sendServerVersion = sendServerVersion;
+        }
+
+        public Builder() {
         }
 
         public JettyHttpConfiguration build() {

--- a/heroic-core/src/main/java/com/spotify/heroic/jetty/JettyJSONErrorHandler.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/jetty/JettyJSONErrorHandler.java
@@ -24,23 +24,25 @@ package com.spotify.heroic.jetty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
 import com.spotify.heroic.ws.InternalErrorMessage;
-import lombok.RequiredArgsConstructor;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.server.Dispatcher;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-
-@RequiredArgsConstructor
 public class JettyJSONErrorHandler extends ErrorHandler {
     private static final String CONTENT_TYPE = "application/json; charset=UTF-8";
 
     private final ObjectMapper mapper;
+
+    @java.beans.ConstructorProperties({ "mapper" })
+    public JettyJSONErrorHandler(final ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
 
     @Override
     public void handle(

--- a/heroic-core/src/main/java/com/spotify/heroic/jetty/JettyServerConnector.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/jetty/JettyServerConnector.java
@@ -24,23 +24,30 @@ package com.spotify.heroic.jetty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Optional;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 
-import java.net.InetSocketAddress;
-import java.util.List;
-import java.util.Optional;
-
-@RequiredArgsConstructor
 public class JettyServerConnector {
     private final Optional<InetSocketAddress> address;
     private final List<JettyConnectionFactory> factories;
     private final Optional<String> defaultProtocol;
     private final JettyHttpConfiguration config;
+
+    @java.beans.ConstructorProperties({ "address", "factories", "defaultProtocol", "config" })
+    public JettyServerConnector(final Optional<InetSocketAddress> address,
+                                final List<JettyConnectionFactory> factories,
+                                final Optional<String> defaultProtocol,
+                                final JettyHttpConfiguration config) {
+        this.address = address;
+        this.factories = factories;
+        this.defaultProtocol = defaultProtocol;
+        this.config = config;
+    }
 
     public static List<JettyConnectionFactory.Builder> defaultFactories() {
         return ImmutableList.of(HttpJettyConnectionFactory.builder(),
@@ -68,7 +75,6 @@ public class JettyServerConnector {
         return new Builder();
     }
 
-    @NoArgsConstructor
     public static class Builder {
         private Optional<InetSocketAddress> address = Optional.empty();
         private Optional<List<JettyConnectionFactory.Builder>> factories = Optional.empty();
@@ -84,6 +90,9 @@ public class JettyServerConnector {
             this.address = address;
             this.factories = facts;
             this.defaultProtocol = defaultProtocol;
+        }
+
+        public Builder() {
         }
 
         public Builder address(final InetSocketAddress address) {

--- a/heroic-core/src/main/java/com/spotify/heroic/jetty/TLSJettyConnectionFactory.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/jetty/TLSJettyConnectionFactory.java
@@ -23,17 +23,13 @@ package com.spotify.heroic.jetty;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
+import java.util.Optional;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
-import java.util.Optional;
-
-@RequiredArgsConstructor
 public class TLSJettyConnectionFactory implements JettyConnectionFactory {
     private final Optional<String> keyStorePath;
     private final Optional<String> keyStorePassword;
@@ -41,6 +37,19 @@ public class TLSJettyConnectionFactory implements JettyConnectionFactory {
     private final Optional<Boolean> trustAll;
 
     private final String nextProtocol;
+
+    @java.beans.ConstructorProperties({ "keyStorePath", "keyStorePassword", "keyManagerPassword",
+                                        "trustAll", "nextProtocol" })
+    public TLSJettyConnectionFactory(final Optional<String> keyStorePath,
+                                     final Optional<String> keyStorePassword,
+                                     final Optional<String> keyManagerPassword,
+                                     final Optional<Boolean> trustAll, final String nextProtocol) {
+        this.keyStorePath = keyStorePath;
+        this.keyStorePassword = keyStorePassword;
+        this.keyManagerPassword = keyManagerPassword;
+        this.trustAll = trustAll;
+        this.nextProtocol = nextProtocol;
+    }
 
     @Override
     public ConnectionFactory setup(final HttpConfiguration config) {
@@ -56,7 +65,6 @@ public class TLSJettyConnectionFactory implements JettyConnectionFactory {
         return new Builder();
     }
 
-    @NoArgsConstructor
     public static class Builder implements JettyConnectionFactory.Builder {
         private Optional<String> keyStorePath = Optional.empty();
         private Optional<String> keyStorePassword = Optional.empty();
@@ -68,6 +76,9 @@ public class TLSJettyConnectionFactory implements JettyConnectionFactory {
         @JsonCreator
         public Builder(@JsonProperty("nextProtocol") final Optional<String> nextProtocol) {
             this.nextProtocol = nextProtocol;
+        }
+
+        public Builder() {
         }
 
         public Builder keyStorePath(final String keyStorePath) {

--- a/heroic-core/src/main/java/com/spotify/heroic/lifecycle/CoreLifeCycleManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/lifecycle/CoreLifeCycleManager.java
@@ -22,8 +22,6 @@
 package com.spotify.heroic.lifecycle;
 
 import com.spotify.heroic.dagger.PrimaryScope;
-import lombok.RequiredArgsConstructor;
-
 import javax.inject.Inject;
 
 @PrimaryScope
@@ -45,10 +43,14 @@ public class CoreLifeCycleManager implements LifeCycleManager {
         return new ManagedLifeCycle(id, instance);
     }
 
-    @RequiredArgsConstructor
     class ManagedLifeCycle implements LifeCycle {
         private final String id;
         private final LifeCycles instance;
+
+        public ManagedLifeCycle(final String id, final LifeCycles instance) {
+            this.id = id;
+            this.instance = instance;
+        }
 
         @Override
         public void install() {

--- a/heroic-core/src/main/java/com/spotify/heroic/metadata/MetadataBackendGroup.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metadata/MetadataBackendGroup.java
@@ -28,16 +28,20 @@ import com.spotify.heroic.common.SelectedGroup;
 import com.spotify.heroic.common.Statistics;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
 import lombok.ToString;
 
-import java.util.List;
-
-@RequiredArgsConstructor
 @ToString(of = {"backends"})
 public class MetadataBackendGroup implements MetadataBackend {
     private final SelectedGroup<MetadataBackend> backends;
     private final AsyncFramework async;
+
+    @java.beans.ConstructorProperties({ "backends", "async" })
+    public MetadataBackendGroup(final SelectedGroup<MetadataBackend> backends,
+                                final AsyncFramework async) {
+        this.backends = backends;
+        this.async = async;
+    }
 
     @Override
     public AsyncFuture<Void> configure() {

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -72,7 +72,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.inject.Inject;
 import javax.inject.Named;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.NotImplementedException;
@@ -471,7 +470,6 @@ public class LocalMetricManager implements MetricManager {
         }
     }
 
-    @RequiredArgsConstructor
     private abstract static class ResultCollector
         implements StreamCollector<FetchData.Result, FullQuery> {
         private static final String ROWS_ACCESSED = "rowsAccessed";
@@ -488,6 +486,24 @@ public class LocalMetricManager implements MetricManager {
         final boolean failOnLimits;
 
         private final ConcurrentHashMultiset<Long> rowDensityData = ConcurrentHashMultiset.create();
+
+        private ResultCollector(
+            final QuotaWatcher watcher,
+            final DataInMemoryReporter dataInMemoryReporter,
+            final AggregationInstance aggregation,
+            final AggregationSession session,
+            final ResultLimits limits,
+            final OptionalLimit groupLimit,
+            final boolean failOnLimits
+        ) {
+            this.watcher = watcher;
+            this.dataInMemoryReporter = dataInMemoryReporter;
+            this.aggregation = aggregation;
+            this.session = session;
+            this.limits = limits;
+            this.groupLimit = groupLimit;
+            this.failOnLimits = failOnLimits;
+        }
 
         @Override
         public void resolved(final FetchData.Result result) throws Exception {
@@ -628,7 +644,6 @@ public class LocalMetricManager implements MetricManager {
         }
     }
 
-    @RequiredArgsConstructor
     private static class QuotaWatcher implements FetchQuotaWatcher, RetainQuotaWatcher {
         private final long dataLimit;
         private final long retainLimit;
@@ -638,6 +653,13 @@ public class LocalMetricManager implements MetricManager {
         private final AtomicLong retained = new AtomicLong();
 
         private final LongAdder rowsAccessed = new LongAdder();
+
+        private QuotaWatcher(final long dataLimit, final long retainLimit,
+                             final DataInMemoryReporter dataInMemoryReporter) {
+            this.dataLimit = dataLimit;
+            this.retainLimit = retainLimit;
+            this.dataInMemoryReporter = dataInMemoryReporter;
+        }
 
         @Override
         public void readData(long n) {

--- a/heroic-core/src/main/java/com/spotify/heroic/querylogging/Slf4jQueryLogger.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/querylogging/Slf4jQueryLogger.java
@@ -34,16 +34,22 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @QueryLoggingScope
 @Slf4j
-@RequiredArgsConstructor
 public class Slf4jQueryLogger implements QueryLogger {
     private final Consumer<String> queryLog;
     private final ObjectMapper objectMapper;
     private final String component;
+
+    @java.beans.ConstructorProperties({ "queryLog", "objectMapper", "component" })
+    public Slf4jQueryLogger(final Consumer<String> queryLog, final ObjectMapper objectMapper,
+                            final String component) {
+        this.queryLog = queryLog;
+        this.objectMapper = objectMapper;
+        this.component = component;
+    }
 
     @Override
     public void logHttpQueryText(

--- a/heroic-core/src/main/java/com/spotify/heroic/servlet/ShutdownFilter.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/servlet/ShutdownFilter.java
@@ -24,7 +24,6 @@ package com.spotify.heroic.servlet;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
 import com.spotify.heroic.ws.InternalErrorMessage;
-import lombok.RequiredArgsConstructor;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -39,12 +38,16 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.function.Supplier;
 
-@RequiredArgsConstructor
 public class ShutdownFilter implements Filter {
     private static final String CONTENT_TYPE = "application/json; charset=UTF-8";
 
     private final Supplier<Boolean> stopping;
     private final ObjectMapper mapper;
+
+    public ShutdownFilter(final Supplier<Boolean> stopping, final ObjectMapper mapper) {
+        this.stopping = stopping;
+        this.mapper = mapper;
+    }
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/ShellServerClientThread.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/ShellServerClientThread.java
@@ -30,9 +30,6 @@ import com.spotify.heroic.shell.protocol.SimpleMessageVisitor;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.serializer.SerializerFramework;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -41,14 +38,24 @@ import java.io.Writer;
 import java.net.Socket;
 import java.nio.file.Path;
 import java.util.Arrays;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@RequiredArgsConstructor
 class ShellServerClientThread implements Runnable {
     final Socket socket;
     final ShellTasks tasks;
     final SerializerFramework serializer;
     final AsyncFramework async;
+
+    @java.beans.ConstructorProperties({ "socket", "tasks", "serializer", "async" })
+    public ShellServerClientThread(final Socket socket, final ShellTasks tasks,
+                                   final SerializerFramework serializer,
+                                   final AsyncFramework async) {
+        this.socket = socket;
+        this.tasks = tasks;
+        this.serializer = serializer;
+        this.async = async;
+    }
 
     @Override
     public void run() {

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/SuggestPerformance.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/SuggestPerformance.java
@@ -67,7 +67,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import lombok.Data;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.kohsuke.args4j.Option;
@@ -347,10 +346,15 @@ public class SuggestPerformance implements ShellTask {
     }
 
     @Data
-    @RequiredArgsConstructor
     public static class Suggestion {
         private final Optional<String> key;
         private final Optional<String> value;
+
+        @java.beans.ConstructorProperties({ "key", "value" })
+        public Suggestion(final Optional<String> key, final Optional<String> value) {
+            this.key = key;
+            this.value = value;
+        }
     }
 
     public static SuggestPerformance setup(final CoreComponent core) {

--- a/heroic-core/src/main/java/com/spotify/heroic/ws/ErrorMessage.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/ws/ErrorMessage.java
@@ -21,18 +21,11 @@
 
 package com.spotify.heroic.ws;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
 import javax.ws.rs.core.Response;
 
-@RequiredArgsConstructor
 public class ErrorMessage {
-    @Getter
     private final String message;
-    @Getter
     private final String reason;
-    @Getter
     private final int status;
 
     public ErrorMessage(final String message, final Response.Status status) {
@@ -41,7 +34,26 @@ public class ErrorMessage {
         this.status = status.getStatusCode();
     }
 
+    @java.beans.ConstructorProperties({ "message", "reason", "status" })
+    public ErrorMessage(final String message, final String reason, final int status) {
+        this.message = message;
+        this.reason = reason;
+        this.status = status;
+    }
+
     public String getType() {
         return "error";
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public String getReason() {
+        return this.reason;
+    }
+
+    public int getStatus() {
+        return this.status;
     }
 }

--- a/heroic-dist/src/main/java/com/spotify/heroic/reflection/ResourceFileLoader.java
+++ b/heroic-dist/src/main/java/com/spotify/heroic/reflection/ResourceFileLoader.java
@@ -23,8 +23,6 @@ package com.spotify.heroic.reflection;
 
 import com.google.common.base.Charsets;
 import com.spotify.heroic.HeroicService.Configuration;
-import lombok.RequiredArgsConstructor;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,8 +33,11 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-@RequiredArgsConstructor
 public final class ResourceFileLoader {
+
+    public ResourceFileLoader() {
+    }
+
     public static <T> List<ResourceInstance<T>> loadInstances(
         String path, ClassLoader loader, Class<T> expected
     ) throws ResourceException {

--- a/heroic-dist/src/main/java/com/spotify/heroic/reflection/ResourceInstance.java
+++ b/heroic-dist/src/main/java/com/spotify/heroic/reflection/ResourceInstance.java
@@ -22,7 +22,6 @@
 package com.spotify.heroic.reflection;
 
 import eu.toolchain.async.Transform;
-import lombok.RequiredArgsConstructor;
 
 /**
  * Wraps an instance of something that have been reflectively created from a single line of a
@@ -32,10 +31,15 @@ import lombok.RequiredArgsConstructor;
  * context that declares the instance, giving the user information of where the resource that caused
  * the error came from (e.g. which line from a particular file).
  */
-@RequiredArgsConstructor
 public class ResourceInstance<T> {
     private final ResourceLineContext ctx;
     private final T instance;
+
+    @java.beans.ConstructorProperties({ "ctx", "instance" })
+    public ResourceInstance(final ResourceLineContext ctx, final T instance) {
+        this.ctx = ctx;
+        this.instance = instance;
+    }
 
     public <R> R invoke(Transform<T, R> transform) throws ResourceException {
         try {

--- a/heroic-dist/src/main/java/com/spotify/heroic/reflection/ResourceLineContext.java
+++ b/heroic-dist/src/main/java/com/spotify/heroic/reflection/ResourceLineContext.java
@@ -21,12 +21,15 @@
 
 package com.spotify.heroic.reflection;
 
-import lombok.RequiredArgsConstructor;
-
-@RequiredArgsConstructor
 class ResourceLineContext {
     private final ResourcePathContext parent;
     private final int line;
+
+    @java.beans.ConstructorProperties({ "parent", "line" })
+    public ResourceLineContext(final ResourcePathContext parent, final int line) {
+        this.parent = parent;
+        this.line = line;
+    }
 
     public ResourceException exception(final String message) {
         return new ResourceException(parent.context() + ":" + line + ": " + message);

--- a/heroic-dist/src/main/java/com/spotify/heroic/reflection/ResourcePathContext.java
+++ b/heroic-dist/src/main/java/com/spotify/heroic/reflection/ResourcePathContext.java
@@ -21,11 +21,13 @@
 
 package com.spotify.heroic.reflection;
 
-import lombok.RequiredArgsConstructor;
-
-@RequiredArgsConstructor
 class ResourcePathContext {
     private final String context;
+
+    @java.beans.ConstructorProperties({ "context" })
+    public ResourcePathContext(final String context) {
+        this.context = context;
+    }
 
     public String context() {
         return context;

--- a/heroic-dist/src/test/java/com/spotify/heroic/cluster/CoreClusterManagerIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/cluster/CoreClusterManagerIT.java
@@ -19,7 +19,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
@@ -119,7 +118,6 @@ public class CoreClusterManagerIT extends AbstractLocalClusterIT {
         return t;
     }
 
-    @RequiredArgsConstructor
     private class ClusterRefreshThread extends Thread {
         private final ClusterManager clusterManager;
         private final int iterations;
@@ -127,6 +125,12 @@ public class CoreClusterManagerIT extends AbstractLocalClusterIT {
         private final AtomicReference<Exception> refreshError = new AtomicReference<>();
         private final AtomicInteger refreshes = new AtomicInteger();
         private final AtomicBoolean shutdown = new AtomicBoolean(false);
+
+        @java.beans.ConstructorProperties({ "clusterManager", "iterations" })
+        public ClusterRefreshThread(final ClusterManager clusterManager, final int iterations) {
+            this.clusterManager = clusterManager;
+            this.iterations = iterations;
+        }
 
         @Override
         public void run() {

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/AbstractElasticsearchBackend.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/AbstractElasticsearchBackend.java
@@ -26,15 +26,18 @@ import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.ResolvableFuture;
 import eu.toolchain.async.Transform;
 import javax.inject.Provider;
-import lombok.RequiredArgsConstructor;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ListenableActionFuture;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 
-@RequiredArgsConstructor
 public class AbstractElasticsearchBackend {
     protected final AsyncFramework async;
+
+    @java.beans.ConstructorProperties({ "async" })
+    public AbstractElasticsearchBackend(final AsyncFramework async) {
+        this.async = async;
+    }
 
     protected <T extends ActionResponse> AsyncFuture<T> bind(
         final ListenableActionFuture<T> actionFuture

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/AbstractElasticsearchMetadataBackend.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/AbstractElasticsearchMetadataBackend.java
@@ -44,7 +44,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 import org.elasticsearch.action.ListenableActionFuture;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -87,7 +86,6 @@ public abstract class AbstractElasticsearchMetadataBackend extends AbstractElast
         return bind(request.execute()).lazyTransform(scrollTransform);
     }
 
-    @RequiredArgsConstructor
     public static class ScrollTransform<T> implements LazyTransform<SearchResponse, LimitedSet<T>> {
         private final AsyncFramework async;
         private final OptionalLimit limit;
@@ -97,6 +95,19 @@ public abstract class AbstractElasticsearchMetadataBackend extends AbstractElast
         final Set<T> results = new HashSet<>();
         final Function<SearchHit, T> converter;
         final Function<String, Supplier<AsyncFuture<SearchResponse>>> scrollFactory;
+
+        @java.beans.ConstructorProperties({ "async", "limit", "converter", "scrollFactory" })
+        public ScrollTransform(
+            final AsyncFramework async,
+            final OptionalLimit limit,
+            final Function<SearchHit, T> converter,
+            final Function<String, Supplier<AsyncFuture<SearchResponse>>> scrollFactory
+        ) {
+            this.async = async;
+            this.limit = limit;
+            this.converter = converter;
+            this.scrollFactory = scrollFactory;
+        }
 
         @Override
         public AsyncFuture<LimitedSet<T>> transform(final SearchResponse response)
@@ -134,7 +145,6 @@ public abstract class AbstractElasticsearchMetadataBackend extends AbstractElast
         }
     }
 
-    @RequiredArgsConstructor
     public static class ScrollTransformStream<T> implements LazyTransform<SearchResponse, Void> {
         private final OptionalLimit limit;
         private final Function<Set<T>, AsyncFuture<Void>> seriesFunction;
@@ -142,6 +152,20 @@ public abstract class AbstractElasticsearchMetadataBackend extends AbstractElast
         private final Function<String, Supplier<AsyncFuture<SearchResponse>>> scrollFactory;
 
         int size = 0;
+
+        @java.beans.ConstructorProperties({ "limit", "seriesFunction", "converter",
+                                            "scrollFactory" })
+        public ScrollTransformStream(
+            final OptionalLimit limit,
+            final Function<Set<T>, AsyncFuture<Void>> seriesFunction,
+            final Function<SearchHit, T> converter,
+            final Function<String, Supplier<AsyncFuture<SearchResponse>>> scrollFactory
+        ) {
+            this.limit = limit;
+            this.seriesFunction = seriesFunction;
+            this.converter = converter;
+            this.scrollFactory = scrollFactory;
+        }
 
         @Override
         public AsyncFuture<Void> transform(final SearchResponse response) throws Exception {

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/Connection.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/Connection.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.ActionListener;
@@ -47,7 +46,6 @@ import org.elasticsearch.client.IndicesAdminClient;
  * Common connection abstraction between Node and TransportClient.
  */
 @Slf4j
-@RequiredArgsConstructor
 @ToString(of = {"index", "client"})
 public class Connection {
     private final AsyncFramework async;
@@ -56,6 +54,17 @@ public class Connection {
 
     private final String templateName;
     private final BackendType type;
+
+    @java.beans.ConstructorProperties({ "async", "index", "client", "templateName", "type" })
+    public Connection(final AsyncFramework async, final IndexMapping index,
+                      final ClientSetup.ClientWrapper client, final String templateName,
+                      final BackendType type) {
+        this.async = async;
+        this.index = index;
+        this.client = client;
+        this.templateName = templateName;
+        this.type = type;
+    }
 
     public AsyncFuture<Void> close() {
         final List<AsyncFuture<Void>> futures = new ArrayList<>();

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/ConnectionModule.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/ConnectionModule.java
@@ -21,6 +21,8 @@
 
 package com.spotify.heroic.elasticsearch;
 
+import static java.util.Optional.ofNullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -33,13 +35,9 @@ import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.Managed;
 import eu.toolchain.async.ManagedSetup;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.List;
 import java.util.Map;
-
-import static java.util.Optional.ofNullable;
+import lombok.extern.slf4j.Slf4j;
 
 @Module
 @Slf4j
@@ -90,9 +88,13 @@ public class ConnectionModule {
         return new Provider(async);
     }
 
-    @RequiredArgsConstructor
     public class Provider {
         private final AsyncFramework async;
+
+        @java.beans.ConstructorProperties({ "async" })
+        public Provider(final AsyncFramework async) {
+            this.async = async;
+        }
 
         public Managed<Connection> construct(
             final String defaultTemplateName, final BackendType type

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/DefaultRateLimitedCache.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/DefaultRateLimitedCache.java
@@ -26,8 +26,6 @@ import io.opencensus.common.Scope;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
-import lombok.RequiredArgsConstructor;
-
 import java.util.concurrent.ConcurrentMap;
 
 /**
@@ -36,11 +34,17 @@ import java.util.concurrent.ConcurrentMap;
  * @param <K>
  * @author mehrdad
  */
-@RequiredArgsConstructor
 public class DefaultRateLimitedCache<K> implements RateLimitedCache<K> {
     private final ConcurrentMap<K, Boolean> cache;
     private final RateLimiter rateLimiter;
     private final Tracer tracer = Tracing.getTracer();
+
+    @java.beans.ConstructorProperties({ "cache", "rateLimiter" })
+    public DefaultRateLimitedCache(final ConcurrentMap<K, Boolean> cache,
+                                   final RateLimiter rateLimiter) {
+        this.cache = cache;
+        this.rateLimiter = rateLimiter;
+    }
 
     public boolean acquire(K key, final Runnable cacheHit) {
         try (Scope ss = tracer.spanBuilder("DefaultRateLimitedCache").startScopedSpan()) {

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/DisabledRateLimitedCache.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/DisabledRateLimitedCache.java
@@ -22,16 +22,19 @@
 package com.spotify.heroic.elasticsearch;
 
 import java.util.concurrent.ConcurrentMap;
-import lombok.RequiredArgsConstructor;
 
 /**
  * A cache to reduce writes to Elasticsearch.
  *
  * Main difference from {@link DefaultRateLimitedCache} is there is no rate limiting enforced.
  */
-@RequiredArgsConstructor
 public class DisabledRateLimitedCache<K> implements RateLimitedCache<K> {
     private final ConcurrentMap<K, Boolean> cache;
+
+    @java.beans.ConstructorProperties({ "cache" })
+    public DisabledRateLimitedCache(final ConcurrentMap<K, Boolean> cache) {
+        this.cache = cache;
+    }
 
     @Override
     public boolean acquire(K key, final Runnable cacheHit) {

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/DistributedRateLimitedCache.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/DistributedRateLimitedCache.java
@@ -37,7 +37,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -50,7 +49,6 @@ import lombok.extern.slf4j.Slf4j;
  * @author dmichel
  */
 @Slf4j
-@RequiredArgsConstructor
 public class DistributedRateLimitedCache<K> implements RateLimitedCache<K> {
 
   private final ConcurrentMap<K, Boolean> cache;
@@ -61,6 +59,20 @@ public class DistributedRateLimitedCache<K> implements RateLimitedCache<K> {
 
   private static final HashFunction HASH_FUNCTION = Hashing.murmur3_128();
   private final Tracer tracer = Tracing.getTracer();
+
+  @java.beans.ConstructorProperties({ "cache", "rateLimiter", "memcachedClient",
+                                      "memcachedTtlSeconds", "memcachedReporter" })
+  public DistributedRateLimitedCache(final ConcurrentMap<K, Boolean> cache,
+                                     final RateLimiter rateLimiter,
+                                     final MemcacheClient memcachedClient,
+                                     final int memcachedTtlSeconds,
+                                     final MemcachedReporter memcachedReporter) {
+    this.cache = cache;
+    this.rateLimiter = rateLimiter;
+    this.memcachedClient = memcachedClient;
+    this.memcachedTtlSeconds = memcachedTtlSeconds;
+    this.memcachedReporter = memcachedReporter;
+  }
 
 
   /**

--- a/heroic-loading/src/main/java/com/spotify/heroic/aggregation/CoreAggregationFactory.java
+++ b/heroic-loading/src/main/java/com/spotify/heroic/aggregation/CoreAggregationFactory.java
@@ -22,14 +22,16 @@
 package com.spotify.heroic.aggregation;
 
 import com.spotify.heroic.grammar.Expression;
-import lombok.RequiredArgsConstructor;
-
 import java.util.List;
 import java.util.Map;
 
-@RequiredArgsConstructor
 public class CoreAggregationFactory implements AggregationFactory {
     final Map<String, AggregationDSL> builderMap;
+
+    @java.beans.ConstructorProperties({ "builderMap" })
+    public CoreAggregationFactory(final Map<String, AggregationDSL> builderMap) {
+        this.builderMap = builderMap;
+    }
 
     @Override
     public Aggregation build(String name, List<Expression> args, Map<String, Expression> keywords) {

--- a/heroic-loading/src/main/java/com/spotify/heroic/aggregation/CoreAggregationRegistry.java
+++ b/heroic-loading/src/main/java/com/spotify/heroic/aggregation/CoreAggregationRegistry.java
@@ -25,8 +25,6 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import eu.toolchain.serializer.Serializer;
-import lombok.RequiredArgsConstructor;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,7 +36,6 @@ import java.util.Map;
  *
  * @author udoprog
  */
-@RequiredArgsConstructor
 public class CoreAggregationRegistry implements AggregationRegistry {
     final Serializer<String> string;
 
@@ -47,6 +44,11 @@ public class CoreAggregationRegistry implements AggregationRegistry {
     final Map<String, AggregationDSL> builderMap = new HashMap<>();
 
     private final Object lock = new Object();
+
+    @java.beans.ConstructorProperties({ "string" })
+    public CoreAggregationRegistry(final Serializer<String> string) {
+        this.string = string;
+    }
 
     @Override
     public <A extends Aggregation, I extends AggregationInstance> void register(

--- a/heroic-loading/src/main/java/com/spotify/heroic/dagger/LoadingModule.java
+++ b/heroic-loading/src/main/java/com/spotify/heroic/dagger/LoadingModule.java
@@ -54,9 +54,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Named;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 @Module
 public class LoadingModule {
     private final ExecutorService executor;
@@ -64,6 +62,15 @@ public class LoadingModule {
     private final boolean managedExecutor;
     private final HeroicConfiguration options;
     private final ExtraParameters parameters;
+
+    public LoadingModule(final ExecutorService executor, final boolean managedExecutor,
+                         final HeroicConfiguration options,
+                         final ExtraParameters parameters) {
+        this.executor = executor;
+        this.managedExecutor = managedExecutor;
+        this.options = options;
+        this.parameters = parameters;
+    }
 
     @Provides
     @LoadingScope

--- a/heroic-loading/src/main/java/com/spotify/heroic/filter/FilterRegistry.java
+++ b/heroic-loading/src/main/java/com/spotify/heroic/filter/FilterRegistry.java
@@ -44,7 +44,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
 
 /**
  * Registry of all known filters.
@@ -61,7 +60,6 @@ import lombok.RequiredArgsConstructor;
  *
  * @see com.spotify.heroic.filter.Filter
  */
-@RequiredArgsConstructor
 public class FilterRegistry {
     private final Map<String, FilterEncoding<? extends Filter>> deserializers = new HashMap<>();
 
@@ -70,6 +68,9 @@ public class FilterRegistry {
 
     private final HashMap<Class<? extends Filter>, String> typeMapping = new HashMap<>();
     private final HashMap<String, Class<? extends Filter>> typeNameMapping = new HashMap<>();
+
+    public FilterRegistry() {
+    }
 
     public <T extends Filter> void registerList(
         String id, Class<T> type, FilterEncoding<T> s
@@ -143,9 +144,13 @@ public class FilterRegistry {
         return annotation.value();
     }
 
-    @RequiredArgsConstructor
     private static final class FilterJsonSerializer extends JsonSerializer<Filter> {
         private final FilterEncoding<Filter> serializer;
+
+        @java.beans.ConstructorProperties({ "serializer" })
+        public FilterJsonSerializer(final FilterEncoding<Filter> serializer) {
+            this.serializer = serializer;
+        }
 
         @Override
         public void serialize(Filter value, JsonGenerator g, SerializerProvider provider)
@@ -158,9 +163,13 @@ public class FilterRegistry {
             g.writeEndArray();
         }
 
-        @RequiredArgsConstructor
         private static final class EncoderImpl implements FilterEncoding.Encoder {
             private final JsonGenerator generator;
+
+            @java.beans.ConstructorProperties({ "generator" })
+            public EncoderImpl(final JsonGenerator generator) {
+                this.generator = generator;
+            }
 
             @Override
             public void string(String string) throws IOException {
@@ -177,11 +186,20 @@ public class FilterRegistry {
     /**
      * Provides both array, and object based deserialization for filters.
      */
-    @RequiredArgsConstructor
     static class FilterJsonDeserializer extends JsonDeserializer<Filter> {
         final Map<String, FilterEncoding<? extends Filter>> deserializers;
         final HashMap<String, Class<? extends Filter>> typeNameMapping;
         final QueryParser parser;
+
+        @java.beans.ConstructorProperties({ "deserializers", "typeNameMapping", "parser" })
+        public FilterJsonDeserializer(
+            final Map<String, FilterEncoding<? extends Filter>> deserializers,
+            final HashMap<String, Class<? extends Filter>> typeNameMapping,
+            final QueryParser parser) {
+            this.deserializers = deserializers;
+            this.typeNameMapping = typeNameMapping;
+            this.parser = parser;
+        }
 
         @Override
         public Filter deserialize(JsonParser p, DeserializationContext c) throws IOException {
@@ -265,12 +283,17 @@ public class FilterRegistry {
             return parser.parseFilter(filter.filter());
         }
 
-        @RequiredArgsConstructor
         private static final class Decoder implements FilterEncoding.Decoder {
             private final JsonParser parser;
             private final DeserializationContext c;
 
             private int index = 0;
+
+            @java.beans.ConstructorProperties({ "parser", "c" })
+            public Decoder(final JsonParser parser, final DeserializationContext c) {
+                this.parser = parser;
+                this.c = c;
+            }
 
             @Override
             public Optional<String> string() throws IOException {

--- a/heroic-loading/src/main/java/com/spotify/heroic/filter/MultiArgumentsFilterBase.java
+++ b/heroic-loading/src/main/java/com/spotify/heroic/filter/MultiArgumentsFilterBase.java
@@ -24,14 +24,11 @@ package com.spotify.heroic.filter;
 import com.google.common.collect.ImmutableList;
 import com.spotify.heroic.common.BiConsumerIO;
 import com.spotify.heroic.common.FunctionIO;
-import lombok.RequiredArgsConstructor;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-@RequiredArgsConstructor
 public class MultiArgumentsFilterBase<T extends Filter, A> implements FilterEncoding<T> {
     private final Function<List<A>, T> builder;
     private final Function<T, List<A>> argument;
@@ -48,6 +45,17 @@ public class MultiArgumentsFilterBase<T extends Filter, A> implements FilterEnco
 
         this.decode = encoding.getDecoder();
         this.encode = encoding.getEncoder();
+    }
+
+    @java.beans.ConstructorProperties({ "builder", "argument", "decode", "encode" })
+    public MultiArgumentsFilterBase(final Function<List<A>, T> builder,
+                                    final Function<T, List<A>> argument,
+                                    final FunctionIO<Decoder, Optional<A>> decode,
+                                    final BiConsumerIO<Encoder, A> encode) {
+        this.builder = builder;
+        this.argument = argument;
+        this.decode = decode;
+        this.encode = encode;
     }
 
     @Override

--- a/heroic-loading/src/main/java/com/spotify/heroic/filter/NoArgumentFilterBase.java
+++ b/heroic-loading/src/main/java/com/spotify/heroic/filter/NoArgumentFilterBase.java
@@ -21,13 +21,15 @@
 
 package com.spotify.heroic.filter;
 
-import lombok.RequiredArgsConstructor;
-
 import javax.inject.Provider;
 
-@RequiredArgsConstructor
 public class NoArgumentFilterBase<T extends Filter> implements FilterEncoding<T> {
     private final Provider<T> provider;
+
+    @java.beans.ConstructorProperties({ "provider" })
+    public NoArgumentFilterBase(final Provider<T> provider) {
+        this.provider = provider;
+    }
 
     @Override
     public T deserialize(Decoder decoder) {

--- a/heroic-loading/src/main/java/com/spotify/heroic/filter/OneArgumentFilterEncoding.java
+++ b/heroic-loading/src/main/java/com/spotify/heroic/filter/OneArgumentFilterEncoding.java
@@ -23,13 +23,10 @@ package com.spotify.heroic.filter;
 
 import com.spotify.heroic.common.BiConsumerIO;
 import com.spotify.heroic.common.FunctionIO;
-import lombok.RequiredArgsConstructor;
-
 import java.io.IOException;
 import java.util.Optional;
 import java.util.function.Function;
 
-@RequiredArgsConstructor
 public class OneArgumentFilterEncoding<T extends Filter, A> implements FilterEncoding<T> {
     private final Function<A, T> builder;
     private final Function<T, A> firstArgument;
@@ -46,6 +43,17 @@ public class OneArgumentFilterEncoding<T extends Filter, A> implements FilterEnc
 
         this.decodeFirst = first.getDecoder();
         this.encodeFirst = first.getEncoder();
+    }
+
+    @java.beans.ConstructorProperties({ "builder", "firstArgument", "decodeFirst", "encodeFirst" })
+    public OneArgumentFilterEncoding(final Function<A, T> builder,
+                                     final Function<T, A> firstArgument,
+                                     final FunctionIO<Decoder, Optional<A>> decodeFirst,
+                                     final BiConsumerIO<Encoder, A> encodeFirst) {
+        this.builder = builder;
+        this.firstArgument = firstArgument;
+        this.decodeFirst = decodeFirst;
+        this.encodeFirst = encodeFirst;
     }
 
     @Override

--- a/heroic-loading/src/main/java/com/spotify/heroic/lifecycle/CoreLifeCycleRegistry.java
+++ b/heroic-loading/src/main/java/com/spotify/heroic/lifecycle/CoreLifeCycleRegistry.java
@@ -23,8 +23,6 @@ package com.spotify.heroic.lifecycle;
 
 import com.google.common.collect.ImmutableList;
 import eu.toolchain.async.AsyncFuture;
-import lombok.RequiredArgsConstructor;
-
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -81,10 +79,15 @@ public class CoreLifeCycleRegistry implements LifeCycleRegistry {
         stoppers.add(new Hook(id, stopper));
     }
 
-    @RequiredArgsConstructor
     static class Hook implements LifeCycleNamedHook<AsyncFuture<Void>> {
         private final String id;
         private final LifeCycleHook<AsyncFuture<Void>> parent;
+
+        @java.beans.ConstructorProperties({ "id", "parent" })
+        public Hook(final String id, final LifeCycleHook<AsyncFuture<Void>> parent) {
+            this.id = id;
+            this.parent = parent;
+        }
 
         @Override
         public AsyncFuture<Void> get() throws Exception {

--- a/heroic-loading/src/main/java/com/spotify/heroic/scheduler/DefaultScheduler.java
+++ b/heroic-loading/src/main/java/com/spotify/heroic/scheduler/DefaultScheduler.java
@@ -21,20 +21,22 @@
 
 package com.spotify.heroic.scheduler;
 
-import lombok.RequiredArgsConstructor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-
 @Slf4j
-@RequiredArgsConstructor
 @ToString(exclude = {"scheduler"})
 public class DefaultScheduler implements Scheduler {
     private static final String UNKNOWN = "unknown";
 
     private final ScheduledExecutorService scheduler;
+
+    @java.beans.ConstructorProperties({ "scheduler" })
+    public DefaultScheduler(final ScheduledExecutorService scheduler) {
+        this.scheduler = scheduler;
+    }
 
     @Override
     public void periodically(long value, final TimeUnit unit, final Task task) {

--- a/heroic-parser/src/main/java/com/spotify/heroic/grammar/QueryListener.java
+++ b/heroic-parser/src/main/java/com/spotify/heroic/grammar/QueryListener.java
@@ -67,12 +67,6 @@ import com.spotify.heroic.grammar.HeroicQueryParser.SourceRangeRelativeContext;
 import com.spotify.heroic.grammar.HeroicQueryParser.StringContext;
 import com.spotify.heroic.grammar.HeroicQueryParser.WhereContext;
 import com.spotify.heroic.metric.MetricType;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-import org.antlr.v4.runtime.CommonToken;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.tree.ParseTree;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -80,9 +74,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Stack;
 import java.util.concurrent.TimeUnit;
+import lombok.Data;
+import org.antlr.v4.runtime.CommonToken;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.ParseTree;
 
 @SuppressWarnings("unchecked")
-@RequiredArgsConstructor
 public class QueryListener extends HeroicQueryBaseListener {
     private static final Object KEY_VALUES_MARK = new ObjectMark("KEY_VALUES_MARK");
     private static final Object LIST_MARK = new ObjectMark("LIST_MARK");
@@ -90,6 +87,9 @@ public class QueryListener extends HeroicQueryBaseListener {
 
     public static final Object EMPTY = new ObjectMark("EMPTY");
     public static final Object NOT_EMPTY = new ObjectMark("NOT_EMPTY");
+
+    public QueryListener() {
+    }
 
     enum QueryMark {
         QUERY, SELECT, WHERE, FROM, WITH, AS
@@ -825,9 +825,13 @@ public class QueryListener extends HeroicQueryBaseListener {
         private final Map<String, Expression> map;
     }
 
-    @RequiredArgsConstructor
     static class ObjectMark {
         private final String name;
+
+        @java.beans.ConstructorProperties({ "name" })
+        public ObjectMark(final String name) {
+            this.name = name;
+        }
 
         @Override
         public String toString() {

--- a/heroic-parser/src/test/java/com/spotify/heroic/grammar/QueryParserTest.java
+++ b/heroic-parser/src/test/java/com/spotify/heroic/grammar/QueryParserTest.java
@@ -1,5 +1,16 @@
 package com.spotify.heroic.grammar;
 
+import static com.spotify.heroic.grammar.Expression.duration;
+import static com.spotify.heroic.grammar.Expression.empty;
+import static com.spotify.heroic.grammar.Expression.function;
+import static com.spotify.heroic.grammar.Expression.integer;
+import static com.spotify.heroic.grammar.Expression.let;
+import static com.spotify.heroic.grammar.Expression.list;
+import static com.spotify.heroic.grammar.Expression.range;
+import static com.spotify.heroic.grammar.Expression.reference;
+import static com.spotify.heroic.grammar.Expression.string;
+import static org.junit.Assert.assertEquals;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.spotify.heroic.filter.AndFilter;
@@ -14,30 +25,17 @@ import com.spotify.heroic.filter.RegexFilter;
 import com.spotify.heroic.filter.StartsWithFilter;
 import com.spotify.heroic.filter.TrueFilter;
 import com.spotify.heroic.metric.MetricType;
-import lombok.RequiredArgsConstructor;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-
-import static com.spotify.heroic.grammar.Expression.duration;
-import static com.spotify.heroic.grammar.Expression.empty;
-import static com.spotify.heroic.grammar.Expression.function;
-import static com.spotify.heroic.grammar.Expression.integer;
-import static com.spotify.heroic.grammar.Expression.let;
-import static com.spotify.heroic.grammar.Expression.list;
-import static com.spotify.heroic.grammar.Expression.range;
-import static com.spotify.heroic.grammar.Expression.reference;
-import static com.spotify.heroic.grammar.Expression.string;
-import static org.junit.Assert.assertEquals;
 
 @RunWith(MockitoJUnitRunner.class)
 public class QueryParserTest {
@@ -304,7 +302,6 @@ public class QueryParserTest {
         return new QueryBuilder(ctx);
     }
 
-    @RequiredArgsConstructor
     static class QueryBuilder {
         private final Context context;
 
@@ -314,6 +311,11 @@ public class QueryParserTest {
         private Optional<Filter> filter = Optional.empty();
         private Map<String, Expression> with = ImmutableMap.of();
         private Map<String, Expression> as = ImmutableMap.of();
+
+        @java.beans.ConstructorProperties({ "context" })
+        public QueryBuilder(final Context context) {
+            this.context = context;
+        }
 
         public QueryBuilder select(final Expression select) {
             this.select = Optional.of(select);

--- a/heroic-shell/src/main/java/com/spotify/heroic/HeroicInteractiveShell.java
+++ b/heroic-shell/src/main/java/com/spotify/heroic/HeroicInteractiveShell.java
@@ -29,14 +29,6 @@ import com.spotify.heroic.shell.QuoteParser;
 import com.spotify.heroic.shell.ShellIO;
 import com.spotify.heroic.shell.Tasks;
 import eu.toolchain.async.AsyncFuture;
-import jline.console.ConsoleReader;
-import jline.console.UserInterruptException;
-import jline.console.completer.StringsCompleter;
-import jline.console.history.FileHistory;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -45,9 +37,14 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import jline.console.ConsoleReader;
+import jline.console.UserInterruptException;
+import jline.console.completer.StringsCompleter;
+import jline.console.history.FileHistory;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
-@RequiredArgsConstructor
 public class HeroicInteractiveShell {
     final ConsoleReader reader;
     final List<CommandDefinition> commands;
@@ -57,6 +54,15 @@ public class HeroicInteractiveShell {
 
     // mutable state, a.k.a. settings
     int timeout = 10;
+
+    @java.beans.ConstructorProperties({ "reader", "commands", "history" })
+    public HeroicInteractiveShell(final ConsoleReader reader,
+                                  final List<CommandDefinition> commands,
+                                  final FileHistory history) {
+        this.reader = reader;
+        this.commands = commands;
+        this.history = history;
+    }
 
     public void run(final CoreInterface core) throws Exception {
         final PrintWriter out = new PrintWriter(reader.getOutput());

--- a/heroic-shell/src/main/java/com/spotify/heroic/HeroicShell.java
+++ b/heroic-shell/src/main/java/com/spotify/heroic/HeroicShell.java
@@ -34,14 +34,6 @@ import com.spotify.heroic.shell.TaskParameters;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.TinyAsync;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
-import org.kohsuke.args4j.CmdLineException;
-import org.kohsuke.args4j.CmdLineParser;
-import org.kohsuke.args4j.Option;
-
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -57,6 +49,12 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Executors;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
 
 @Slf4j
 public class HeroicShell {
@@ -394,10 +392,15 @@ public class HeroicShell {
         private List<String> parameters = new ArrayList<>();
     }
 
-    @RequiredArgsConstructor
     static class ParsedArguments {
         final List<String> primary;
         final List<String> child;
+
+        @java.beans.ConstructorProperties({ "primary", "child" })
+        public ParsedArguments(final List<String> primary, final List<String> child) {
+            this.primary = primary;
+            this.child = child;
+        }
 
         public static ParsedArguments parse(String[] args) {
             final List<String> primary = new ArrayList<>();

--- a/heroic-test/src/main/java/com/spotify/heroic/test/FakeModuleLoader.java
+++ b/heroic-test/src/main/java/com/spotify/heroic/test/FakeModuleLoader.java
@@ -45,12 +45,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public class FakeModuleLoader {
     private final LoadingComponent loading;
     private final ObjectMapper json;
+
+    @java.beans.ConstructorProperties({ "loading", "json" })
+    public FakeModuleLoader(final LoadingComponent loading, final ObjectMapper json) {
+        this.loading = loading;
+        this.json = json;
+    }
 
     public FakeModuleLoader load(final Class<? extends HeroicModule> module) {
         final HeroicModule instance = ReflectionUtils.buildInstance(module);

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/ElasticsearchMetadataModule.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/ElasticsearchMetadataModule.java
@@ -69,7 +69,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import javax.inject.Named;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
 
 @Data
@@ -181,7 +180,6 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
         LifeCycle life();
     }
 
-    @RequiredArgsConstructor
     @Module
     class M {
         public static final String ELASTICSEARCH_CONFIGURE_PARAM = "elasticsearch.configure";
@@ -192,6 +190,21 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
         private final Double writesPerSecond;
         private final Long rateLimitSlowStartSeconds;
         private final Long writeCacheDurationMinutes;
+
+        @java.beans.ConstructorProperties({ "groups", "templateName", "backendType",
+                                            "writesPerSecond",
+                                            "rateLimitSlowStartSeconds",
+                                            "writeCacheDurationMinutes" })
+        public M(final Groups groups, final String templateName, final BackendType backendType,
+                 final Double writesPerSecond, final Long rateLimitSlowStartSeconds,
+                 final Long writeCacheDurationMinutes) {
+            this.groups = groups;
+            this.templateName = templateName;
+            this.backendType = backendType;
+            this.writesPerSecond = writesPerSecond;
+            this.rateLimitSlowStartSeconds = rateLimitSlowStartSeconds;
+            this.writeCacheDurationMinutes = writeCacheDurationMinutes;
+        }
 
         @Provides
         @ElasticsearchScope

--- a/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsMetricBackend.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsMetricBackend.java
@@ -39,14 +39,19 @@ import eu.toolchain.async.AsyncFuture;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.function.Consumer;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @ToString
-@RequiredArgsConstructor
 class BigtableAnalyticsMetricBackend implements MetricBackend {
     private final BigtableMetricAnalytics analytics;
     private final MetricBackend backend;
+
+    @java.beans.ConstructorProperties({ "analytics", "backend" })
+    public BigtableAnalyticsMetricBackend(final BigtableMetricAnalytics analytics,
+                                          final MetricBackend backend) {
+        this.analytics = analytics;
+        this.backend = backend;
+    }
 
     @Override
     public boolean isReady() {

--- a/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsModule.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsModule.java
@@ -43,12 +43,9 @@ import eu.toolchain.async.ManagedSetup;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import javax.inject.Named;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @ToString
-@RequiredArgsConstructor
 @Module
 public class BigtableAnalyticsModule implements AnalyticsModule {
     public static final String DEFAULT_CLUSTER = "heroic";
@@ -64,6 +61,16 @@ public class BigtableAnalyticsModule implements AnalyticsModule {
     private final String cluster;
     private final CredentialsBuilder credentials;
     private final int maxPendingReports;
+
+    @java.beans.ConstructorProperties({ "project", "cluster", "credentials", "maxPendingReports" })
+    public BigtableAnalyticsModule(final String project, final String cluster,
+                                   final CredentialsBuilder credentials,
+                                   final int maxPendingReports) {
+        this.project = project;
+        this.cluster = cluster;
+        this.credentials = credentials;
+        this.maxPendingReports = maxPendingReports;
+    }
 
     @Override
     public AnalyticsComponent module(final PrimaryComponent primary) {
@@ -137,7 +144,6 @@ public class BigtableAnalyticsModule implements AnalyticsModule {
         return new Builder();
     }
 
-    @NoArgsConstructor
     public static class Builder implements AnalyticsModule.Builder {
         private Optional<String> project = Optional.empty();
         private Optional<String> instance = Optional.empty();
@@ -155,6 +161,9 @@ public class BigtableAnalyticsModule implements AnalyticsModule {
             this.instance = instance;
             this.credentials = credentials;
             this.maxPendingReports = maxPendingReports;
+        }
+
+        public Builder() {
         }
 
         public Builder project(String project) {

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
@@ -24,12 +24,12 @@ package com.spotify.heroic.metric.bigtable;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.bigtable.grpc.scanner.FlatRow;
+import com.google.cloud.bigtable.util.RowKeyUtil;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
-import com.google.cloud.bigtable.grpc.scanner.FlatRow;
-import com.google.cloud.bigtable.util.RowKeyUtil;
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Groups;
 import com.spotify.heroic.common.RequestTimer;
@@ -86,7 +86,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.inject.Named;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
@@ -577,7 +576,6 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
         // @formatter:on
     }
 
-    @RequiredArgsConstructor
     private static final class PreparedQuery {
         private final ByteString rowKeyStart;
         private final ByteString rowKeyEnd;
@@ -586,6 +584,24 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
         private final ByteString endQualifierClosed;
         private final BiFunction<Long, ByteString, Metric> deserializer;
         private final long base;
+
+        @java.beans.ConstructorProperties({ "rowKeyStart", "rowKeyEnd", "columnFamily",
+                                            "startQualifierOpen", "endQualifierClosed",
+                                            "deserializer",
+                                            "base" })
+        public PreparedQuery(final ByteString rowKeyStart, final ByteString rowKeyEnd,
+                             final String columnFamily, final ByteString startQualifierOpen,
+                             final ByteString endQualifierClosed,
+                             final BiFunction<Long, ByteString, Metric> deserializer,
+                             final long base) {
+            this.rowKeyStart = rowKeyStart;
+            this.rowKeyEnd = rowKeyEnd;
+            this.columnFamily = columnFamily;
+            this.startQualifierOpen = startQualifierOpen;
+            this.endQualifierClosed = endQualifierClosed;
+            this.deserializer = deserializer;
+            this.base = base;
+        }
 
         private Metric deserialize(final ByteString qualifier, final ByteString value) {
             final long timestamp = base + deserializeOffset(qualifier);

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnectionBuilder.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnectionBuilder.java
@@ -27,7 +27,6 @@ import com.google.cloud.bigtable.config.CredentialOptions;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.common.collect.ImmutableList;
-import io.grpc.Status;
 import com.spotify.heroic.metric.bigtable.api.BigtableDataClient;
 import com.spotify.heroic.metric.bigtable.api.BigtableDataClientImpl;
 import com.spotify.heroic.metric.bigtable.api.BigtableMutator;
@@ -36,13 +35,12 @@ import com.spotify.heroic.metric.bigtable.api.BigtableTableAdminClient;
 import com.spotify.heroic.metric.bigtable.api.BigtableTableTableAdminClientImpl;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
+import io.grpc.Status;
 import java.util.Optional;
 import java.util.concurrent.Callable;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @ToString(of = {"project", "instance", "credentials"})
-@RequiredArgsConstructor
 public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
     private static final String USER_AGENT = "heroic";
 
@@ -56,6 +54,23 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
     private final boolean disableBulkMutations;
     private final int flushIntervalSeconds;
     private final Optional<Integer> batchSize;
+
+    @java.beans.ConstructorProperties({ "project", "instance", "credentials", "async",
+                                        "disableBulkMutations", "flushIntervalSeconds",
+                                        "batchSize" })
+    public BigtableConnectionBuilder(final String project, final String instance,
+                                     final CredentialsBuilder credentials,
+                                     final AsyncFramework async, final boolean disableBulkMutations,
+                                     final int flushIntervalSeconds,
+                                     final Optional<Integer> batchSize) {
+        this.project = project;
+        this.instance = instance;
+        this.credentials = credentials;
+        this.async = async;
+        this.disableBulkMutations = disableBulkMutations;
+        this.flushIntervalSeconds = flushIntervalSeconds;
+        this.batchSize = batchSize;
+    }
 
     @Override
     public BigtableConnection call() throws Exception {
@@ -97,7 +112,6 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
             client);
     }
 
-    @RequiredArgsConstructor
     @ToString(of = {"project", "instance"})
     public static class GrpcBigtableConnection implements BigtableConnection {
         private final AsyncFramework async;
@@ -108,6 +122,22 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
         final BigtableMutator mutator;
         final BigtableTableAdminClient tableAdminClient;
         final BigtableDataClient dataClient;
+
+        @java.beans.ConstructorProperties({ "async", "project", "instance", "session", "mutator",
+                                            "tableAdminClient", "dataClient" })
+        public GrpcBigtableConnection(final AsyncFramework async, final String project,
+                                      final String instance, final BigtableSession session,
+                                      final BigtableMutator mutator,
+                                      final BigtableTableAdminClient tableAdminClient,
+                                      final BigtableDataClient dataClient) {
+            this.async = async;
+            this.project = project;
+            this.instance = instance;
+            this.session = session;
+            this.mutator = mutator;
+            this.tableAdminClient = tableAdminClient;
+            this.dataClient = dataClient;
+        }
 
         @Override
         public BigtableTableAdminClient tableAdminClient() {

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/CustomStringSerializer.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/CustomStringSerializer.java
@@ -24,8 +24,6 @@ package com.spotify.heroic.metric.bigtable;
 import eu.toolchain.serializer.SerialReader;
 import eu.toolchain.serializer.SerialWriter;
 import eu.toolchain.serializer.Serializer;
-import lombok.RequiredArgsConstructor;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
@@ -36,11 +34,15 @@ import java.nio.charset.CharsetEncoder;
 /**
  * Custom string serializer to be backwards compatible with our previous serialization.
  */
-@RequiredArgsConstructor
 public class CustomStringSerializer implements Serializer<String> {
     private final Serializer<Integer> size;
 
     private static final Charset UTF_8 = Charset.forName("utf8");
+
+    @java.beans.ConstructorProperties({ "size" })
+    public CustomStringSerializer(final Serializer<Integer> size) {
+        this.size = size;
+    }
 
     @Override
     public void serialize(SerialWriter buffer, String value) throws IOException {

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableDataClientImpl.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableDataClientImpl.java
@@ -22,6 +22,9 @@
 package com.spotify.heroic.metric.bigtable.api;
 
 import com.google.bigtable.v2.ReadModifyWriteRowRequest;
+import com.google.cloud.bigtable.grpc.BigtableSession;
+import com.google.cloud.bigtable.grpc.scanner.FlatRow;
+import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -29,17 +32,13 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import com.spotify.heroic.async.AsyncObservable;
 import com.spotify.heroic.async.AsyncObserver;
-import com.google.cloud.bigtable.grpc.scanner.FlatRow;
-import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.ResolvableFuture;
 import java.io.IOException;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
-@RequiredArgsConstructor
 @ToString
 public class BigtableDataClientImpl implements BigtableDataClient {
     private final AsyncFramework async;
@@ -59,6 +58,15 @@ public class BigtableDataClientImpl implements BigtableDataClient {
         this.session = session;
         this.mutator = mutator;
         this.clusterUri = String.format("projects/%s/instances/%s", project, cluster);
+    }
+
+    @java.beans.ConstructorProperties({ "async", "session", "mutator", "clusterUri" })
+    public BigtableDataClientImpl(final AsyncFramework async, final BigtableSession session,
+                                  final BigtableMutator mutator, final String clusterUri) {
+        this.async = async;
+        this.session = session;
+        this.mutator = mutator;
+        this.clusterUri = clusterUri;
     }
 
     @Override

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/FakeBigtableConnection.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/FakeBigtableConnection.java
@@ -24,9 +24,9 @@ package com.spotify.heroic.metric.bigtable.api;
 import static com.spotify.heroic.metric.bigtable.api.RowFilter.compareByteStrings;
 
 import com.google.bigtable.v2.Mutation;
+import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.protobuf.ByteString;
 import com.spotify.heroic.async.AsyncObservable;
-import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.spotify.heroic.metric.bigtable.BigtableConnection;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
@@ -39,7 +39,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Inject;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -166,7 +165,6 @@ public class FakeBigtableConnection implements BigtableConnection {
     }
 
     @Data
-    @AllArgsConstructor
     class TableStorage {
         private Table table;
 
@@ -174,6 +172,11 @@ public class FakeBigtableConnection implements BigtableConnection {
             new ConcurrentHashMap<>();
 
         private final Object lock = new Object();
+
+        @java.beans.ConstructorProperties({ "table" })
+        public TableStorage(final Table table) {
+            this.table = table;
+        }
 
         public AsyncFuture<Void> mutateRow(final ByteString rowKey, final Mutations mutations) {
             return async.call(() -> {

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/Mutations.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/Mutations.java
@@ -21,16 +21,20 @@
 
 package com.spotify.heroic.metric.bigtable.api;
 
+import com.google.bigtable.v2.Mutation;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public class Mutations {
     private final List<com.google.bigtable.v2.Mutation> mutations;
+
+    @java.beans.ConstructorProperties({ "mutations" })
+    public Mutations(final List<Mutation> mutations) {
+        this.mutations = mutations;
+    }
 
     /**
      * Get the list of mutations.

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/ReadModifyWriteRules.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/ReadModifyWriteRules.java
@@ -21,18 +21,21 @@
 
 package com.spotify.heroic.metric.bigtable.api;
 
+import com.google.bigtable.v2.ReadModifyWriteRule;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Data;
 
-@RequiredArgsConstructor
 public class ReadModifyWriteRules {
     private final List<com.google.bigtable.v2.ReadModifyWriteRule>
         rules;
+
+    @java.beans.ConstructorProperties({ "rules" })
+    public ReadModifyWriteRules(final List<ReadModifyWriteRule> rules) {
+        this.rules = rules;
+    }
 
     /**
      * Get the list of rules.

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/ReadRowsRequest.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/ReadRowsRequest.java
@@ -22,10 +22,8 @@
 package com.spotify.heroic.metric.bigtable.api;
 
 import com.google.protobuf.ByteString;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Optional;
+import lombok.Data;
 
 @Data
 public class ReadRowsRequest {
@@ -58,11 +56,13 @@ public class ReadRowsRequest {
         return new Builder();
     }
 
-    @RequiredArgsConstructor
     public static class Builder {
         private Optional<RowRange> range = Optional.empty();
         private Optional<RowFilter> filter = Optional.empty();
         private Optional<ByteString> rowKey = Optional.empty();
+
+        public Builder() {
+        }
 
         public Builder range(final RowRange range) {
             this.range = Optional.of(range);

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/RowFilter.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/RowFilter.java
@@ -25,7 +25,6 @@ import com.google.protobuf.ByteString;
 import java.util.List;
 import java.util.Optional;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 
 public interface RowFilter {
     static ColumnRange.Builder newColumnRangeBuilder(String family) {
@@ -169,7 +168,6 @@ public interface RowFilter {
                 .build();
         }
 
-        @RequiredArgsConstructor
         public static class Builder {
             private final String family;
 
@@ -177,6 +175,11 @@ public interface RowFilter {
             private Optional<ByteString> startQualifierOpen = Optional.empty();
             private Optional<ByteString> endQualifierClosed = Optional.empty();
             private Optional<ByteString> endQualifierOpen = Optional.empty();
+
+            @java.beans.ConstructorProperties({ "family" })
+            public Builder(final String family) {
+                this.family = family;
+            }
 
             public Builder startQualifierClosed(final ByteString startQualifierClosed) {
                 this.startQualifierClosed = Optional.of(startQualifierClosed);

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/Table.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/Table.java
@@ -27,10 +27,8 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 
 @Data
-@RequiredArgsConstructor
 public class Table {
     final String clusterUri;
     final String name;
@@ -44,6 +42,14 @@ public class Table {
         Pattern.compile("^(.+)\\/tables\\/([_a-zA-Z0-9][-_.a-zA-Z0-9]*)$");
 
     private static final String TABLE_NAME_FORMAT = "%s/tables/%s";
+
+    @java.beans.ConstructorProperties({ "clusterUri", "name", "columnFamilies" })
+    public Table(final String clusterUri, final String name,
+                 final Map<String, ColumnFamily> columnFamilies) {
+        this.clusterUri = clusterUri;
+        this.name = name;
+        this.columnFamilies = columnFamilies;
+    }
 
     public String getName() {
         return name;

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/Connection.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/Connection.java
@@ -23,10 +23,14 @@ package com.spotify.heroic.metric.datastax;
 
 import com.datastax.driver.core.Session;
 import com.spotify.heroic.metric.datastax.schema.SchemaInstance;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public final class Connection {
     protected final Session session;
     protected final SchemaInstance schema;
+
+    @java.beans.ConstructorProperties({ "session", "schema" })
+    public Connection(final Session session, final SchemaInstance schema) {
+        this.session = session;
+        this.schema = schema;
+    }
 }

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxBackend.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxBackend.java
@@ -45,8 +45,8 @@ import com.spotify.heroic.metric.BackendKeySet;
 import com.spotify.heroic.metric.FetchData;
 import com.spotify.heroic.metric.FetchQuotaWatcher;
 import com.spotify.heroic.metric.MetricCollection;
-import com.spotify.heroic.metric.MetricType;
 import com.spotify.heroic.metric.MetricReadResult;
+import com.spotify.heroic.metric.MetricType;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.QueryError;
 import com.spotify.heroic.metric.QueryTrace;
@@ -80,9 +80,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.inject.Inject;
-import lombok.AccessLevel;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Marker;
@@ -545,13 +543,21 @@ public class DatastaxBackend extends AbstractMetricBackend implements LifeCycles
         return fetches;
     }
 
-    @RequiredArgsConstructor
     private final class RowFetchHelper<R, T> implements FutureDone<ResultSet> {
         private final List<R> data = new ArrayList<>();
 
         private final ResolvableFuture<T> future;
         private final Transform<Row, R> rowConverter;
         private final Transform<RowFetchResult<R>, AsyncFuture<T>> converter;
+
+        @java.beans.ConstructorProperties({ "future", "rowConverter", "converter" })
+        public RowFetchHelper(final ResolvableFuture<T> future,
+                              final Transform<Row, R> rowConverter,
+                              final Transform<RowFetchResult<R>, AsyncFuture<T>> converter) {
+            this.future = future;
+            this.rowConverter = rowConverter;
+            this.converter = converter;
+        }
 
         @Override
         public void failed(Throwable cause) throws Exception {
@@ -640,7 +646,6 @@ public class DatastaxBackend extends AbstractMetricBackend implements LifeCycles
         }
     }
 
-    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     private final class RowStreamHelper<R> implements FutureDone<ResultSet> {
         private final AsyncObserver<List<R>> observer;
         private final Transform<Row, R> rowConverter;
@@ -655,6 +660,15 @@ public class DatastaxBackend extends AbstractMetricBackend implements LifeCycles
 
         public RowStreamHelper(AsyncObserver<List<R>> observer, Transform<Row, R> rowConverter) {
             this(observer, rowConverter, Optional.empty());
+        }
+
+        @java.beans.ConstructorProperties({ "observer", "rowConverter", "errorHandler" })
+        private RowStreamHelper(final AsyncObserver<List<R>> observer,
+                                final Transform<Row, R> rowConverter,
+                                final Optional<Consumer<Throwable>> errorHandler) {
+            this.observer = observer;
+            this.rowConverter = rowConverter;
+            this.errorHandler = errorHandler;
         }
 
         @Override

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/ManagedSetupConnection.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/ManagedSetupConnection.java
@@ -34,13 +34,10 @@ import com.spotify.heroic.metric.datastax.schema.Schema;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.ManagedSetup;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
-
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import lombok.ToString;
 
-@RequiredArgsConstructor
 @ToString(of = {"seeds"})
 public class ManagedSetupConnection implements ManagedSetup<Connection> {
     private final AsyncFramework async;
@@ -53,6 +50,29 @@ public class ManagedSetupConnection implements ManagedSetup<Connection> {
     private final RetryPolicy retryPolicy;
     private final DatastaxAuthentication authentication;
     private final DatastaxPoolingOptions poolingOptions;
+
+    @java.beans.ConstructorProperties({ "async", "seeds", "schema", "configure", "fetchSize",
+                                        "readTimeout", "consistencyLevel", "retryPolicy",
+                                        "authentication", "poolingOptions" })
+    public ManagedSetupConnection(final AsyncFramework async,
+                                  final Collection<InetSocketAddress> seeds, final Schema schema,
+                                  final boolean configure, final int fetchSize,
+                                  final Duration readTimeout,
+                                  final ConsistencyLevel consistencyLevel,
+                                  final RetryPolicy retryPolicy,
+                                  final DatastaxAuthentication authentication,
+                                  final DatastaxPoolingOptions poolingOptions) {
+        this.async = async;
+        this.seeds = seeds;
+        this.schema = schema;
+        this.configure = configure;
+        this.fetchSize = fetchSize;
+        this.readTimeout = readTimeout;
+        this.consistencyLevel = consistencyLevel;
+        this.retryPolicy = retryPolicy;
+        this.authentication = authentication;
+        this.poolingOptions = poolingOptions;
+    }
 
     public AsyncFuture<Connection> construct() {
         AsyncFuture<Session> session = async.call(() -> {

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/schema/AbstractCassandraSchema.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/schema/AbstractCassandraSchema.java
@@ -29,17 +29,19 @@ import com.spotify.heroic.metric.datastax.Async;
 import com.spotify.heroic.metric.datastax.ManagedSetupConnection;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.text.StrSubstitutor;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Map;
+import org.apache.commons.lang3.text.StrSubstitutor;
 
-@RequiredArgsConstructor
 public class AbstractCassandraSchema {
     protected final AsyncFramework async;
+
+    @java.beans.ConstructorProperties({ "async" })
+    public AbstractCassandraSchema(final AsyncFramework async) {
+        this.async = async;
+    }
 
     protected AsyncFuture<PreparedStatement> prepareTemplate(
         final Map<String, String> values, Session s, final String path

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/schema/AbstractSchemaInstance.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/schema/AbstractSchemaInstance.java
@@ -26,13 +26,15 @@ import com.spotify.heroic.metric.BackendKey;
 import com.spotify.heroic.metric.MetricType;
 import com.spotify.heroic.metric.datastax.MetricsRowKey;
 import eu.toolchain.async.Transform;
-import lombok.RequiredArgsConstructor;
-
 import java.util.Optional;
 
-@RequiredArgsConstructor
 public abstract class AbstractSchemaInstance implements SchemaInstance {
     protected final String key;
+
+    @java.beans.ConstructorProperties({ "key" })
+    public AbstractSchemaInstance(final String key) {
+        this.key = key;
+    }
 
     @Override
     public Transform<Row, BackendKey> keyConverter() {

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/schema/SchemaBoundStatement.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/schema/SchemaBoundStatement.java
@@ -21,10 +21,8 @@
 
 package com.spotify.heroic.metric.datastax.schema;
 
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
 import java.util.List;
+import lombok.Data;
 
 /**
  * Represents a CQL statement with a list of bindings that should be applied.
@@ -32,7 +30,6 @@ import java.util.List;
  * @author udoprog
  */
 @Data
-@RequiredArgsConstructor
 public class SchemaBoundStatement {
     final String statement;
     final List<Object> bindings;

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/schema/legacy/CompositeStream.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/schema/legacy/CompositeStream.java
@@ -22,16 +22,18 @@
 package com.spotify.heroic.metric.datastax.schema.legacy;
 
 import com.spotify.heroic.metric.datastax.TypeSerializer;
-import lombok.RequiredArgsConstructor;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-@RequiredArgsConstructor
 public class CompositeStream {
     private static final byte EQ = 0x0;
 
     private final ByteBuffer buffer;
+
+    @java.beans.ConstructorProperties({ "buffer" })
+    public CompositeStream(final ByteBuffer buffer) {
+        this.buffer = buffer;
+    }
 
     public <T> T next(TypeSerializer<T> serializer) throws IOException {
         final short segment = buffer.getShort();

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/schema/legacy/MapSerializer.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/schema/legacy/MapSerializer.java
@@ -22,20 +22,23 @@
 package com.spotify.heroic.metric.datastax.schema.legacy;
 
 import com.spotify.heroic.metric.datastax.TypeSerializer;
-import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.tuple.Pair;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
 
-@RequiredArgsConstructor
 public class MapSerializer<A, B> implements TypeSerializer<Map<A, B>> {
     private final TypeSerializer<A> a;
     private final TypeSerializer<B> b;
+
+    @java.beans.ConstructorProperties({ "a", "b" })
+    public MapSerializer(final TypeSerializer<A> a, final TypeSerializer<B> b) {
+        this.a = a;
+        this.b = b;
+    }
 
     @Override
     public ByteBuffer serialize(final Map<A, B> value) throws IOException {

--- a/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcClient.java
+++ b/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcClient.java
@@ -35,11 +35,9 @@ import io.grpc.Metadata;
 import io.grpc.Status;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@RequiredArgsConstructor
 public class GrpcRpcClient {
     private final AsyncFramework async;
     private final InetSocketAddress address;
@@ -48,6 +46,18 @@ public class GrpcRpcClient {
     private final Meter errors = new Meter();
 
     private static final GrpcRpcEmptyBody EMPTY = new GrpcRpcEmptyBody();
+
+    public GrpcRpcClient(
+        final AsyncFramework async,
+        final InetSocketAddress address,
+        final ObjectMapper mapper,
+        final Managed<ManagedChannel> channel
+    ) {
+        this.async = async;
+        this.address = address;
+        this.mapper = mapper;
+        this.channel = channel;
+    }
 
     public AsyncFuture<Void> close() {
         return channel.stop();

--- a/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcEndpointHandleBase.java
+++ b/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcEndpointHandleBase.java
@@ -23,11 +23,14 @@ package com.spotify.heroic.rpc.grpc;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.grpc.MethodDescriptor;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public abstract class GrpcRpcEndpointHandleBase<Q, R> implements GrpcEndpointHandle<Q, R> {
     private final GrpcDescriptor<Q, R> spec;
+
+    @java.beans.ConstructorProperties({ "spec" })
+    public GrpcRpcEndpointHandleBase(final GrpcDescriptor<Q, R> spec) {
+        this.spec = spec;
+    }
 
     @Override
     public TypeReference<Q> queryType() {

--- a/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcEndpointSpec.java
+++ b/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcEndpointSpec.java
@@ -23,13 +23,20 @@ package com.spotify.heroic.rpc.grpc;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.grpc.MethodDescriptor;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public class GrpcRpcEndpointSpec<Q, R> implements GrpcDescriptor<Q, R> {
     private final TypeReference<Q> queryType;
     private final TypeReference<R> responseType;
     private final MethodDescriptor<byte[], byte[]> descriptor;
+
+    @java.beans.ConstructorProperties({ "queryType", "responseType", "descriptor" })
+    public GrpcRpcEndpointSpec(final TypeReference<Q> queryType,
+                               final TypeReference<R> responseType,
+                               final MethodDescriptor<byte[], byte[]> descriptor) {
+        this.queryType = queryType;
+        this.responseType = responseType;
+        this.descriptor = descriptor;
+    }
 
     @Override
     public TypeReference<Q> queryType() {

--- a/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcProtocolModule.java
+++ b/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcProtocolModule.java
@@ -33,14 +33,12 @@ import dagger.Provides;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.ResolvableFuture;
 import io.netty.channel.nio.NioEventLoopGroup;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
-import javax.inject.Named;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import javax.inject.Named;
+import lombok.Data;
 
 @Data
 public class GrpcRpcProtocolModule implements RpcProtocolModule {
@@ -91,7 +89,6 @@ public class GrpcRpcProtocolModule implements RpcProtocolModule {
         LifeCycle life();
     }
 
-    @RequiredArgsConstructor
     @Module
     class M {
         @Provides

--- a/rpc/jvm/src/main/java/com/spotify/heroic/rpc/jvm/JvmRpcProtocolModule.java
+++ b/rpc/jvm/src/main/java/com/spotify/heroic/rpc/jvm/JvmRpcProtocolModule.java
@@ -30,13 +30,11 @@ import com.spotify.heroic.lifecycle.LifeCycleManager;
 import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
-import javax.inject.Named;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import javax.inject.Named;
+import lombok.Data;
 
 @Data
 public class JvmRpcProtocolModule implements RpcProtocolModule {
@@ -72,7 +70,6 @@ public class JvmRpcProtocolModule implements RpcProtocolModule {
         LifeCycle life();
     }
 
-    @RequiredArgsConstructor
     @Module
     class M {
         @Provides

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoir.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/MinMaxSlidingTimeReservoir.java
@@ -30,7 +30,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 public class MinMaxSlidingTimeReservoir implements Reservoir {
@@ -153,9 +152,13 @@ public class MinMaxSlidingTimeReservoir implements Reservoir {
     }
 
     @ToString
-    @RequiredArgsConstructor
     private static class MinMaxEntry {
         private final long min;
         private final long max;
+
+        private MinMaxEntry(final long min, final long max) {
+            this.min = min;
+            this.max = max;
+        }
     }
 }

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticConsumerReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticConsumerReporter.java
@@ -28,11 +28,9 @@ import com.spotify.heroic.statistics.FutureReporter;
 import com.spotify.heroic.statistics.HeroicTimer;
 import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricRegistry;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @ToString(of = {"base"})
-@RequiredArgsConstructor
 public class SemanticConsumerReporter implements ConsumerReporter {
     private static final String COMPONENT = "consumer";
 
@@ -80,6 +78,39 @@ public class SemanticConsumerReporter implements ConsumerReporter {
         consumerCommitPhase2Timer =
             registry.register(base.tagged("what", "consumer-commit-phase2-latency"),
                 new SemanticHeroicTimerGauge());
+    }
+
+    @java.beans.ConstructorProperties({ "base", "messageIn", "messageError", "messageRetry",
+                                        "consumerSchemaError", "consumerThreadsLiveRatio",
+                                        "messageSize", "messageDrift", "consumer",
+                                        "consumerCommitWholeOperationTimer",
+                                        "consumerCommitPhase1Timer", "consumerCommitPhase2Timer" })
+    public SemanticConsumerReporter(
+        final MetricId base,
+        final Counter messageIn,
+        final Counter messageError,
+        final Counter messageRetry,
+        final Counter consumerSchemaError,
+        final SemanticRatioGauge consumerThreadsLiveRatio,
+        final Histogram messageSize,
+        final Histogram messageDrift,
+        final SemanticFutureReporter consumer,
+        final SemanticHeroicTimerGauge consumerCommitWholeOperationTimer,
+        final SemanticHeroicTimerGauge consumerCommitPhase1Timer,
+        final SemanticHeroicTimerGauge consumerCommitPhase2Timer
+    ) {
+        this.base = base;
+        this.messageIn = messageIn;
+        this.messageError = messageError;
+        this.messageRetry = messageRetry;
+        this.consumerSchemaError = consumerSchemaError;
+        this.consumerThreadsLiveRatio = consumerThreadsLiveRatio;
+        this.messageSize = messageSize;
+        this.messageDrift = messageDrift;
+        this.consumer = consumer;
+        this.consumerCommitWholeOperationTimer = consumerCommitWholeOperationTimer;
+        this.consumerCommitPhase1Timer = consumerCommitPhase1Timer;
+        this.consumerCommitPhase2Timer = consumerCommitPhase2Timer;
     }
 
     @Override

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticFutureReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticFutureReporter.java
@@ -26,7 +26,6 @@ import com.spotify.heroic.statistics.FutureReporter;
 import com.spotify.heroic.statistics.HeroicTimer;
 import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricRegistry;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @ToString(of = {})
@@ -61,9 +60,13 @@ public class SemanticFutureReporter implements FutureReporter {
         return new SemanticContext(timer.time());
     }
 
-    @RequiredArgsConstructor
     private class SemanticContext implements FutureReporter.Context {
         private final HeroicTimer.Context context;
+
+        @java.beans.ConstructorProperties({ "context" })
+        public SemanticContext(final HeroicTimer.Context context) {
+            this.context = context;
+        }
 
         @Override
         public void failed(Throwable e) throws Exception {

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticHeroicReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticHeroicReporter.java
@@ -44,11 +44,9 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @ToString(of = {})
-@RequiredArgsConstructor
 public class SemanticHeroicReporter implements HeroicReporter {
     private final SemanticMetricRegistry registry;
 
@@ -56,6 +54,11 @@ public class SemanticHeroicReporter implements HeroicReporter {
     private final ConcurrentMap<String, List<Supplier<Long>>> cacheSizes =
         new ConcurrentHashMap<>();
     private final Set<ClusteredManager> clusteredManagers = new HashSet<>();
+
+    @java.beans.ConstructorProperties({ "registry" })
+    public SemanticHeroicReporter(final SemanticMetricRegistry registry) {
+        this.registry = registry;
+    }
 
     @Override
     public ConsumerReporter newConsumer(String id) {

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticHeroicTimer.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticHeroicTimer.java
@@ -23,15 +23,23 @@ package com.spotify.heroic.statistics.semantic;
 
 import com.codahale.metrics.Timer;
 import com.spotify.heroic.statistics.HeroicTimer;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @ToString(of = {})
-@RequiredArgsConstructor
 public class SemanticHeroicTimer implements HeroicTimer {
-    @RequiredArgsConstructor
+
+    @java.beans.ConstructorProperties({ "timer" })
+    public SemanticHeroicTimer(final Timer timer) {
+        this.timer = timer;
+    }
+
     public class SemanticContext implements Context {
         private final Timer.Context context;
+
+        @java.beans.ConstructorProperties({ "context" })
+        public SemanticContext(final Timer.Context context) {
+            this.context = context;
+        }
 
         @Override
         public void finished() throws Exception {

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticHeroicTimerGauge.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticHeroicTimerGauge.java
@@ -26,14 +26,15 @@ import com.google.common.base.Stopwatch;
 import com.spotify.heroic.statistics.HeroicTimer;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @ToString(of = {})
-@RequiredArgsConstructor
 public class SemanticHeroicTimerGauge implements HeroicTimer, Gauge<Long> {
 
     private final AtomicLong value = new AtomicLong(0);
+
+    public SemanticHeroicTimerGauge() {
+    }
 
     @Override
     public Context time() {

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporter.java
@@ -41,7 +41,6 @@ import com.spotify.heroic.statistics.MetadataBackendReporter;
 import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricRegistry;
 import eu.toolchain.async.AsyncFuture;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @ToString(of = {"base"})
@@ -112,9 +111,13 @@ public class SemanticMetadataBackendReporter implements MetadataBackendReporter 
         writesDroppedByDuplicate.inc();
     }
 
-    @RequiredArgsConstructor
     class InstrumentedMetadataBackend implements MetadataBackend {
         private final MetadataBackend delegate;
+
+        @java.beans.ConstructorProperties({ "delegate" })
+        public InstrumentedMetadataBackend(final MetadataBackend delegate) {
+            this.delegate = delegate;
+        }
 
         @Override
         public AsyncFuture<Void> configure() {

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
@@ -51,7 +51,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAccumulator;
 import java.util.function.Consumer;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @ToString(of = {"base"})
@@ -205,9 +204,13 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
         return queryMetrics.setup();
     }
 
-    @RequiredArgsConstructor
     private class InstrumentedMetricBackend implements MetricBackend {
         private final MetricBackend delegate;
+
+        @java.beans.ConstructorProperties({ "delegate" })
+        public InstrumentedMetricBackend(final MetricBackend delegate) {
+            this.delegate = delegate;
+        }
 
         @Override
         public Statistics getStatistics() {

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticRatioGauge.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticRatioGauge.java
@@ -23,9 +23,7 @@ package com.spotify.heroic.statistics.semantic;
 
 import com.codahale.metrics.RatioGauge;
 import java.util.concurrent.atomic.AtomicLong;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public class SemanticRatioGauge extends RatioGauge {
     private final AtomicLong numerator = new AtomicLong();
     private final AtomicLong denominator = new AtomicLong();
@@ -33,6 +31,9 @@ public class SemanticRatioGauge extends RatioGauge {
     public SemanticRatioGauge(final long numerator, final long denominator) {
         this.numerator.set(numerator);
         this.denominator.set(denominator);
+    }
+
+    public SemanticRatioGauge() {
     }
 
     public void setNumerator(final long value) {

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticSuggestBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticSuggestBackendReporter.java
@@ -39,7 +39,6 @@ import eu.toolchain.async.AsyncFuture;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @ToString(of = {"base"})
@@ -104,9 +103,13 @@ public class SemanticSuggestBackendReporter implements SuggestBackendReporter {
         return backendWrite.setup();
     }
 
-    @RequiredArgsConstructor
     private class InstrumentedSuggestBackend implements SuggestBackend {
         private final SuggestBackend delegate;
+
+        @java.beans.ConstructorProperties({ "delegate" })
+        public InstrumentedSuggestBackend(final SuggestBackend delegate) {
+            this.delegate = delegate;
+        }
 
         @Override
         public AsyncFuture<Void> configure() {

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SimpleGauge.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SimpleGauge.java
@@ -23,14 +23,15 @@ package com.spotify.heroic.statistics.semantic;
 
 import com.codahale.metrics.Gauge;
 import java.util.concurrent.atomic.AtomicLong;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @ToString(of = {})
-@RequiredArgsConstructor
 public class SimpleGauge implements Gauge<Long> {
 
     private final AtomicLong value = new AtomicLong(0);
+
+    public SimpleGauge() {
+    }
 
     public void setValue(final long value) {
         this.value.set(value);

--- a/suggest/elasticsearch/src/main/java/com/spotify/heroic/suggest/elasticsearch/ElasticsearchSuggestModule.java
+++ b/suggest/elasticsearch/src/main/java/com/spotify/heroic/suggest/elasticsearch/ElasticsearchSuggestModule.java
@@ -67,7 +67,6 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import javax.inject.Named;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
 
 @Data
@@ -185,10 +184,13 @@ public final class ElasticsearchSuggestModule implements SuggestModule, DynamicM
         LifeCycle life();
     }
 
-    @RequiredArgsConstructor
     @Module
     class M {
         private final BackendType backendType;
+
+        public M(final BackendType backendType) {
+            this.backendType = backendType;
+        }
 
         @Provides
         @ElasticsearchScope

--- a/suggest/memory/src/main/java/com/spotify/heroic/suggest/memory/MemorySuggestModule.java
+++ b/suggest/memory/src/main/java/com/spotify/heroic/suggest/memory/MemorySuggestModule.java
@@ -32,7 +32,6 @@ import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 
 import java.util.Optional;
 
@@ -74,7 +73,6 @@ public final class MemorySuggestModule implements SuggestModule, DynamicModuleId
         MemoryBackend backend();
     }
 
-    @RequiredArgsConstructor
     @Module
     class M {
         @Provides


### PR DESCRIPTION
The java.beans annotations are not really necessary, they're a byproduct of running delombok in these classes. They shouldn't have any downside other than adding verbosity, so it was easier to leave them.