### PR TITLE
fix path to java executable in the openjdk:8 container

### DIFF
--- a/run-heroic.sh
+++ b/run-heroic.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /usr/bin/java $JVM_DEFAULT_ARGS $JVM_ARGS -jar /usr/share/heroic/heroic.jar "$@"
+exec java $JVM_DEFAULT_ARGS $JVM_ARGS -jar /usr/share/heroic/heroic.jar "$@"


### PR DESCRIPTION
Not sure when this happened, but the current revision of the openjdk:8 container in docker hub removed the link to the java executable in `/usr/bin`:

```
$ docker run -it openjdk:8 bash
root@6a2961fa7d6f:/# which java
/usr/local/openjdk-8/bin/java
root@6a2961fa7d6f:/# ls -l /usr/bin/java
ls: cannot access '/usr/bin/java': No such file or directory
root@6a2961fa7d6f:/# echo $PATH
/usr/local/openjdk-8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
root@6a2961fa7d6f:/# exit
```

As a result, `run-heroic.sh` would fail in any recently built container :(