### PR TITLE
Explicitly setting cell timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ parameter. You can use [docs/log4j2-file.xml](/docs/log4j2-file.xml) as a base.
 We run tests with Gradle:
 
 ```
+# Start pubsub emulator
+gcloud beta emulators pubsub start
+
 # run unit tests
 ./gradlew test
 

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/Mutations.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/Mutations.java
@@ -26,7 +26,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import lombok.Data;
+import org.joda.time.DateTime;
 
 public class Mutations {
     private final List<com.google.bigtable.v2.Mutation> mutations;
@@ -66,6 +68,7 @@ public class Mutations {
                     .newBuilder()
                     .setFamilyName(family)
                     .setColumnQualifier(columnQualifier)
+                    .setTimestampMicros(TimeUnit.MILLISECONDS.toMicros(DateTime.now().getMillis()))
                     .setValue(value);
 
             mutations.add(

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/Mutations.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/Mutations.java
@@ -26,9 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import lombok.Data;
-import org.joda.time.DateTime;
 
 public class Mutations {
     private final List<com.google.bigtable.v2.Mutation> mutations;
@@ -68,7 +66,7 @@ public class Mutations {
                     .newBuilder()
                     .setFamilyName(family)
                     .setColumnQualifier(columnQualifier)
-                    .setTimestampMicros(TimeUnit.MILLISECONDS.toMicros(DateTime.now().getMillis()))
+                    .setTimestampMicros(-1)
                     .setValue(value);
 
             mutations.add(


### PR DESCRIPTION
Fixing cell timestamp to be used by BigTable built-in garbage collection.