### PR TITLE
[core] add jaxb-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,6 +201,9 @@ allprojects {
                 entry 'jetty-rewrite'
                 entry 'jetty-util'
             }
+            
+            dependency 'javax.xml.bind:jaxb-api:2.3.1'
+            
             dependency 'org.eclipse.jetty.http2:http2-server:9.4.12.v20180830'
 
             dependency 'javax.servlet:javax.servlet-api:3.1.0'

--- a/heroic-core/build.gradle
+++ b/heroic-core/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation 'org.eclipse.jetty:jetty-server'
     implementation 'org.eclipse.jetty.http2:http2-server'
     implementation 'javax.mail:mail'
+    implementation 'javax.xml.bind:jaxb-api'
     implementation 'org.eclipse.jetty:jetty-rewrite'
     implementation 'org.eclipse.jetty:jetty-util'
     implementation 'org.glassfish.jersey.containers:jersey-container-servlet-core'


### PR DESCRIPTION
With java11 this library is no longer included and needs to be explicitly added