### PR TITLE
[tracing] add version and only a whitelisted set of request headers

### DIFF
--- a/docs/content/_docs/config.md
+++ b/docs/content/_docs/config.md
@@ -988,6 +988,10 @@ probability: <float> default = 0.01
 # Local port to expose zpages on. Traces are accessible at http://localhost:{port}/tracez
 zpagesPort: <int>
 
+# Add request headers if present as tags to the trace.
+requestHeadersToTags:
+- x-user-request
+
 # Configuration for exporting traces to LightStep.
 lightstep:
 

--- a/heroic-component/src/main/java/com/spotify/heroic/tracing/TracingConfig.kt
+++ b/heroic-component/src/main/java/com/spotify/heroic/tracing/TracingConfig.kt
@@ -1,0 +1,19 @@
+package com.spotify.heroic.tracing
+
+data class TracingConfig (
+    val probability: Double = 0.01,
+    val zpagesPort: Int = 0,
+    val requestHeadersToTags: List<String> = listOf(),
+    val lightstep: Lightstep = Lightstep()
+) {
+    data class Lightstep (
+        val collectorHost: String = "",
+        val collectorPort: Int = 80,
+        val accessToken: String = "",
+        val componentName: String = "heroic",
+        val reportingIntervalMs: Int = 1000,
+        val maxBufferedSpans: Int = 5000,
+        val resetClient: Boolean = false
+    )
+}
+

--- a/heroic-core/src/main/java/com/spotify/heroic/HeroicConfig.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/HeroicConfig.java
@@ -57,15 +57,14 @@ import com.spotify.heroic.shell.ShellServerModule;
 import com.spotify.heroic.statistics.StatisticsModule;
 import com.spotify.heroic.statistics.noop.NoopStatisticsModule;
 import com.spotify.heroic.suggest.SuggestManagerModule;
