### PR TITLE
[metadata] clear search scroll when complete

### DIFF
--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/Connection.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/Connection.java
@@ -29,7 +29,6 @@ import eu.toolchain.async.ResolvableFuture;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequestBuilder;
 import org.elasticsearch.action.delete.DeleteRequestBuilder;
@@ -142,7 +141,6 @@ public class Connection {
         return client.getClient().prepareSearchScroll(scrollId);
     }
 
-    @Nonnull
     public ClearScrollRequestBuilder clearSearchScroll(String scrollId) {
       return client.getClient().prepareClearScroll().addScrollId(scrollId);
     }

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/Connection.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/Connection.java
@@ -29,6 +29,7 @@ import eu.toolchain.async.ResolvableFuture;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequestBuilder;
 import org.elasticsearch.action.delete.DeleteRequestBuilder;
@@ -141,6 +142,7 @@ public class Connection {
         return client.getClient().prepareSearchScroll(scrollId);
     }
 
+    @Nonnull
     public ClearScrollRequestBuilder clearSearchScroll(String scrollId) {
       return client.getClient().prepareClearScroll().addScrollId(scrollId);
     }

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/Connection.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/Connection.java
@@ -33,6 +33,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequestBuilder;
 import org.elasticsearch.action.delete.DeleteRequestBuilder;
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.ClearScrollRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchScrollRequestBuilder;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -138,6 +139,10 @@ public class Connection {
 
     public SearchScrollRequestBuilder prepareSearchScroll(String scrollId) {
         return client.getClient().prepareSearchScroll(scrollId);
+    }
+
+    public ClearScrollRequestBuilder clearSearchScroll(String scrollId) {
+      return client.getClient().prepareClearScroll().addScrollId(scrollId);
     }
 
     public List<DeleteRequestBuilder> delete(String type, String id)

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/ScrollTransformResult.kt
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/ScrollTransformResult.kt
@@ -23,10 +23,12 @@ package com.spotify.heroic.elasticsearch
 
 import com.google.common.collect.ImmutableSet
 
-data class LimitedSet<T>(val set: Set<T>?, val isLimited: Boolean) {
+data class ScrollTransformResult<T>(
+    val set: Set<T>, val isLimited: Boolean, val lastScrollId: String?) {
+
     companion object {
-        @JvmStatic fun <T> of(): LimitedSet<T> {
-            return LimitedSet(ImmutableSet.of<T>(), false)
+        @JvmStatic fun <T> of(): ScrollTransformResult<T> {
+            return ScrollTransformResult(ImmutableSet.of<T>(), false, null)
         }
     }
 }

--- a/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/ScrollTransformStreamTest.java
+++ b/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/ScrollTransformStreamTest.java
@@ -40,7 +40,7 @@ public class ScrollTransformStreamTest {
     private AsyncFramework async;
 
     @Mock
-    private AsyncFuture<LimitedSet> resolved;
+    private AsyncFuture<ScrollTransformResult> resolved;
 
     @Mock
     private Supplier<AsyncFuture<SearchResponse>> scroller;
@@ -82,12 +82,12 @@ public class ScrollTransformStreamTest {
 
         doReturn(scroller).when(scrollerFactory).apply(any(String.class));
         doReturn(response).when(scroller).get();
-        doAnswer(new Answer<AsyncFuture<LimitedSet<Integer>>>() {
-            public AsyncFuture<LimitedSet<Integer>> answer(
+        doAnswer(new Answer<AsyncFuture<ScrollTransformResult<Integer>>>() {
+            public AsyncFuture<ScrollTransformResult<Integer>> answer(
                 InvocationOnMock invocation
             ) throws Exception {
-                final LazyTransform<SearchResponse, LimitedSet<Integer>> transform =
-                    (LazyTransform<SearchResponse, LimitedSet<Integer>>) invocation.getArguments
+                final LazyTransform<SearchResponse, ScrollTransformResult<Integer>> transform =
+                    (LazyTransform<SearchResponse, ScrollTransformResult<Integer>>) invocation.getArguments
                         ()[0];
                 return transform.transform(searchResponse);
             }
@@ -101,12 +101,12 @@ public class ScrollTransformStreamTest {
             }
         }).when(seriesFunction).apply(any());
 
-        doAnswer(new Answer<AsyncFuture<LimitedSet<Integer>>>() {
-            public AsyncFuture<LimitedSet<Integer>> answer(
+        doAnswer(new Answer<AsyncFuture<ScrollTransformResult<Integer>>>() {
+            public AsyncFuture<ScrollTransformResult<Integer>> answer(
                 InvocationOnMock invocation
             ) throws Exception {
-                final LazyTransform<Void, LimitedSet<Integer>> transform =
-                    (LazyTransform<Void, LimitedSet<Integer>>) invocation.getArguments()[0];
+                final LazyTransform<Void, ScrollTransformResult<Integer>> transform =
+                    (LazyTransform<Void, ScrollTransformResult<Integer>>) invocation.getArguments()[0];
                 final Void ignore = null;
                 return transform.transform(ignore);
             }

--- a/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/ScrollTransformTest.java
+++ b/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/ScrollTransformTest.java
@@ -27,11 +27,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.OngoingStubbing;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(org.mockito.junit.MockitoJUnitRunner.class)
 public class ScrollTransformTest {
     private final String scrollID = "scroller1";
 
@@ -39,7 +38,7 @@ public class ScrollTransformTest {
     private AsyncFramework async;
 
     @Mock
-    private AsyncFuture<LimitedSet> resolved;
+    private AsyncFuture<ScrollTransformResult> resolved;
 
     @Mock
     Supplier<AsyncFuture<SearchResponse>> scroller;
@@ -68,18 +67,18 @@ public class ScrollTransformTest {
 
     @Before
     public void setup() {
-        doReturn(resolved).when(async).resolved(any(LimitedSet.class));
+        doReturn(resolved).when(async).resolved(any(ScrollTransformResult.class));
         doReturn(searchHits).when(searchResponse).getHits();
         doReturn(scrollID).when(searchResponse).getScrollId();
 
         doReturn(scroller).when(scrollerFactory).apply(any(String.class));
         doReturn(response).when(scroller).get();
-        doAnswer(new Answer<AsyncFuture<LimitedSet<Integer>>>() {
-            public AsyncFuture<LimitedSet<Integer>> answer(
+        doAnswer(new Answer<AsyncFuture<ScrollTransformResult<Integer>>>() {
+            public AsyncFuture<ScrollTransformResult<Integer>> answer(
                 InvocationOnMock invocation
             ) throws Exception {
-                final LazyTransform<SearchResponse, LimitedSet<Integer>> transform =
-                    (LazyTransform<SearchResponse, LimitedSet<Integer>>) invocation.getArguments
+                final LazyTransform<SearchResponse, ScrollTransformResult<Integer>> transform =
+                    (LazyTransform<SearchResponse, ScrollTransformResult<Integer>>) invocation.getArguments
                         ()[0];
                 return transform.transform(searchResponse);
             }
@@ -101,7 +100,7 @@ public class ScrollTransformTest {
         return new ScrollTransform<>(async, optionalLimit, Function.identity(), scrollerFactory);
     }
 
-    public LimitedSet<SearchHit> createLimitSet(Integer limit, SearchHit[]... pages) {
+    public ScrollTransformResult<SearchHit> createLimitSet(Integer limit, SearchHit[]... pages) {
         final Set<SearchHit> set = new HashSet<>();
 
         Stream<SearchHit> stream =
@@ -113,7 +112,7 @@ public class ScrollTransformTest {
 
         stream.map(Function.identity()).forEach(set::add);
 
-        return new LimitedSet<>(set, limit != null);
+        return new ScrollTransformResult<>(set, limit != null, scrollID);
     }
 
     @Test

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
@@ -22,6 +22,7 @@
 package com.spotify.heroic.metadata.elasticsearch;
 
 import static com.spotify.heroic.metadata.elasticsearch.ElasticsearchMetadataUtils.loadJsonResource;
+import static java.util.Optional.ofNullable;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.prefixQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
@@ -38,8 +39,8 @@ import com.spotify.heroic.common.Statistics;
 import com.spotify.heroic.elasticsearch.AbstractElasticsearchMetadataBackend;
 import com.spotify.heroic.elasticsearch.BackendType;
 import com.spotify.heroic.elasticsearch.Connection;
-import com.spotify.heroic.elasticsearch.ScrollTransformResult;
 import com.spotify.heroic.elasticsearch.RateLimitedCache;
+import com.spotify.heroic.elasticsearch.ScrollTransformResult;
 import com.spotify.heroic.elasticsearch.index.NoIndexSelectedException;
 import com.spotify.heroic.filter.AndFilter;
 import com.spotify.heroic.filter.FalseFilter;
@@ -454,7 +455,8 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
                 c, builder, limit, converter);
 
             return scroll
-                .onResolved(r -> c.clearSearchScroll(r.getLastScrollId()).execute())
+                .onResolved(r -> ofNullable(r.getLastScrollId())
+                    .ifPresent(id -> c.clearSearchScroll(id).execute()))
                 .directTransform(collector);
         });
     }


### PR DESCRIPTION
The search scroll must be closed when it's no longer needed otherwise elasticsearch will hold onto them until the timeout is reached. In previous versions of elasticsearch the number of scrolls that could be open was unlimited, with ES7 the default is now 500. It can be overriden with `search.max_open_scroll_context`.

https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-scroll.html#_clear_scroll_api