### PR TITLE
[aggregation] add ratePerSecond

### DIFF
--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/DistributedBucketInstance.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/DistributedBucketInstance.java
@@ -29,6 +29,10 @@ import com.spotify.heroic.metric.MetricType;
 
 import java.util.Set;
 
+/*
+   Any aggregation using this bucket will have its updateSpreads method called given
+   distributed() is overridden to return Spreads and  "Set<MetricType> input" includes it.
+ */
 public abstract class DistributedBucketInstance<B extends Bucket>
     extends BucketAggregationInstance<B> {
     public DistributedBucketInstance(

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Module.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Module.java
@@ -86,6 +86,9 @@ public class Module implements HeroicModule {
 
             c.register(Max.NAME, Max.class, MaxInstance.class, samplingBuilder(Max::new));
 
+            c.register(RatePerSecond.NAME, RatePerSecond.class, RatePerSecondInstance.class,
+                samplingBuilder(RatePerSecond::new));
+
             c.register(StdDev.NAME, StdDev.class, StdDevInstance.class,
                 samplingBuilder(StdDev::new));
 

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/RatePerSecond.kt
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/RatePerSecond.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.spotify.heroic.aggregation.AggregationContext
+import com.spotify.heroic.aggregation.SamplingAggregation
+import com.spotify.heroic.aggregation.SamplingQuery
+import com.spotify.heroic.common.Duration
+
+data class RatePerSecond(override var size: Duration?, override var extent: Duration?)
+    : SamplingAggregation {
+
+    @JsonCreator
+    constructor(sampling: SamplingQuery?, size: Duration?, extent: Duration?) :
+        this(size ?: sampling?.size, extent ?: sampling?.extent)
+
+    override fun apply(context: AggregationContext?, size: Long, extent: Long): RatePerSecondInstance {
+        return RatePerSecondInstance(size, extent)
+    }
+
+    companion object {
+        const val NAME = "ratePerSecond"
+    }
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/RatePerSecondInstance.kt
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/RatePerSecondInstance.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2019 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple
+
+import com.google.common.collect.ImmutableSet
+import com.google.common.util.concurrent.AtomicDouble
+import com.spotify.heroic.aggregation.AbstractBucket
+import com.spotify.heroic.aggregation.AggregationInstance
+import com.spotify.heroic.aggregation.BucketAggregationInstance
+import com.spotify.heroic.aggregation.DoubleBucket
+import com.spotify.heroic.metric.Metric
+import com.spotify.heroic.metric.MetricType
+import com.spotify.heroic.metric.Point
+
+/*
+    Calculate the rate per second of cumulative counters. When the counter is reset
+    because of an instance restart the interval will be skipped.
+ */
+data class RatePerSecondInstance(
+    override val size: Long,
+    override val extent: Long
+) : BucketAggregationInstance<RatePerSecondInstance.RateBucket>(size,
+    extent,
+    ImmutableSet.of(MetricType.POINT),
+    MetricType.POINT
+) {
+    override fun distributable(): Boolean {
+        return false
+    }
+
+    override fun buildBucket(timestamp: Long): RateBucket {
+        return RateBucket(timestamp)
+    }
+
+    override fun reducer(): AggregationInstance {
+        return SumInstance(size, extent)
+    }
+
+    override fun build(bucket: RateBucket): Metric {
+        val value = bucket.value()
+
+        return if (java.lang.Double.isNaN(value)) {
+            Metric.invalid
+        } else Point(bucket.timestamp, value)
+    }
+
+    data class RateBucket(override val timestamp: Long) : AbstractBucket(), DoubleBucket {
+        private var firstPoint: Point? = null
+        private var lastPoint: Point? = null
+        private val rate = AtomicDouble()
+
+        override fun updatePoint(key: Map<String, String>, sample: Point) {
+            if (firstPoint == null) {
+                firstPoint = sample
+            }
+
+            // Don't produce a negative value when a monotonically increasing counter is reset.
+            if (sample.value > lastPoint?.value ?: sample.value) {
+                rate.addAndGet(sample.value - lastPoint!!.value)
+            }
+            lastPoint = sample
+        }
+
+        override fun value(): Double {
+            val timeDiff = (lastPoint?.timestamp ?: 0) - (firstPoint?.timestamp ?: 0)
+            return (rate.toDouble()/timeDiff * 1000)
+        }
+    }
+
+}

--- a/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/RatePerSecondTest.java
+++ b/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/RatePerSecondTest.java
@@ -1,0 +1,98 @@
+package com.spotify.heroic.aggregation.simple;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.spotify.heroic.aggregation.AggregationSession;
+import com.spotify.heroic.common.DateRange;
+import com.spotify.heroic.common.Series;
+import com.spotify.heroic.metric.Point;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+public class RatePerSecondTest {
+    final private long startRange = 1571686200000L;
+    final private long endRange = 1571687100000L;
+    final private DateRange fifteenMinuteRange = new DateRange(startRange, endRange);
+    final private Map<String, String> group = ImmutableMap.of();
+    final private Set<Series> series = ImmutableSet.of();
+
+    private List<Point> makePoints() {
+        final ArrayList<Point> points = new ArrayList<>();
+        points.add(new Point(1571686240329L,100.0));
+        points.add(new Point(1571686300329L,200.0));
+        points.add(new Point(1571686360329L,500.0));
+        points.add(new Point(1571686420329L,1_000.0));
+        points.add(new Point(1571686480329L,1_000.0));
+        points.add(new Point(1571686540329L,1_100.0));
+        points.add(new Point(1571686600329L,1_200.0));
+        points.add(new Point(1571686660329L,1_300.0));
+        points.add(new Point(1571686720329L,1_500.0));
+        points.add(new Point(1571686780329L,1_600.0));
+        points.add(new Point(1571686840329L,1_900.0));
+        points.add(new Point(1571686900329L,3_100.0));
+        points.add(new Point(1571686960329L,3_200.0));
+        points.add(new Point(1571687020329L,3_300.0));
+        points.add(new Point(1571687080329L,3_400.0));
+        return points;
+    }
+
+    @Test
+    public void testTwoMinuteSamplingWindowNoCounterResets() {
+        final long sampleResolution = Duration.ofMinutes(2).toMillis();
+        final RatePerSecondInstance rateInstance =
+            new RatePerSecondInstance(sampleResolution, sampleResolution);
+        final AggregationSession session = rateInstance.session(fifteenMinuteRange);
+
+        session.updatePoints(group, series,  makePoints());
+
+        final List<Point> p = (List<Point>)
+            session.result().getResult().get(0).getMetrics().data();
+
+        assertEquals(1.66, p.get(0).getValue(), 0.01);
+        assertEquals(8.33, p.get(1).getValue(), 0.01);
+        assertEquals(1.66, p.get(6).getValue(), 0.01);
+    }
+
+    @Test
+    public void testSamplingWindowEqualResolutionNoCounterResets() {
+        final long sampleResolution = Duration.ofMinutes(15).toMillis();
+        final RatePerSecondInstance rateInstance =
+            new RatePerSecondInstance(sampleResolution, sampleResolution);
+        final AggregationSession session = rateInstance.session(fifteenMinuteRange);
+
+        session.updatePoints(group, series,  makePoints());
+
+        final List<Point> p = (List<Point>)
+            session.result().getResult().get(0).getMetrics().data();
+
+        assertEquals(3.928, p.get(0).getValue(), 0.01);
+    }
+
+    @Test
+    public void testSamplingWindowEqualResolutionCounterReset() {
+        final long sampleResolution = Duration.ofMinutes(15).toMillis();
+        final RatePerSecondInstance rateInstance =
+            new RatePerSecondInstance(sampleResolution, sampleResolution);
+        final AggregationSession session = rateInstance.session(fifteenMinuteRange);
+
+        final List<Point> points = makePoints();
+        points.add(1, new Point(1571686300329L, 0D));
+        points.remove(2);
+
+        session.updatePoints(group, series,  points);
+
+        final List<Point> p = (List<Point>)
+            session.result().getResult().get(0).getMetrics().data();
+
+        assertEquals(4.047, p.get(0).getValue(), 0.01);
+    }
+
+
+
+}

--- a/docs/content/_docs/aggregations.html
+++ b/docs/content/_docs/aggregations.html
@@ -20,6 +20,7 @@ title: Aggregations
   <li><a href="#count">Count Aggregation</a></li>
   <li><a href="#delta">Delta Aggregation</a></li>
   <li><a href="#deltapersec">Delta per Second Aggregation</a></li>
+  <li><a href="#ratepersec">Rate per Second Aggregation</a></li>
   <li><a href="#max">Maximum Aggregation</a></li>
   <li><a href="#min">Minimum Aggregation</a></li>
   <li><a href="#notneg">Not Negative Aggregation</a></li>
@@ -157,7 +158,9 @@ delta()
 <h5>Description</h5>
 
 <p>
-  The delta aggregation calculates the change between samples in a given extent.
+  The delta aggregation calculates the difference between samples in a given extent.<br /><br />
+
+  It's intended to be used with gauges and can produce negative values.
 </p>
 
 
@@ -181,7 +184,42 @@ deltaPerSecond()
 <h5>Description</h5>
 
 <p>
-  The delta per second aggregation calculates the change per second between samples in a given extent.
+  The delta per second aggregation calculates the difference per second between samples in a given extent.<br /><br />
+
+  It's intended to be used with gauges and can produce negative values.
+</p>
+
+<h3 id="ratepersec">
+  Rate per Second Aggregation
+  <a class="link-to" href="#ratepersec"><span class="glyphicon glyphicon-link"></span></a>
+</h3>
+
+<h5>JSON</h5>
+
+<pre><code class="language-json">
+{"type": "ratePerSecond"}
+</code></pre>
+
+<h5>HQL</h5>
+
+<pre><code class="language-hql">
+ratePerSecond()
+</code></pre>
+
+<h5>Description</h5>
+
+<p>
+  The rate per second aggregation calculates the rate per second between samples in a given extent.<br /><br />
+
+  Rate per second works with sampling. If a queries resolution is 1 minute and points are published
+  every 30s each bucket will contain 2 points. The rate will be calculated by getting the difference
+  between the two points values and dividing them by the time between the points.<br /><br />
+
+  Note: at least 2 points are required in order to calculate the rate. Otherwise the previous value
+  is unknown.<br /><br />
+
+  It's intended to be used with cumulative counters. It will handle the counters being reset because
+  of restarts, etc.
 </p>
 
 


### PR DESCRIPTION
The rate per second aggregation calculates the rate per second between samples in a given extent.

Rate per second works with sampling. If a queries resolution is 1 minute and points are published every 30s each bucket will contain 2 points. The rate will be calculated by getting the difference between the two points values and dividing them by the time between the points.

Note: at least 2 points are required in order to calculate the rate. Otherwise the previous value is unknown.

It's intended to be used with cumulative counters. It will handle the counters being reset because of restarts, etc.


I reimplemented an earlier pull request #408 that implemented `ratePerSecond` similarly to how `deltaPerSecond` works which does not support sampling the data. I think sampling is a requirement for most aggregations otherwise a large number of timeseries and points will likely cause the frontend to crash or produce graphs that are hard to read.

This closes #452. 