+import com.spotify.heroic.tracing.TracingConfig;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.LoggerFactory;
@@ -95,7 +94,7 @@ public abstract class HeroicConfig {
         StatisticsModule statistics,
         QueryLoggingModule queryLogging,
         Optional<ConditionalFeatures> conditionalFeatures,
-        Map<String, Object> tracing,
+        TracingConfig tracing,
         String version,
         String service,
         String commit
@@ -149,7 +148,7 @@ public abstract class HeroicConfig {
     public abstract StatisticsModule statistics();
     public abstract QueryLoggingModule queryLogging();
     public abstract Optional<ConditionalFeatures> conditionalFeature();
-    public abstract Map<String, Object> tracing();
+    public abstract TracingConfig tracing();
 
     public abstract String version();
     public abstract String service();
@@ -229,7 +228,7 @@ public abstract class HeroicConfig {
         private Optional<StatisticsModule> statistics = empty();
         private Optional<QueryLoggingModule> queryLogging = empty();
         private Optional<ConditionalFeatures> conditionalFeatures = empty();
-        private Optional<Map<String, Object>> tracing = empty();
+        private Optional<TracingConfig> tracing = empty();
 
         private Optional<String> version = empty();
         private Optional<String> service = empty();
@@ -261,7 +260,7 @@ public abstract class HeroicConfig {
             @JsonProperty("statistics") Optional<StatisticsModule> statistics,
             @JsonProperty("queryLogging") Optional<QueryLoggingModule> queryLogging,
             @JsonProperty("conditionalFeatures") Optional<ConditionalFeatures> conditionalFeatures,
-            @JsonProperty("tracing") Optional<Map<String, Object>> tracing,
+            @JsonProperty("tracing") Optional<TracingConfig> tracing,
             @JsonProperty("version") Optional<String> version,
             @JsonProperty("service") Optional<String> service
         ) {
@@ -383,7 +382,7 @@ public abstract class HeroicConfig {
             return this;
         }
 
-        public Builder tracing(Map<String, Object> tracing) {
+        public Builder tracing(TracingConfig tracing) {
             this.tracing = of(tracing);
             return this;
         }
@@ -452,7 +451,7 @@ public abstract class HeroicConfig {
                 statistics.orElseGet(NoopStatisticsModule::new),
                 queryLogging.orElseGet(NoopQueryLoggingModule::new),
                 conditionalFeatures,
-                tracing.orElseGet(HashMap::new),
+                tracing.orElse(new TracingConfig()),
                 version.orElseGet(this::loadDefaultVersion),
                 service.orElse(DEFAULT_SERVICE),
                 loadCommit()

--- a/heroic-core/src/main/java/com/spotify/heroic/http/HttpServerModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/HttpServerModule.java
@@ -24,6 +24,7 @@ package com.spotify.heroic.http;
 import com.spotify.heroic.jetty.JettyServerConnector;
 import com.spotify.heroic.lifecycle.LifeCycle;
 import com.spotify.heroic.lifecycle.LifeCycleManager;
+import com.spotify.heroic.tracing.TracingConfig;
 import dagger.Provides;
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -36,15 +37,19 @@ public class HttpServerModule {
     private final boolean enableCors;
     private final Optional<String> corsAllowOrigin;
     private final List<JettyServerConnector> connectors;
+    private final TracingConfig tracingConfig;
 
     @java.beans.ConstructorProperties({ "bind", "enableCors", "corsAllowOrigin", "connectors" })
-    public HttpServerModule(final InetSocketAddress bind, final boolean enableCors,
+    public HttpServerModule(final InetSocketAddress bind,
+                            final boolean enableCors,
                             final Optional<String> corsAllowOrigin,
-                            final List<JettyServerConnector> connectors) {
+                            final List<JettyServerConnector> connectors,
+                            final TracingConfig tracingConfig) {
         this.bind = bind;
         this.enableCors = enableCors;
         this.corsAllowOrigin = corsAllowOrigin;
         this.connectors = connectors;
+        this.tracingConfig = tracingConfig;
     }
 
     @Provides
@@ -72,6 +77,13 @@ public class HttpServerModule {
     @HttpServerScope
     List<JettyServerConnector> connectors() {
         return connectors;
+    }
+
+    @Provides
+    @Named("tracingConfig")
+    @HttpServerScope
+    TracingConfig tracingConfig() {
+        return tracingConfig;
     }
 
     @Provides

--- a/heroic-core/src/main/java/com/spotify/heroic/http/tracing/OpenCensusFeature.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/tracing/OpenCensusFeature.java
@@ -21,6 +21,8 @@
 
 package com.spotify.heroic.http.tracing;
 
+import com.spotify.heroic.common.ServiceInfo;
+import com.spotify.heroic.tracing.TracingConfig;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
@@ -29,20 +31,16 @@ import org.apache.commons.lang3.NotImplementedException;
 
 public class OpenCensusFeature implements Feature {
     private final Verbosity verbosity;
+    private final TracingConfig tracing;
+    private final ServiceInfo serviceInfo;
 
     /**
      * Creates feature instance with default ({@link Verbosity#INFO} verbosity level.
      */
-    public OpenCensusFeature() {
-        verbosity = Verbosity.INFO;
-    }
-
-    /**
-     * Creates feature instance with given ({@link Verbosity} level.
-     * @param verbosity desired level of logging verbosity
-     */
-    public OpenCensusFeature(Verbosity verbosity) {
-        this.verbosity = verbosity;
+    public OpenCensusFeature(final TracingConfig tracing, final ServiceInfo serviceInfo) {
+        this.tracing = tracing;
+        this.serviceInfo = serviceInfo;
+        this.verbosity = Verbosity.INFO;
     }
 
     /**
@@ -57,7 +55,8 @@ public class OpenCensusFeature implements Feature {
             case CLIENT:
                 throw new NotImplementedException("Client tracing not implemented");
             case SERVER:
-                context.register(new OpenCensusApplicationEventListener(verbosity));
+                context.register(new OpenCensusApplicationEventListener(
+                    verbosity, tracing, serviceInfo));
             default:
                 // This can't happen.
         }

--- a/heroic-core/src/main/java/com/spotify/heroic/http/tracing/OpenCensusUtils.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/tracing/OpenCensusUtils.java
@@ -25,30 +25,9 @@ import io.opencensus.trace.Status;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import javax.ws.rs.core.MultivaluedMap;
 
 class OpenCensusUtils {
-    private OpenCensusUtils() {
-    }
-
-    /**
-     * Convert request/response headers from {@link MultivaluedMap} into printable form.
-     *
-     * @param headers multi-valued map of request or response headers
-     * @return {@code String} representation, e.g. "[header1=foo]; [header2=bar, baz]"
-     */
-    static String headersAsString(final MultivaluedMap<String, ?> headers) {
-        return headers.entrySet()
-            .stream()
-            .map((entry) -> "["
-                            + entry.getKey() + "="
-                            + entry.getValue()
-                                .stream()
-                                .map(Object::toString)
-                                .collect(Collectors.joining(", "))
-                            + "]")
-            .collect(Collectors.joining("; "));
-    }
+    private OpenCensusUtils() { }
 
     static String formatList(List<?> list) {
         return list.stream().map(Object::toString).collect(Collectors.joining(", "));


### PR DESCRIPTION
* the version tag is now a tag on a trace.
* configure which request headers should be tags via `requestHeadersToTags` rather than adding all the headers.
* moved the tracing config to be typed.