### PR TITLE
[elasticsearch] Timout fix for multi-page scrolling requests.

### DIFF
--- a/docs/content/_docs/config.md
+++ b/docs/content/_docs/config.md
@@ -574,6 +574,9 @@ templateName: <string> default = heroic-metadata
 
 # Automatically add index mappings and settings.
 configure: <bool> default = false
+
+# Number of results to return in each response when using Elasticsearch scrolling.
+scrollSize: <int> default = 1000
 ```
 
 ##### `<es_index_config>`

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/AbstractElasticsearchMetadataBackend.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/AbstractElasticsearchMetadataBackend.java
@@ -74,21 +74,21 @@ public abstract class AbstractElasticsearchMetadataBackend extends AbstractElast
         final Function<SearchHit, T> converter
     ) {
 
-    final ScrollTransform<T> scrollTransform =
-        new ScrollTransform<>(
-            async,
-            limit,
-            converter,
-            scrollId -> {
-                // Function<> that returns a Supplier
-                return () -> {
-                    final ResolvableFuture<SearchResponse> future = async.future();
-                    connection.searchScroll(scrollId, SCROLL_TIME, bind(future));
-                    return future;
-                };
-            });
-            final ResolvableFuture<SearchResponse> future = async.future();
-            connection.execute(request, bind(future));
+        final ScrollTransform<T> scrollTransform =
+            new ScrollTransform<>(
+                async,
+                limit,
+                converter,
+                scrollId -> {
+                    // Function<> that returns a Supplier
+                    return () -> {
+                        final ResolvableFuture<SearchResponse> future = async.future();
+                        connection.searchScroll(scrollId, SCROLL_TIME, bind(future));
+                        return future;
+                    };
+                });
+        final ResolvableFuture<SearchResponse> future = async.future();
+        connection.execute(request, bind(future));
 
         return future.lazyTransform(scrollTransform);
     }
@@ -119,8 +119,7 @@ public abstract class AbstractElasticsearchMetadataBackend extends AbstractElast
         }
 
         @Override
-        public AsyncFuture<ScrollTransformResult<T>> transform(final SearchResponse response)
-            throws Exception {
+        public AsyncFuture<ScrollTransformResult<T>> transform(final SearchResponse response) {
             final SearchHit[] hits = response.getHits().getHits();
             final String scrollId = response.getScrollId();
 

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/RestConnection.kt
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/RestConnection.kt
@@ -106,7 +106,8 @@ class RestConnection(
     override fun searchScroll(
         scrollId: String, timeout: TimeValue, listener: ActionListener<SearchResponse>
     ) {
-        client.scrollAsync(SearchScrollRequest(scrollId), options, listener)
+        val request = SearchScrollRequest(scrollId).scroll(timeout)
+        client.scrollAsync(request, options, listener)
     }
 
     override fun clearSearchScroll(scrollId: String): ActionFuture<ClearScrollResponse> {

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/TransportConnection.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/TransportConnection.java
@@ -157,7 +157,7 @@ public class TransportConnection implements Connection<StringTerms> {
         @NotNull TimeValue timeout,
         @NotNull ActionListener<SearchResponse> listener
     ) {
-        SearchScrollRequest request = new SearchScrollRequest(scrollId);
+        SearchScrollRequest request = new SearchScrollRequest(scrollId).scroll(timeout);
         client.searchScroll(request, listener);
     }
 

--- a/heroic-test/src/main/java/com/spotify/heroic/test/AbstractMetadataBackendIT.java
+++ b/heroic-test/src/main/java/com/spotify/heroic/test/AbstractMetadataBackendIT.java
@@ -77,6 +77,8 @@ public abstract class AbstractMetadataBackendIT {
 
     private AsyncFramework async;
 
+    protected final int numSeries = 3;
+
     private final Series s1 = Series.of("s1", ImmutableMap.of("role", "foo"));
     private final Series s2 = Series.of("s2", ImmutableMap.of("role", "bar"));
     private final Series s3 = Series.of("s3", ImmutableMap.of("role", "baz"));

--- a/heroic-test/src/test/java/com/spotify/heroic/metadata/elasticsearch/AbstractMetadataBackendKVIT.java
+++ b/heroic-test/src/test/java/com/spotify/heroic/metadata/elasticsearch/AbstractMetadataBackendKVIT.java
@@ -60,6 +60,7 @@ public abstract class AbstractMetadataBackendKVIT extends AbstractMetadataBacken
                 .index(index)
                 .clientSetup(setupClient())
                 .build())
+            .scrollSize(numSeries / 2)
             .build();
     }
 }


### PR DESCRIPTION
My refactoring of ES missed adding the timeout for search scroll requests (not the initial search). Without this timeout, any requests that cause more than one page of results silently fail - no errors are returned, but Heroic ends up without any hits. Elasticsearch keeps the scroll context open in this case as well. Since the scroll ID in the second response is empty the code path to clear the search scroll is never hit.

I made scrollSize configurable primarily just so it would be easier to test. Closes #632 