### PR TITLE
[discovery] use port from srv record

### DIFF
--- a/discovery/simple/src/main/java/com/spotify/heroic/cluster/discovery/simple/SrvRecordDiscovery.java
+++ b/discovery/simple/src/main/java/com/spotify/heroic/cluster/discovery/simple/SrvRecordDiscovery.java
@@ -39,8 +39,7 @@ import org.xbill.DNS.SRVRecord;
 import org.xbill.DNS.Type;
 
 public class SrvRecordDiscovery implements ClusterDiscovery {
-    public static final String DEFAULT_PROTOCOL = "nativerpc";
-    public static final int DEFAULT_PORT = 1394;
+    public static final String DEFAULT_PROTOCOL = "grpc";
     private static final Logger log = LoggerFactory.getLogger(SrvRecordDiscovery.class);
 
     private final AsyncFramework async;
@@ -50,9 +49,9 @@ public class SrvRecordDiscovery implements ClusterDiscovery {
 
     @Inject
     public SrvRecordDiscovery(
-        AsyncFramework async, @Named("records") List<String> records,
+        AsyncFramework async,
+        @Named("records") List<String> records,
         @Named("protocol") Optional<String> protocol,
-
         @Named("port") Optional<Integer> port
     ) {
         this.async = async;
@@ -84,7 +83,7 @@ public class SrvRecordDiscovery implements ClusterDiscovery {
                     for (final Record a : result) {
                         final SRVRecord srv = (SRVRecord) a;
                         results.add(new URI(protocol.orElse(DEFAULT_PROTOCOL) + "://" +
-                            srv.getTarget().canonicalize() + ":" + port.orElse(DEFAULT_PORT)));
+                            srv.getTarget().canonicalize() + ":" + port.orElse(srv.getPort())));
                     }
                 }
 

--- a/discovery/simple/src/main/java/com/spotify/heroic/cluster/discovery/simple/StaticListDiscovery.java
+++ b/discovery/simple/src/main/java/com/spotify/heroic/cluster/discovery/simple/StaticListDiscovery.java
@@ -35,7 +35,8 @@ public class StaticListDiscovery implements ClusterDiscovery {
 
     @Inject
     public StaticListDiscovery(
-        AsyncFramework async, @Named("nodes") List<URI> nodes
+        AsyncFramework async,
+        @Named("nodes") List<URI> nodes
     ) {
         this.async = async;
         this.nodes = nodes;

--- a/docs/content/_docs/config/cluster.html
+++ b/docs/content/_docs/config/cluster.html
@@ -18,8 +18,6 @@ cluster:
     site: london
   protocols:
     - type: grpc
-  capabilities:
-    - QUERY
   discovery:
     type: static
     nodes:
@@ -45,7 +43,31 @@ site: london
   See the <a href="docs/federation">federation</a> section for more details.
 </p>
 
-<h3><code>protocols</code></h3>
+
+<h3 id="topology">
+  <code>topology</code>
+  <a class="link-to" href="{{ page.short_url }}#topology"><span class="glyphicon glyphicon-link"></span></a>
+</h3>
+
+<pre><code class="language-yaml">
+topology:
+  - site: london
+</code></pre>
+
+<p>
+  Actual topology (shards) is detected based on the metadata coming from the nodes.
+  Expected topology is specified in the optional 'topology'. This specifies the minimum
+  shards expected, i.e. additional shards may also exist. If an expected shard is not responding the
+  response will be include which shard was failing.
+
+  See the <a href="docs/federation">federation</a> section for more details.
+</p>
+
+
+<h3>
+  <code>protocols</code>
+  <a class="link-to" href="{{ page.short_url }}#protocols"><span class="glyphicon glyphicon-link"></span></a>
+</h3>
 
 <p>
   Contains a list of protocols that this node can speak.
@@ -56,6 +78,8 @@ site: london
 <pre><code class="language-yaml">
 host: &lt;host&gt;
 port: &lt;port&gt;
+maxFrameSize: &lt;maxFrameSize&gt;
+
 </code></pre>
 
 <table class="table">
@@ -66,6 +90,10 @@ port: &lt;port&gt;
   <tr>
     <td><code>port</code></td>
     <td>the port number that this node will bind to.</td>
+  </tr>
+  <tr>
+    <td><code>maxFrameSize</code></td>
+    <td>frame size limit in bytes.</td>
   </tr>
 </table>
 
@@ -73,74 +101,16 @@ port: &lt;port&gt;
     <a href="https://grpc.io">gRPC</a> is an open source RPC protocol.
 </p>
 
-<h4>nativerpc</h4>
-
-<pre><code class="language-yaml">
-host: &lt;host&gt;
-port: &lt;port&gt;
-</code></pre>
-
-<table class="table">
-  <tr>
-    <td><code>host</code></td>
-    <td>the address of the interface that this node will bind to.</td>
-  </tr>
-  <tr>
-    <td><code>port</code></td>
-    <td>the port number that this node will bind to.</td>
-  </tr>
-</table>
-
-<p>
-  nativerpc is a protocol specifically designed to combat timeout and keep-alive issues that exists in HTTP.
-  A TCP connection might decide to stall for arbitrary periods of time, and most HTTP clients have a hard time detecting if this happens <em>after</em> a request has been received by the server.
-</p>
-
-<p>
-  A typical HTTP client supports two times of timeouts, <em>connection</em> and <em>read</em>.
-</p>
-
-<ul>
-  <li>The <em>connection</em> timeout is typically the time it takes to establish an open TCP connection.</li>
-  <li>The <em>read</em> timeout is typically the time it takes to send and receive a response from the remote server.</li>
-</ul>
-
-<p>
-  A common error scenario arises when a client cannot predict how long a request will be running for.
-  Given that we are dealing with cross-site traffic this is very bad, because a broken flow will leave the client hanging until it triggers its <em>read</em> timeout.
-</p>
-
-<p>
-  <b>nativerpc</b> solves this by using <em>heartbeats</em>.
-  The client communicates at which interval it expects to receive heartbeats, and as long as the server is actively processing the request it is expected to keep sending them.
-</p>
-
-<p>
-  This simple mechanism allows the client to detect broken flows, regardless of cause.
-  And allows the request to fail faster than what is permitted by HTTP.
-</p>
-
-<h3><code>capabilities</code></h3>
-
-<p>
-  This is a list of capabilities that is supported by this node.
-  Capabilities restrict what other nodes perceive this node to be capable of doing.
-  The current set of capabilities available right now are.
-</p>
-
-<ul>
-  <li><code>QUERY</code> - the node is capable of receiving queries, this needs to be set if you intend for this node to receive queries over the cluster.</li>
-  <li><code>WRITE</code> - the node is capable of receiving writes, this needs to be set if you intend for this node to receive writes over the cluster.</li>
-</ul>
-
-<h3><code>discovery</code></h3>
+<h3>
+  <code>discovery</code>
+  <a class="link-to" href="{{ page.short_url }}#discovery"><span class="glyphicon glyphicon-link"></span></a>
+</h3>
 
 <p>
   The mechanism used to discover nodes in the cluster.
 </p>
 
 <h4>static</h4>
-
 <pre><code class="language-yaml">
 nodes:
   - &lt;url&gt;
@@ -163,4 +133,41 @@ nodes:
   It takes a list of nodes that may, or may not be reachable at the moment.
 
   This list will be queried at a given interval, and any that responds to a metadata request will be added to the local list of known members.
+</p>
+
+<h4>srv</h4>
+<pre><code class="language-yaml">
+records:
+  - &lt;srv record&gt;
+  - ..
+</code></pre>
+
+<table class="table">
+  <tr>
+    <th>records</th>
+    <td>
+      Is the list of srv records that this node will attempt to resolve and add  to its cluster registry.
+    </td>
+  </tr>
+
+  <tr>
+    <th>protocol</th>
+    <td>
+      Protocol to use when building the URI. Defaults to grpc.
+    </td>
+  </tr>
+
+  <tr>
+    <th>port</th>
+    <td>
+      Port to use when building the URI. Defaults to using the port specified in the SRV record unless the port is explicitly defined in the config.
+    </td>
+  </tr>
+</table>
+
+<p>
+  Srv records are useful when running Heroic on more ephemeral environments like kubernetes.
+
+  It takes a list srv records and resolves each one at a given interval, and any that responds to a metadata
+  request will be added to the local list of known members.
 </p>

--- a/example/heroic.example.yml
+++ b/example/heroic.example.yml
@@ -1,9 +1,6 @@
 # vim: filetype=yaml
 port: 8080
 
-# Schedule for refreshing cluster metadata.
-refreshClusterSchedule: "0 */1 * * * ?"
-
 # Cluster configuration.
 cluster:
   # Local ID.
@@ -12,25 +9,32 @@ cluster:
   # When communicating with self, avoid using the network.
   # @default false
   #useLocal: false
-  # Node capabilities.
-  #  * QUERY Node can be queried for data (api node).
-  #  * WRITE Node can be written to.
-  # @default ["QUERY", "WRITE"]
-  capabilities:
-    - QUERY
+
   # Discovery mechanism
   discovery:
     ## Static discovery mechanism.
     type: static
     nodes:
-      - native://localhost:8100
+      - grpc://localhost:9698
+
+    ## SRV discovery mechanism. The port will be read from the SRV record.
+    # type: srv
+    # records:
+    # - srv-record-1.example.com
+    # - srv-record-2.example.com
+
   # RPC mechanism
-  rpc:
-    type: native
-    host: 0.0.0.0
-    port: 8100
-    parentThreads: 2
-    childThreads: 10
+  protocols:
+    - type: grpc
+      host: 0.0.0.0
+      port: 9698
+      maxFrameSize: 10000000
+
+  tags:
+    site: london
+
+  topology:
+    - site: london
 
 # Metrics configuration.
 metrics:

--- a/heroic-core/src/main/java/com/spotify/heroic/cluster/ClusterManagerModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/cluster/ClusterManagerModule.java
@@ -113,8 +113,10 @@ public class ClusterManagerModule {
     @ClusterScope
     public List<Pair<String, RpcProtocolComponent>> protocolComponents(
         final NodeMetadataProvider metadataProvider,
-        @Named("local") final ClusterNode localClusterNode, final PrimaryComponent primary,
-        final MetricComponent metric, final MetadataComponent metadata,
+        @Named("local") final ClusterNode localClusterNode,
+        final PrimaryComponent primary,
+        final MetricComponent metric,
+        final MetadataComponent metadata,
         final SuggestComponent suggest
     ) {
         final ImmutableList.Builder<Pair<String, RpcProtocolComponent>> protocolComponents =

--- a/heroic-core/src/main/java/com/spotify/heroic/cluster/CoreClusterManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/cluster/CoreClusterManager.java
@@ -93,14 +93,20 @@ public class CoreClusterManager implements ClusterManager, LifeCycles {
 
     final Object updateRegistryLock = new Object();
 
-    @Inject
-    public CoreClusterManager(
-        AsyncFramework async, ClusterDiscovery discovery, NodeMetadata localMetadata,
-        Map<String, RpcProtocol> protocols, Scheduler scheduler,
-        @Named("useLocal") Boolean useLocal, HeroicConfiguration options, LocalClusterNode local,
-        HeroicContext context, @Named("topology") Set<Map<String, String>> expectedTopology,
-        final QueryReporter reporter
-    ) {
+  @Inject
+  public CoreClusterManager(
+      AsyncFramework async,
+      ClusterDiscovery discovery,
+      NodeMetadata localMetadata,
+      Map<String, RpcProtocol> protocols,
+      Scheduler scheduler,
+      @Named("useLocal") Boolean useLocal,
+      HeroicConfiguration options,
+      LocalClusterNode local,
+      HeroicContext context,
+      @Named("topology") Set<Map<String, String>> expectedTopology,
+
+      final QueryReporter reporter) {
         this.async = async;
         this.discovery = discovery;
         this.localMetadata = localMetadata;

--- a/heroic-loading/src/main/java/com/spotify/heroic/dagger/LoadingModule.java
+++ b/heroic-loading/src/main/java/com/spotify/heroic/dagger/LoadingModule.java
@@ -173,8 +173,10 @@ public class LoadingModule {
     @LoadingScope
     @Named("loading")
     LifeCycle loadingLifeCycles(
-        @Named("internal") LifeCycleRegistry registry, final AsyncFramework async,
-        final ScheduledExecutorService scheduler, final ExecutorService executor
+        @Named("internal") LifeCycleRegistry registry,
+        final AsyncFramework async,
+        final ScheduledExecutorService scheduler,
+        final ExecutorService executor
     ) {
         return () -> {
             registry.scoped("loading scheduler").stop(() -> async.call(() -> {

--- a/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcProtocol.java
+++ b/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcProtocol.java
@@ -88,9 +88,11 @@ public class GrpcRpcProtocol implements RpcProtocol {
 
     @Inject
     public GrpcRpcProtocol(
-        AsyncFramework async, @Named("application/json+internal") ObjectMapper mapper,
+        AsyncFramework async,
+        @Named("application/json+internal") ObjectMapper mapper,
         @Named("bindFuture") ResolvableFuture<InetSocketAddress> bindFuture,
-        @Named("defaultPort") int defaultPort, @Named("maxFrameSize") int maxFrameSize,
+        @Named("defaultPort") int defaultPort,
+        @Named("maxFrameSize") int maxFrameSize,
         @Named("worker") NioEventLoopGroup workerGroup
     ) {
         this.async = async;

--- a/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcProtocolModule.java
+++ b/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcProtocolModule.java
@@ -42,31 +42,21 @@ import lombok.Data;
 
 @Data
 public class GrpcRpcProtocolModule implements RpcProtocolModule {
-    private static final Object PARENT = new Object();
-
     private static final String DEFAULT_HOST = "0.0.0.0";
     private static final int DEFAULT_PORT = 9698;
-    private static final int DEFAULT_PARENT_THREADS = 2;
-    private static final int DEFAULT_CHILD_THREADS = 100;
-    private static final int DEFAULT_MAX_FRAME_SIZE = 10 * 1000000;
-    private static final long DEFAULT_SEND_TIMEOUT = 5000;
+    private static final int DEFAULT_MAX_FRAME_SIZE = 10 * 1_000_000;
 
     private final InetSocketAddress address;
-    private final int parentThreads;
-    private final int childThreads;
     private final int maxFrameSize;
 
     @JsonCreator
     public GrpcRpcProtocolModule(
-        @JsonProperty("host") String host, @JsonProperty("port") Integer port,
-        @JsonProperty("parentThreads") Integer parentThreads,
-        @JsonProperty("childThreads") Integer childThreads,
+        @JsonProperty("host") String host,
+        @JsonProperty("port") Integer port,
         @JsonProperty("maxFrameSize") Integer maxFrameSize
     ) {
         this.address = new InetSocketAddress(Optional.ofNullable(host).orElse(DEFAULT_HOST),
             Optional.ofNullable(port).orElse(DEFAULT_PORT));
-        this.parentThreads = Optional.ofNullable(parentThreads).orElse(DEFAULT_PARENT_THREADS);
-        this.childThreads = Optional.ofNullable(childThreads).orElse(DEFAULT_CHILD_THREADS);
         this.maxFrameSize = Optional.ofNullable(maxFrameSize).orElse(DEFAULT_MAX_FRAME_SIZE);
     }
 
@@ -156,8 +146,6 @@ public class GrpcRpcProtocolModule implements RpcProtocolModule {
     public static class Builder {
         private String host = DEFAULT_HOST;
         private int port = DEFAULT_PORT;
-        private int parentThreads = DEFAULT_PARENT_THREADS;
-        private int childThreads = DEFAULT_CHILD_THREADS;
         private int maxFrameSize = DEFAULT_MAX_FRAME_SIZE;
 
         public Builder host(final String host) {
@@ -170,23 +158,13 @@ public class GrpcRpcProtocolModule implements RpcProtocolModule {
             return this;
         }
 
-        public Builder parentThreads(final int parentThreads) {
-            this.parentThreads = parentThreads;
-            return this;
-        }
-
-        public Builder childThreads(final int childThreads) {
-            this.childThreads = childThreads;
-            return this;
-        }
-
         public Builder maxFrameSize(final int maxFrameSize) {
             this.maxFrameSize = maxFrameSize;
             return this;
         }
 
         public GrpcRpcProtocolModule build() {
-            return new GrpcRpcProtocolModule(host, port, parentThreads, childThreads, maxFrameSize);
+            return new GrpcRpcProtocolModule(host, port, maxFrameSize);
         }
     }
 }

--- a/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcProtocolServer.java
+++ b/rpc/grpc/src/main/java/com/spotify/heroic/rpc/grpc/GrpcRpcProtocolServer.java
@@ -79,12 +79,16 @@ public class GrpcRpcProtocolServer implements LifeCycles {
 
     @Inject
     public GrpcRpcProtocolServer(
-        AsyncFramework async, MetricManager metrics, MetadataManager metadata,
-        SuggestManager suggest, NodeMetadataProvider metadataProvider,
+        AsyncFramework async,
+        MetricManager metrics,
+        MetadataManager metadata,
+        SuggestManager suggest,
+        NodeMetadataProvider metadataProvider,
         @Named("application/json+internal") ObjectMapper mapper,
         @Named("bindFuture") ResolvableFuture<InetSocketAddress> bindFuture,
         @Named("grpcBindAddress") InetSocketAddress address,
-        @Named("maxFrameSize") int maxFrameSize, @Named("boss") NioEventLoopGroup bossGroup,
+        @Named("maxFrameSize") int maxFrameSize,
+        @Named("boss") NioEventLoopGroup bossGroup,
         @Named("worker") NioEventLoopGroup workerGroup
     ) {
         this.async = async;


### PR DESCRIPTION
The port returned as part of the SRV record will be used instead of the port in the config or the default port in the class. If the port is specified in the config it will override the port returned via the SRV record

Cleaned up the docs along with unused parameters like parentThreads and childThreads