### PR TITLE
Enable stale issue bot.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,29 @@
+pulls:
+  daysUntilStale: 30
+  # Comment to post when marking a PR as stale.
+  markComment: >
+    This PR has been automatically marked as stale because it has not been updated for at least one month. If you believe this is still important, leave a comment to prevent the PR from being closed.
+
+    This PR will automatically be closed in ten days if no further activity occurs. Thank you for all your contributions.
+
+issues:
+  daysUnilStale: 60
+  # Comment to post when marking an issue as stale.
+  markComment: >
+    This issue has been automatically marked as stale because it has not been updated for at least two months.
+
+    If this is a bug and you can still reproduce this error on the master branch, please reply with all of the information you have about it in order to keep the issue open.
+
+    This issue will automatically be closed in ten days if no further activity occurs. Thank you for all your contributions.
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 10
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - type:bug
+  - note:rfc
+  - note:accepted
+# Label to use when marking an issue as stale
+staleLabel: note:stale
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,7 +2,7 @@ pulls:
   daysUntilStale: 30
   # Comment to post when marking a PR as stale.
   markComment: >
-    This PR has been automatically marked as stale because it has not been updated for at least one month. If you believe this is still important, leave a comment to prevent the PR from being closed.
+    ⚠ This PR has been automatically marked as stale because it has not been updated for at least one month. If you believe this is still important, leave a comment to prevent the PR from being closed.
 
     This PR will automatically be closed in ten days if no further activity occurs. Thank you for all your contributions.
 
@@ -10,7 +10,7 @@ issues:
   daysUnilStale: 60
   # Comment to post when marking an issue as stale.
   markComment: >
-    This issue has been automatically marked as stale because it has not been updated for at least two months.
+    ⚠ This issue has been automatically marked as stale because it has not been updated for at least two months.
 
     If this is a bug and you can still reproduce this error on the master branch, please reply with all of the information you have about it in order to keep the issue open.
 


### PR DESCRIPTION
Enables [the stale bot](https://github.com/probot/stale) to close out issues/PRs that haven't had activity for a long time. I set the thresholds kind of arbitrarily, happy to adjust them if anyone has an opinion.