### PR TITLE
Add git to the docker build.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-/.git/
 Dockerfile
 .dockerignore
 .gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM maven:3.5.4-jdk-11 as builder
 LABEL maintainer "layer8 <layer8@spotify.com>"
 
+RUN apt-get update && apt-get install -y git
 COPY . .
 RUN tools/install-repackaged
 RUN _JAVA_OPTIONS=-Djdk.net.URLClassPath.disableClassPathURLCheck=true ./gradlew clean assemble


### PR DESCRIPTION
In #572 we started using the `git` cli to parse the branch/tag and set version information in the build. This broke the Docker build (reported in #577) since the builder image didn't have git installed.