### PR TITLE
[all] Upgrade guava dependency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ allprojects {
     dependencyManagement {
         dependencies {
             dependency 'com.spotify.heroic.repackaged:datastax-driver-core:3.2.0'
-            dependency 'com.spotify:folsom:1.6.0'
+            dependency 'com.spotify:folsom:1.6.2'
 
             dependencySet(group: 'com.spotify.metrics', version: '1.0.2') {
                 entry 'semantic-metrics-core'
@@ -178,7 +178,7 @@ allprojects {
             dependency 'javax.mail:mail:1.4.7'
             dependency 'args4j:args4j:2.33'
             dependency 'org.apache.commons:commons-lang3:3.3.2'
-            dependency 'com.google.guava:guava:20.0'
+            dependency 'com.google.guava:guava:28.0-jre'
             dependency 'io.thekraken:grok:0.1.1'
             dependency 'org.jfree:jfreechart:1.0.19'
             dependency 'joda-time:joda-time:2.8.2'

--- a/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/MemcachedConnectionTest.java
+++ b/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/MemcachedConnectionTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.elasticsearch;
+
+import org.junit.Test;
+
+public class MemcachedConnectionTest {
+    @Test
+    public void testSrvClientCreation() {
+        MemcachedConnection.create("example.com");
+    }
+}

--- a/metric/bigtable/build.gradle
+++ b/metric/bigtable/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     }
     implementation 'io.grpc:grpc-netty'
     implementation 'io.netty:netty-tcnative-boringssl-static:2.0.7.Final'
+    implementation 'com.google.guava:guava'
     implementation project(':heroic-component')
     implementation 'eu.toolchain.serializer:tiny-serializer-core'
     compileOnly 'org.projectlombok:lombok'

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableDataClientImpl.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableDataClientImpl.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 import com.spotify.heroic.async.AsyncObservable;
 import com.spotify.heroic.async.AsyncObserver;
@@ -210,7 +211,7 @@ public class BigtableDataClientImpl implements BigtableDataClient {
             public void onFailure(Throwable t) {
                 future.fail(t);
             }
-        });
+        }, MoreExecutors.directExecutor());
 
         return future;
     }

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableMutatorImpl.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableMutatorImpl.java
@@ -26,6 +26,7 @@ import com.google.cloud.bigtable.grpc.async.BulkMutation;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.ByteString;
 import eu.toolchain.async.AsyncFramework;
@@ -187,7 +188,7 @@ public class BigtableMutatorImpl implements BigtableMutator {
             public void onFailure(Throwable t) {
                 future.fail(t);
             }
-        });
+        }, MoreExecutors.directExecutor());
 
         return future;
     }

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/Async.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/Async.java
@@ -24,6 +24,7 @@ package com.spotify.heroic.metric.datastax;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.ResolvableFuture;
@@ -45,7 +46,7 @@ public final class Async {
             public void onFailure(Throwable t) {
                 target.fail(t);
             }
-        });
+        }, MoreExecutors.directExecutor());
 
         target.onCancelled(() -> {
             source.cancel(false);


### PR DESCRIPTION
The version of guava we were using was incompatible with the updated folsom. Unfortunately, nothing failed until trying to run it with a memcached client enabled in the suggest/metadata backends.

I added a small test for the client creation - it makes a DNS request to `example.com` but doesn't require an actual memcached server.