### PR TITLE
[heroic-dist] include http fields in shaded jar

### DIFF
--- a/heroic-dist/build.gradle
+++ b/heroic-dist/build.gradle
@@ -11,6 +11,7 @@ shadowJar {
     classifier 'shaded'
     zip64 true
 
+    append 'META-INF/services/org.eclipse.jetty.http.HttpFieldPreEncoder'
     // required for lucene
     append 'META-INF/services/org.apache.lucene.codecs.Codec'
     append 'META-INF/services/org.apache.lucene.codecs.DocValuesFormat'


### PR DESCRIPTION
Otherwise at runtime you will encounter a `java.lang.ArrayIndexOutOfBoundsException` when loading `org.eclipse.jetty.http.PreEncodedHttpField`

@hexedpackets @lmuhlha @sjoeboo 