### PR TITLE
[core] allow metric key to be an empty string

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100Proto.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100Proto.java
@@ -90,11 +90,6 @@ public class Spotify100Proto implements ConsumerSchema {
             "time: field must be a positive number: " + metric.toString());
         }
 
-        if (metric.getKey().isEmpty()) {
-          throw new ConsumerSchemaValidationException(
-            "key: field must be defined: " + metric.toString());
-        }
-
         final Series s = Series.of(metric.getKey(), metric.getTagsMap(), metric.getResourceMap());
         final Point p = new Point(metric.getTime(), metric.getValue());
         final List<Point> points = ImmutableList.of(p);

--- a/heroic-core/src/test/java/com/spotify/heroic/consumer/schemas/Spotify100ProtoTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/consumer/schemas/Spotify100ProtoTest.java
@@ -123,14 +123,16 @@ public class Spotify100ProtoTest {
 
 
   @Test
-  public void testKeyDefinedValidationError() throws Exception {
-    exceptionRule.expect(ConsumerSchemaValidationException.class);
-    exceptionRule.expectMessage("key: field must be defined");
-
+  public void testEmptyKeyIsConsumed() throws Exception {
     final Metric metric = Metric.newBuilder().setTime(1000L).build();
     final Batch batch = Batch.newBuilder().addMetric(metric).build();
 
     consumer.consume(Snappy.compress((batch.toByteArray())));
+
+    final Series s = Series.of(metric.getKey(), metric.getTagsMap(), metric.getResourceMap());
+    final Point p = new Point(metric.getTime(), metric.getValue());
+    final List<Point> points = ImmutableList.of(p);
+    verify(ingestion).write(new Ingestion.Request(s, MetricCollection.points(points)));
   }
 
 }


### PR DESCRIPTION
This was supposed to be a null check like the previous schema however with protobuf the key can never be null. The default value for a string in proto is `""` which was making `isEmpty()` be true.