### PR TITLE
[pubsub] use latest version of netty-tcnative-boringssl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,7 +152,13 @@ allprojects {
                 entry 'tiny-serializer-processor'
             }
 
-            dependency 'io.netty:netty-transport:4.1.31.Final'
+            dependencySet(group: 'io.netty', version: '4.1.31.Final') {
+                entry 'netty-transport'
+                entry 'netty-transport-native-epoll'
+                entry 'netty-codec'
+            }
+
+            dependency 'io.netty:netty-tcnative-boringssl-static:2.0.28.Final'
 
             dependencySet(group: 'io.grpc', version: '1.16.1') {
                 entry 'grpc-auth'

--- a/consumer/pubsub/build.gradle
+++ b/consumer/pubsub/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     implementation 'com.google.cloud:google-cloud-pubsub'
     implementation 'io.grpc:grpc-netty'
+    implementation 'io.netty:netty-tcnative-boringssl-static'
     implementation project(':heroic-component')
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/metric/bigtable/build.gradle
+++ b/metric/bigtable/build.gradle
@@ -8,7 +8,7 @@ dependencies {
         exclude group: 'io.dropwizard.metrics', module: 'metrics-core'
     }
     implementation 'io.grpc:grpc-netty'
-    implementation 'io.netty:netty-tcnative-boringssl-static:2.0.7.Final'
+    implementation 'io.netty:netty-tcnative-boringssl-static'
     implementation 'com.google.guava:guava'
     implementation project(':heroic-component')
     implementation 'eu.toolchain.serializer:tiny-serializer-core'


### PR DESCRIPTION
Otherwise when the pubsub connection is setup with SSL there is a run time error. Not quite sure how the dependency tree changed with Netty when the elasticsearch library was updated since the Netty version was always pinned 🤔.