### PR TITLE
Scope request spans so that they link to coreQueryManager.

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
@@ -224,7 +224,7 @@ public class CoreQueryManager implements QueryManager {
 
         @Override
         public AsyncFuture<QueryResult> query(Query query, QueryContext queryContext) {
-            return query(query, queryContext, null);
+            return query(query, queryContext, tracer.getCurrentSpan());
         }
 
         @Override

--- a/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryResource.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/query/QueryResource.java
@@ -69,7 +69,9 @@ public class QueryResource {
 
     @Inject
     public QueryResource(
-        final JavaxRestFramework httpAsync, final QueryManager query, final AsyncFramework async,
+        final JavaxRestFramework httpAsync,
+        final QueryManager query,
+        final AsyncFramework async,
         final QueryLoggerFactory queryLoggerFactory
     ) {
         this.httpAsync = httpAsync;

--- a/heroic-core/src/main/java/com/spotify/heroic/http/tracing/OpenCensusApplicationEventListener.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/tracing/OpenCensusApplicationEventListener.java
@@ -97,11 +97,9 @@ class OpenCensusApplicationEventListener implements ApplicationEventListener {
 
         try {
             final SpanContext spanContext = textFormat.extract(request, textFormatGetter);
-            spanBuilder = globalTracer
-                .spanBuilderWithRemoteParent(spanName, spanContext);
+            spanBuilder = globalTracer.spanBuilderWithRemoteParent(spanName, spanContext);
 
         } catch (SpanContextParseException e) {
-
             spanBuilder = globalTracer.spanBuilder(spanName);
         }
 
@@ -188,9 +186,10 @@ class OpenCensusApplicationEventListener implements ApplicationEventListener {
                         invocable.getDefinitionMethod()));
 
                     final String spanName = invocable.getHandler().getHandlerClass().getName();
-                    resourceSpan = globalTracer
+                    globalTracer
                         .spanBuilderWithExplicitParent(spanName, requestSpan)
-                        .startSpan();
+                        .startScopedSpan();
+                    resourceSpan = globalTracer.getCurrentSpan();
 
                     event.getContainerRequest()
                         .setProperty(OpenCensusFeature.SPAN_CONTEXT_PROPERTY, resourceSpan);

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -397,7 +397,6 @@ public class LocalMetricManager implements MetricManager {
             return metadata
                 .findSeries(new FindSeries.Request(request.filter(), request.range(), seriesLimit))
                 .onDone(reporter.reportFindSeries())
-                .onDone(new EndSpanFutureReporter(findSeriesSpan))
                 .onResolved(t -> findSeriesSpan.putAttribute(
                     "seriesCount", longAttributeValue(t.getSeries().size())))
                 .lazyTransform(transform)
@@ -405,7 +404,8 @@ public class LocalMetricManager implements MetricManager {
                     queryLogger.logOutgoingResponseAtNode(queryContext, fullQuery);
                     return fullQuery;
                 })
-                .onDone(reporter.reportQueryMetrics());
+                .onDone(reporter.reportQueryMetrics())
+                .onDone(new EndSpanFutureReporter(findSeriesSpan));
         }
 
 


### PR DESCRIPTION
I believe this is the final part to close out #505. I also fixed the `findSeries` span so that its end time encompasses the `fetch` child spans.