### PR TITLE
Disable datastax JMX reporting.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,6 @@ COPY --from=builder heroic-dist/build/libs/heroic-dist-0.0.1-SNAPSHOT-shaded.jar
 COPY example/heroic-memory-example.yml /heroic.yml
 COPY run-heroic.sh /usr/bin/heroic.sh
 
+ENV JVM_DEFAULT_ARGS -Dcom.datastax.driver.FORCE_NIO=true
 ENTRYPOINT ["/usr/bin/heroic.sh"]
 CMD ["/heroic.yml"]


### PR DESCRIPTION
Updating Datastax caused an incompatibility with dropwizard metrics - we're loading 4.0.2 which removed the JmxReporter class. The test class path for heroic-metric-datastax has dropwizard 3, so unfortunately this wasn't caught through the IT suite.

Resolves #607 