### PR TITLE
Add squashing trace exporter.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,7 @@ allprojects {
             dependency 'com.lightstep.tracer:tracer-okhttp:0.16.2'
             dependency 'com.lightstep.tracer:java-common:0.16.2'
             dependency 'com.lightstep.tracer:lightstep-tracer-jre:0.14.8'
+            dependency 'com.spotify.tracing:squashing-census-exporter:0.1.0'
 
             dependencySet(group: 'com.google.api', version: '1.35.1') {
                 entry 'gax'

--- a/docs/content/_docs/config.md
+++ b/docs/content/_docs/config.md
@@ -961,12 +961,14 @@ zpagesPort: <int>
 
 # Add request headers if present as tags to the trace.
 requestHeadersToTags:
-- x-user-request
+  - <string>
+  - ...
 
-# These tags are added to all incoming requests and are useful to identify the workload such 
+# These tags are added to all incoming requests and are useful to identify the workload such
 # as the hostname.
 tags:
-  hostname: foobar
+  <string>: <string> | <int> | <bool>
+  ...
 
 # Configuration for exporting traces to Lightstep.
 lightstep:
@@ -990,6 +992,17 @@ lightstep:
   # If enabled, the client connection will be reset at regular intervals.
   # Used to load balance on client side.
   resetClient: <bool> default = false
+
+# Configuration for squashing sibling spans into a summary span. These options are passed to
+# the squashing exporter: https://github.com/spotify/squashing-census-exporter
+squash:
+  # Name of spans that are eligible to be squashed. To allow all spans, set `whitelist: null`
+  whitelist:
+    - <string>
+    - ...
+
+  # Number of repetitive sibling spans required to trigger a squash.
+  threshold: <int> default = 100
 ```
 
 ### [`<usage_tracking_config>`](#usage_tracking_config)

--- a/heroic-component/src/main/java/com/spotify/heroic/tracing/TracingConfig.kt
+++ b/heroic-component/src/main/java/com/spotify/heroic/tracing/TracingConfig.kt
@@ -1,13 +1,14 @@
 package com.spotify.heroic.tracing
 
-data class TracingConfig (
+data class TracingConfig(
     val probability: Double = 0.01,
     val zpagesPort: Int = 0,
     val requestHeadersToTags: List<String> = listOf(),
     val tags: Map<String, String> = mapOf(),
-    val lightstep: Lightstep = Lightstep()
+    val lightstep: Lightstep = Lightstep(),
+    val squash: Squash = Squash()
 ) {
-    data class Lightstep (
+    data class Lightstep(
         val collectorHost: String = "",
         val collectorPort: Int = 80,
         val accessToken: String = "",
@@ -15,5 +16,10 @@ data class TracingConfig (
         val reportingIntervalMs: Int = 1000,
         val maxBufferedSpans: Int = 5000,
         val resetClient: Boolean = false
+    )
+
+    data class Squash(
+        val whitelist: List<String>? = listOf(),
+        val threshold: Int = 100
     )
 }

--- a/heroic-core/build.gradle
+++ b/heroic-core/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation 'com.lightstep.tracer:tracer-okhttp'
     implementation 'com.lightstep.tracer:java-common'
     implementation 'com.lightstep.opencensus:lightstep-opencensus-exporter'
+    implementation 'com.spotify.tracing:squashing-census-exporter'
 
     implementation 'com.typesafe:config:1.3.2'
     implementation 'net.jodah:expiringmap:0.5.1'


### PR DESCRIPTION
By default the trace config will use an empty list for the whitelist, which causes the squashing exporter to simply pass everything through to the delegated handler. As an example, turning it on just for fetchSeries calls would mean adding this to the config:

```yaml
tracing:
  squash:
    whitelist:
      - localMetricsManager.fetchSeries
```