### PR TITLE
[metadata] add metric for failed shards

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/MetadataBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/MetadataBackendReporter.java
@@ -28,6 +28,8 @@ public interface MetadataBackendReporter {
 
     void reportWriteDroppedByDuplicate();
 
+    void failedShards(final long errors);
+
     FutureReporter.Context setupBackendWriteReporter();
 
     MetadataBackend decorate(MetadataBackend backend);

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetadataBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetadataBackendReporter.java
@@ -45,6 +45,9 @@ public class NoopMetadataBackendReporter implements MetadataBackendReporter {
     }
 
     @Override
+    public void failedShards(final long errors) { }
+
+    @Override
     public FutureReporter.Context setupBackendWriteReporter() {
         return NoopFutureReporterContext.get();
     }

--- a/heroic-core/src/main/java/com/spotify/heroic/http/write/WriteResource.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/write/WriteResource.java
@@ -57,7 +57,8 @@ public class WriteResource {
 
     @POST
     public void metrics(
-        @Suspended final AsyncResponse response, @QueryParam("group") String group,
+        @Suspended final AsyncResponse response,
+        @QueryParam("group") String group,
         WriteMetricRequest write
     ) {
         final IngestionGroup ingestionGroup = ingestion.useGroup(group);

--- a/heroic-core/src/main/java/com/spotify/heroic/ingestion/IngestionManagerImpl.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/ingestion/IngestionManagerImpl.java
@@ -21,6 +21,8 @@
 
 package com.spotify.heroic.ingestion;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.spotify.heroic.common.Statistics;
 import com.spotify.heroic.filter.Filter;
 import com.spotify.heroic.metadata.MetadataBackend;
@@ -32,16 +34,13 @@ import com.spotify.heroic.suggest.SuggestBackend;
 import com.spotify.heroic.suggest.SuggestManager;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.util.Optional;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 import java.util.function.Supplier;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import javax.inject.Inject;
+import javax.inject.Named;
 
 public class IngestionManagerImpl implements IngestionManager {
     final AsyncFramework async;
@@ -68,12 +67,16 @@ public class IngestionManagerImpl implements IngestionManager {
      */
     @Inject
     public IngestionManagerImpl(
-        final AsyncFramework async, final MetadataManager metadata, final MetricManager metric,
-        final SuggestManager suggest, final IngestionManagerReporter reporter,
+        final AsyncFramework async,
+        final MetadataManager metadata,
+        final MetricManager metric,
+        final SuggestManager suggest,
+        final IngestionManagerReporter reporter,
         @Named("updateMetrics") final boolean updateMetrics,
         @Named("updateMetadata") final boolean updateMetadata,
         @Named("updateSuggestions") final boolean updateSuggestions,
-        @Named("maxConcurrentWrites") final int maxConcurrentWrites, final Filter filter
+        @Named("maxConcurrentWrites") final int maxConcurrentWrites,
+        final Filter filter
     ) {
         this.async = async;
         this.metadata = metadata;
@@ -113,7 +116,9 @@ public class IngestionManagerImpl implements IngestionManager {
     }
 
     private <I> IngestionGroup buildGroup(
-        final I input, Function<I, MetricBackend> metric, Function<I, MetadataBackend> metadata,
+        final I input,
+        Function<I, MetricBackend> metric,
+        Function<I, MetadataBackend> metadata,
         Function<I, SuggestBackend> suggest
     ) {
         // @formatter:off

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
@@ -154,7 +154,7 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
         @Named("deleteParallelism") int deleteParallelism,
         @Named("scrollSize") int scrollSize
     ) {
-        super(async, METADATA_TYPE);
+        super(async, METADATA_TYPE, reporter);
         this.groups = groups;
         this.reporter = reporter;
         this.async = async;

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporter.java
@@ -57,6 +57,7 @@ public class SemanticMetadataBackendReporter implements MetadataBackendReporter 
     private final Counter entries;
     private final Counter writesDroppedByCacheHit;
     private final Counter writesDroppedByDuplicate;
+    private final Counter failedShards;
 
 
     public SemanticMetadataBackendReporter(SemanticMetricRegistry registry) {
@@ -74,10 +75,11 @@ public class SemanticMetadataBackendReporter implements MetadataBackendReporter 
             base.tagged("what", "delete-series", "unit", Units.QUERY));
         findKeys = new SemanticFutureReporter(registry,
             base.tagged("what", "find-keys", "unit", Units.QUERY));
-        write =
-            new SemanticFutureReporter(registry, base.tagged("what", "write", "unit", Units.WRITE));
+        write = new SemanticFutureReporter(registry,
+            base.tagged("what", "write", "unit", Units.WRITE));
         backendWrite = new SemanticFutureReporter(registry,
             base.tagged("what", "backend-write", "unit", Units.WRITE));
+
         entries = registry.counter(base.tagged("what", "entries", "unit", Units.COUNT));
 
         writesDroppedByCacheHit = registry.counter(
@@ -85,6 +87,9 @@ public class SemanticMetadataBackendReporter implements MetadataBackendReporter 
         writesDroppedByDuplicate = registry.counter(
             base.tagged("what", "writes-dropped-by-duplicate", "unit", Units.COUNT));
 
+        // only relevant to es backend.
+        failedShards = registry.counter(
+            base.tagged("what", "failed-es-shards", "unit", Units.COUNT));
     }
 
     @Override
@@ -103,6 +108,12 @@ public class SemanticMetadataBackendReporter implements MetadataBackendReporter 
     public void reportWriteDroppedByCacheHit() {
         writesDroppedByCacheHit.inc();
     }
+
+    @Override
+    public void failedShards(final long errors) {
+        failedShards.inc(errors);
+    }
+
 
     @Override
     public void reportWriteDroppedByDuplicate() {


### PR DESCRIPTION
The `failed-es-shards` metric can be used to track how often an elasticsearch shard fails.

Ideally this metric would be added to an elasticsearch specific metric reporter but that framework doesn't currently exist.

Closes #633