### PR TITLE
Use new dockerhub build process

### DIFF
--- a/.scripts/trigger_docker_hub.sh
+++ b/.scripts/trigger_docker_hub.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-curl -H "Content-Type: application/json" --data "{\"source_type\": \"Tag\", \"source_name\": \"$TRAVIS_TAG\"}" -X POST https://registry.hub.docker.com/u/spotify/heroic/trigger/$DOCKER_TOKEN/

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,3 @@ after_script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-
-deploy:
-  # trigger docker hub build
-  on:
-      tags: true
-  provider: script
-  script: bash .scripts/trigger_docker_hub.sh


### PR DESCRIPTION
Instead of having travis trigger a dockerhub build, github has been configured to send a webhook to dockerhub to  build the image. Dockerhub will build the master branch and any tags and label the docker image appropriately.