### PR TITLE
[bigtable] Upgrade bigtable-client-core library.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,6 @@ allprojects {
             dependency 'com.lightstep.tracer:java-common:0.16.2'
             dependency 'com.lightstep.tracer:lightstep-tracer-jre:0.14.8'
 
-            //dependency 'com.google.cloud:google-cloud-core:1.53.0'
             dependencySet(group: 'com.google.cloud', version: '1.56.0') {
                 entry('google-cloud-pubsub') {
                     exclude 'io.grpc:grpc-netty-shaded'
@@ -170,6 +169,7 @@ allprojects {
                 entry 'google-cloud-core'
                 entry 'google-cloud-core-grpc'
             }
+            dependency 'com.google.cloud.bigtable:bigtable-client-core:1.12.1'
 
             dependency 'com.addthis:stream-lib:3.0.0'
             dependency 'org.xerial.snappy:snappy-java:1.1.7.2'

--- a/metric/bigtable/build.gradle
+++ b/metric/bigtable/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation('com.google.cloud.bigtable:bigtable-client-core:1.4.0') {
+    implementation('com.google.cloud.bigtable:bigtable-client-core') {
         exclude group: 'io.grpc', module: 'grpc-netty-shaded'
         exclude group: 'io.grpc', module: 'grpc-core'
         exclude group: 'io.opencensus', module: 'opencensus-api'

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/credentials/ComputeEngineCredentialsBuilder.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/credentials/ComputeEngineCredentialsBuilder.java
@@ -28,7 +28,7 @@ import com.spotify.heroic.metric.bigtable.CredentialsBuilder;
 public class ComputeEngineCredentialsBuilder implements CredentialsBuilder {
     @Override
     public CredentialOptions build() {
-        return CredentialOptions.credential(new ComputeEngineCredentials());
+        return CredentialOptions.credential(ComputeEngineCredentials.create());
     }
 
     public String toString() {


### PR DESCRIPTION
Newer bigtable versions have upgraded their guava dependency. This resolves #553 