### PR TITLE
[debian] fix build process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,13 @@ allprojects {
     repositories {
         mavenLocal()
         mavenCentral()
+
+        // Needed for finding the repackaged jars when building the debian package
+        if (project.hasProperty('MAVEN_HOME')) {
+            maven {
+                url "${MAVEN_HOME}/.m2/repository"
+            }
+        }
     }
 
     sourceSets {

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -6,7 +6,7 @@ JAVA_HOME=/usr/lib/jvm/default-java
 MVN=$(CURDIR)/debian/mvn.sh
 GRADLE=$(CURDIR)/gradlew
 
-BUILD=debian-build
+BUILD=build
 
 HEROIC_JAR=$(BUILD)/heroic-full.jar
 HEROIC=$(BUILD)/heroic-RELEASE
@@ -24,7 +24,7 @@ override_dh_auto_clean:
 	GRADLE_USER_HOME=$(BUILD_HOME) $(GRADLE) clean
 
 override_dh_auto_build: repackaged
-	GRADLE_USER_HOME=$(BUILD_HOME) $(GRADLE) -D heroic.version="${DEB_VERSION} (RELEASE)" assemble
+	GRADLE_USER_HOME=$(BUILD_HOME) $(GRADLE) -D heroic.version="${DEB_VERSION} (RELEASE)" assemble -PMAVEN_HOME=$(BUILD_HOME)
 	mkdir -p $(BUILD)
 	cp heroic-dist/build/libs/heroic-dist-0.0.1-SNAPSHOT-shaded.jar $(HEROIC_JAR)
 	cp debian/bin/heroic $(HEROIC)


### PR DESCRIPTION
Building the debian package was failing because gradle couldn't locate the repackaged jars
that get installed in a local m2 repo.

Then the dh_install process couldn't find the build artifacts because the directory name was changed
```
dh_install
cp: cannot stat ‘debian-build/tmp/build/heroic-0.9.0’: No such file or directory
dh_install: cp -a debian-build/tmp/build/heroic-0.9.0 debian-build/heroic-0.9.0/usr/bin/ returned exit code 1
make: *** [binary] Error 2
dpkg-buildpackage: error: debian-build/rules binary gave error exit status 2
```