### PR TITLE
[elasticsearch-utils] remove unused parameters

### DIFF
--- a/docs/content/_docs/config/elasticsearch_connection.html
+++ b/docs/content/_docs/config/elasticsearch_connection.html
@@ -23,18 +23,6 @@ short_url: docs/config/elasticsearch_connection
     <td>If set to <code>true</code>, use a node client by default.</td>
   </tr>
   <tr>
-    <td><code>concurrentBulkRequests</code></td>
-    <td>The number of concurrent bulk requests this connection supports.</td>
-  </tr>
-  <tr>
-    <td><code>flushInterval</code></td>
-    <td>The interval in milliseconds at which the bulk will flush.</td>
-  </tr>
-  <tr>
-    <td><code>bulkActions</code></td>
-    <td>The number of bulk actions that will be pooled before a flush.</td>
-  </tr>
-  <tr>
     <td><code>index</code></td>
     <td>
       The index mapping to use.<br />

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/ConnectionModule.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/ConnectionModule.java
@@ -133,9 +133,6 @@ public class ConnectionModule {
         private Boolean sniff;
         private String nodeSamplerInterval;
         private Boolean nodeClient;
-        private Integer concurrentBulkRequests;
-        private Integer flushInterval;
-        private Integer bulkActions;
         private IndexMapping index;
         private String templateName;
         private ClientSetup clientSetup;
@@ -162,21 +159,6 @@ public class ConnectionModule {
 
         public Builder nodeClient(Boolean nodeClient) {
             this.nodeClient = nodeClient;
-            return this;
-        }
-
-        public Builder nodeClient(Integer concurrentBulkRequests) {
-            this.concurrentBulkRequests = concurrentBulkRequests;
-            return this;
-        }
-
-        public Builder flushInterval(Integer flushInterval) {
-            this.flushInterval = flushInterval;
-            return this;
-        }
-
-        public Builder bulkActions(Integer bulkActions) {
-            this.bulkActions = bulkActions;
             return this;
         }
 


### PR DESCRIPTION
None of these parameters are ever used nor can they be configured via the heroic config.

@spotify/layer8 