### PR TITLE
[tools] update query log mapping for es7

### DIFF
--- a/tools/querylog
+++ b/tools/querylog
@@ -55,8 +55,8 @@ def main():
 
     common = mappings.get('_common', {})
 
-    for (type, mapping) in mappings.items():
-        if type.startswith('_'):
+    for (type_, mapping) in mappings.items():
+        if type_.startswith('_'):
             continue
 
         mapping = dict(mapping)
@@ -83,16 +83,16 @@ def main():
             }
 
         template = {
-            "template": "{}-{}-*".format(index_base, type),
+            "index_patterns": "{}-{}-*".format(index_base, type_),
             "settings": settings,
             "mappings": {
-                "entry": mapping
+                "properties": mapping['properties']
             }
         }
 
         if ns.commit:
             for host in hosts:
-                url = '{}/_template/{}-{}'.format(host, index_base, type)
+                url = '{}/_template/{}-{}'.format(host, index_base, type_)
                 print("PUT", url)
                 response = requests.put(url, json=template)
                 print(response.text)

--- a/tools/querylog_mappings.yaml
+++ b/tools/querylog_mappings.yaml
@@ -23,8 +23,8 @@ _raw_object: &raw_object
   enabled: false
 
 _raw_string: &raw_string
-  type: string
-  analyzer: "keyword"
+  type: keyword
+  index: true
 
 _HttpContext: &http_context
   properties:

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,4 +1,2 @@
 requests
 PyYAML
-
-


### PR DESCRIPTION
the string type in es7 has been deprecated and has been replaced with keyword.

https://www.elastic.co/blog/strings-are-dead-long-live-strings