### PR TITLE
Take resource tags into account when generating the hash code

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/common/Series.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/Series.java
@@ -57,6 +57,10 @@ public class Series implements Comparable<Series> {
     @AutoSerialize.Ignore
     final HashCode hashCode;
 
+    @AutoSerialize.Ignore
+    final HashCode hashCodeTagOnly;
+
+
     /**
      * Package-private constructor to avoid invalid inputs.
      *
@@ -83,6 +87,7 @@ public class Series implements Comparable<Series> {
         this.tags = checkNotNull(tags, "tags");
         this.resource = checkNotNull(resource, "resource");
         this.hashCode = generateHash();
+        this.hashCodeTagOnly = generateHashTagOnly();
     }
 
     public String getKey() {
@@ -95,11 +100,6 @@ public class Series implements Comparable<Series> {
 
     public SortedMap<String, String> getResource() {
         return resource;
-    }
-
-    @JsonIgnore
-    public HashCode getHashCode() {
-        return hashCode;
     }
 
     private HashCode generateHash() {
@@ -122,7 +122,20 @@ public class Series implements Comparable<Series> {
             }
         }
 
-        return hasher.hash();
+        for (final Map.Entry<String, String> kv : resource.entrySet()) {
+          final String k = kv.getKey();
+          final String v = kv.getValue();
+
+          if (k != null) {
+            hasher.putString(k, Charsets.UTF_8);
+          }
+
+          if (v != null) {
+            hasher.putString(v, Charsets.UTF_8);
+          }
+        }
+
+      return hasher.hash();
     }
 
     public String hash() {
@@ -132,6 +145,34 @@ public class Series implements Comparable<Series> {
     @Override
     public int hashCode() {
         return hashCode.asInt();
+    }
+
+    @JsonIgnore
+    public HashCode getHashCodeTagOnly() {
+      return hashCodeTagOnly;
+    }
+
+    private HashCode generateHashTagOnly() {
+      final Hasher hasher = HASH_FUNCTION.newHasher();
+
+      if (key != null) {
+        hasher.putString(key, Charsets.UTF_8);
+      }
+
+      for (final Map.Entry<String, String> kv : tags.entrySet()) {
+        final String k = kv.getKey();
+        final String v = kv.getValue();
+
+        if (k != null) {
+          hasher.putString(k, Charsets.UTF_8);
+        }
+
+        if (v != null) {
+          hasher.putString(v, Charsets.UTF_8);
+        }
+      }
+
+      return hasher.hash();
     }
 
     @Override

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/AnalyticsDumpFetchSeries.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/AnalyticsDumpFetchSeries.java
@@ -77,7 +77,7 @@ public class AnalyticsDumpFetchSeries implements ShellTask {
                 io
                     .out()
                     .println(mapper.writeValueAsString(new AnalyticsHits(series.getSeries(),
-                        series.getSeries().getHashCode().toString(), series.getHits())));
+                        series.getSeries().getHashCodeTagOnly().toString(), series.getHits())));
             } catch (JsonProcessingException e) {
                 throw new RuntimeException(e);
             }

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/MetadataEntries.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/MetadataEntries.java
@@ -97,7 +97,7 @@ public class MetadataEntries implements ShellTask {
                     io
                         .out()
                         .println(mapper.writeValueAsString(
-                            new AnalyticsSeries(series.getHashCode().toString(),
+                            new AnalyticsSeries(series.getHashCodeTagOnly().toString(),
                                 mapper.writeValueAsString(series))));
                 } catch (final Exception e) {
                     log.error("Failed to print series: {}", series, e);

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/MetadataFindSeries.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/MetadataFindSeries.java
@@ -90,7 +90,7 @@ public class MetadataFindSeries implements ShellTask {
                         io
                             .out()
                             .println(mapper.writeValueAsString(
-                                new AnalyticsSeries(series.getHashCode().toString(),
+                                new AnalyticsSeries(series.getHashCodeTagOnly().toString(),
                                     mapper.writeValueAsString(series))));
                     } catch (final Exception e) {
                         throw new RuntimeException(e);

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
@@ -217,7 +217,7 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
                 try (Scope ws = tracer.withSpan(span)) {
                     span.putAttribute("index", AttributeValue.stringAttributeValue(index));
 
-                    if (!writeCache.acquire(Pair.of(index, series.getHashCode()),
+                    if (!writeCache.acquire(Pair.of(index, series.getHashCodeTagOnly()),
                         reporter::reportWriteDroppedByCacheHit)) {
                         span.setStatus(
                             Status.ALREADY_EXISTS.withDescription("Write dropped by cache hit"));

--- a/suggest/elasticsearch/src/main/java/com/spotify/heroic/suggest/elasticsearch/SuggestBackendKV.java
+++ b/suggest/elasticsearch/src/main/java/com/spotify/heroic/suggest/elasticsearch/SuggestBackendKV.java
@@ -572,7 +572,7 @@ public class SuggestBackendKV extends AbstractElasticsearchBackend
                 final Scope indexScope = tracer.withSpan(indexSpan);
                 indexSpan.putAttribute("index", AttributeValue.stringAttributeValue(index));
 
-                final Pair<String, HashCode> key = Pair.of(index, s.getHashCode());
+                final Pair<String, HashCode> key = Pair.of(index, s.getHashCodeTagOnly());
 
                 if (!writeCache.acquire(key, reporter::reportWriteDroppedByCacheHit)) {
                     indexSpan.setStatus(


### PR DESCRIPTION

generateHash takes into account tags but not resource identifiers, so series with different resource identifiers end up looking the same. This leads to alerts not matching up and getting resolved properly, etc. 

Need to take the resource identifiers into account to remediate this issue, and keep a tag-only version for metadata/suggest cache matching. 