### PR TITLE
Chain aggregation fix missing type id

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/Chain.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/Chain.java
@@ -21,6 +21,7 @@
 
 package com.spotify.heroic.aggregation;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -32,7 +33,7 @@ public class Chain implements Aggregation {
 
     private final List<Aggregation> chain;
 
-    public Chain(List<Aggregation> chain) {
+    public Chain(@JsonProperty("chain") List<Aggregation> chain) {
         this.chain = chain;
     }
 

--- a/heroic-component/src/test/java/com/spotify/heroic/aggregation/ChainDeserializeTest.java
+++ b/heroic-component/src/test/java/com/spotify/heroic/aggregation/ChainDeserializeTest.java
@@ -1,0 +1,24 @@
+package com.spotify.heroic.aggregation;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ChainDeserializeTest {
+
+  private ObjectMapper mapper;
+
+  @Before
+  public void setup() {
+    mapper = new ObjectMapper();
+  }
+
+  @Test
+  public void testDeserialize() throws Exception {
+    assertEquals(Chain.class, mapper.readValue("{\"chain\":[]}", Chain.class).getClass());
+
+  }
+
+}

--- a/heroic-component/src/test/java/com/spotify/heroic/aggregation/ChainTest.java
+++ b/heroic-component/src/test/java/com/spotify/heroic/aggregation/ChainTest.java
@@ -2,7 +2,6 @@ package com.spotify.heroic.aggregation;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
 
 import java.io.IOException;
 import org.junit.Before;


### PR DESCRIPTION
Using:
 "aggregators": [{"type": "chain", "chain": [{"type": "delta"}, {"type": "sum", "size": "60s"}]}], 

Replicated the error in production. Tested the fix locally with the same query.