### PR TITLE
[tracing] update opencensus

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,7 @@ allprojects {
                 entry 'grpc-core'
             }
 
-            dependencySet(group: 'io.opencensus', version: '0.19.1') {
+            dependencySet(group: 'io.opencensus', version: '0.22.1') {
                 entry 'opencensus-api'
                 entry 'opencensus-impl'
                 entry 'opencensus-contrib-zpages'
@@ -158,7 +158,7 @@ allprojects {
                 entry 'opencensus-contrib-http-util'
             }
             dependency 'com.lightstep.opencensus:lightstep-opencensus-exporter:0.0.2'
-            dependency 'com.lightstep.tracer:tracer-grpc:0.16.2'
+            dependency 'com.lightstep.tracer:tracer-okhttp:0.16.2'
             dependency 'com.lightstep.tracer:java-common:0.16.2'
             dependency 'com.lightstep.tracer:lightstep-tracer-jre:0.14.8'
 

--- a/docs/content/_docs/config.md
+++ b/docs/content/_docs/config.md
@@ -992,14 +992,12 @@ probability: <float> default = 0.01
 # Local port to expose zpages on. Traces are accessible at http://localhost:{port}/tracez
 zpagesPort: <int>
 
-# Configuration for exporting traces to LightStep. Either a collectorHost or grpcCollectorTarget must be defined.
+# Configuration for exporting traces to LightStep.
 lightstep:
-  # Will distribute requests to all satellites returned by the DNS record over gRPC.
-  grpcCollectorTarget: <string>
 
-  # Collector host and port running the Lightstep satellite. Will take priority over grpcCollectorTarget.
-  collectorHost: <string>
-  collectorPort: <int> default = 8282
+  # Collector host and port running the Lightstep satellite.
+  collectorHost: <string> required
+  collectorPort: <int> default = 80
 
   # Lightstep access token
   accessToken: <string> required
@@ -1007,16 +1005,13 @@ lightstep:
   # Component name will set the "service" name in the Lightstep UI
   componentName: <string> default = heroic
 
-  # Reporting interval in millseconds.
+  # Reporting interval in milliseconds.
   reportingIntervalMs: <int> default = 1000
 
   # Max buffered spans
   maxBufferedSpans: <int> default = 1000
 
-  # Perform round robin between all hosts returned by grpcCollectorTarget.
-  grpcRoundRobin: <bool> default = true
-
-  # If enabled, the gRPC client connection will be reset at regular intervals.
-  # Used to load balance on server side.
-  grpcResetClient: <bool> default = false
+  # If enabled, the client connection will be reset at regular intervals.
+  # Used to load balance on client side.
+  resetClient: <bool> default = false
 ```

--- a/heroic-core/build.gradle
+++ b/heroic-core/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation 'io.opencensus:opencensus-contrib-http-util'
     implementation 'io.opencensus:opencensus-contrib-zpages'
     implementation 'com.lightstep.tracer:lightstep-tracer-jre'
-    implementation 'com.lightstep.tracer:tracer-grpc'
+    implementation 'com.lightstep.tracer:tracer-okhttp'
     implementation 'com.lightstep.tracer:java-common'
     implementation 'com.lightstep.opencensus:lightstep-opencensus-exporter'
     implementation 'com.typesafe:config:1.3.2'

--- a/heroic-core/src/main/java/com/spotify/heroic/HeroicCore.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/HeroicCore.java
@@ -135,12 +135,11 @@ public class HeroicCore implements HeroicConfiguration {
     static final boolean DEFAULT_DISABLE_BACKENDS = false;
     static final boolean DEFAULT_SETUP_SHELL_SERVER = true;
 
-    private static final int DEFAULT_LIGHTSTEP_COLLECTOR_PORT = 8282;
+    private static final int DEFAULT_LIGHTSTEP_COLLECTOR_PORT = 80;
     private static final String DEFAULT_LIGHTSTEP_COMPONENT_NAME = "heroic";
     private static final int DEFAULT_LIGHTSTEP_REPORTING_MS = 1_000;
     private static final int DEFAULT_LIGHTSTEP_MAX_BUFFERED_SPANS = 1_000;
-    private static final boolean DEFAULT_LIGHTSTEP_GRPC_ROUNDROBIN = true;
-    private static final boolean DEFAULT_LIGHTSTEP_GRPC_RESET_CLIENT = false;
+    private static final boolean DEFAULT_LIGHTSTEP_RESET_CLIENT = false;
 
     static final UncaughtExceptionHandler uncaughtExceptionHandler = (Thread t, Throwable e) -> {
         try {
@@ -313,8 +312,6 @@ public class HeroicCore implements HeroicConfiguration {
             final String collectorHost = configMap.get("collectorHost");
             final Integer collectorPort = (Integer) config.getOrDefault("collectorPort",
               DEFAULT_LIGHTSTEP_COLLECTOR_PORT);
-            final String grpcCollectorTarget = configMap.get("grpcCollectorTarget");
-
             final String accessToken = configMap.get("accessToken");
             final String componentName = (String) config.getOrDefault("componentName",
               DEFAULT_LIGHTSTEP_COMPONENT_NAME);
@@ -322,19 +319,17 @@ public class HeroicCore implements HeroicConfiguration {
                 DEFAULT_LIGHTSTEP_REPORTING_MS);
             final Integer maxBufferedSpans = (Integer) config.getOrDefault("maxBufferedSpans",
               DEFAULT_LIGHTSTEP_MAX_BUFFERED_SPANS);
-            final Boolean grpcRoundRobin = (Boolean) config.getOrDefault("grpcRoundRobin",
-              DEFAULT_LIGHTSTEP_GRPC_ROUNDROBIN);
-            final Boolean grpcResetClient = (Boolean) config.getOrDefault("grpcResetClient",
-              DEFAULT_LIGHTSTEP_GRPC_RESET_CLIENT);
+            final Boolean resetClient = (Boolean) config.getOrDefault("resetClient",
+              DEFAULT_LIGHTSTEP_RESET_CLIENT);
 
 
             if (accessToken == null) {
                 throw new IllegalArgumentException("Lightstep accessToken must be defined");
             }
 
-            if (collectorHost == null && grpcCollectorTarget == null) {
+            if (collectorHost == null) {
                 throw new IllegalArgumentException(
-                  "Lightstep collectorHost or grpcCollectorTarget must be defined");
+                  "Lightstep collectorHost must be defined");
             }
 
             final Options.OptionsBuilder optionsBuilder = new Options.OptionsBuilder()
@@ -342,17 +337,10 @@ public class HeroicCore implements HeroicConfiguration {
                 .withMaxReportingIntervalMillis(reportingIntervalMs)
                 .withMaxBufferedSpans(maxBufferedSpans)
                 .withCollectorProtocol("http")
-                .withGrpcRoundRobin(grpcRoundRobin)
-                .withResetClient(grpcResetClient)
-                .withComponentName(componentName);
-
-            if (collectorHost != null) {
-                optionsBuilder.withCollectorHost(collectorHost);
-                optionsBuilder.withCollectorPort(collectorPort);
-            } else {
-                optionsBuilder.withGrpcCollectorTarget(grpcCollectorTarget);
-            }
-
+                .withResetClient(resetClient)
+                .withComponentName(componentName)
+                .withCollectorHost(collectorHost)
+                .withCollectorPort(collectorPort);
 
             final Options options;
             try {

--- a/heroic-core/src/main/java/com/spotify/heroic/http/tracing/OpenCensusApplicationEventListener.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/tracing/OpenCensusApplicationEventListener.java
@@ -185,7 +185,9 @@ class OpenCensusApplicationEventListener implements ApplicationEventListener {
                     // tracing can occur.
                     event.getContainerRequest().setProperty(
                         OpenCensusFeature.SPAN_CONTEXT_PROPERTY, requestSpan);
-                    resourceSpan.end();
+                    if (resourceSpan != null) {
+                        resourceSpan.end();
+                    }
                     logVerbose("Response filtering started.");
                     break;
 


### PR DESCRIPTION
The latest version of opencensus has a fix to control how much memory can be used for spans.

Also switch over transport to the satellites to okhttp instead of grpc.

@lmuhlha 