### PR TITLE
Disable codecov status checks.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project: false
+    patch: false


### PR DESCRIPTION
This disables the commit status checks from codecov. The report will still be added as a comment to PRs, but the PR won't be marked as errored due to coverage.