### PR TITLE
[elasticsearch-metadata] Add option for live cursor

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/common/Feature.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/Feature.java
@@ -72,7 +72,12 @@ public enum Feature {
     /**
      * Permit caching of the query results.
      */
-    CACHE_QUERY("com.spotify.heroic.cache_query");
+    CACHE_QUERY("com.spotify.heroic.cache_query"),
+
+    /**
+     * When paginating metadata results, use a live cursor instead of a snapshot scroll.
+     */
+    METADATA_LIVE_CURSOR("com.spotify.heroic.metadata.live_CURSOR");
 
     private final String id;
 

--- a/heroic-component/src/main/java/com/spotify/heroic/common/Feature.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/Feature.java
@@ -77,7 +77,7 @@ public enum Feature {
     /**
      * When paginating metadata results, use a live cursor instead of a snapshot scroll.
      */
-    METADATA_LIVE_CURSOR("com.spotify.heroic.metadata.live_CURSOR");
+    METADATA_LIVE_CURSOR("com.spotify.heroic.metadata.live_cursor");
 
     private final String id;
 

--- a/heroic-component/src/main/java/com/spotify/heroic/common/FeatureSet.kt
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/FeatureSet.kt
@@ -49,6 +49,10 @@ data class FeatureSet(
         return features
     }
 
+    fun isEmpty(): Boolean {
+        return enabled.isEmpty() && disabled.isEmpty()
+    }
+
     /**
      * Combine this feature set with another.
      *

--- a/heroic-component/src/main/java/com/spotify/heroic/metadata/FindSeries.kt
+++ b/heroic-component/src/main/java/com/spotify/heroic/metadata/FindSeries.kt
@@ -24,9 +24,11 @@ package com.spotify.heroic.metadata
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.spotify.heroic.cluster.ClusterShard
 import com.spotify.heroic.common.DateRange
+import com.spotify.heroic.common.Features
 import com.spotify.heroic.common.OptionalLimit
 import com.spotify.heroic.common.Series
 import com.spotify.heroic.filter.Filter
+import com.spotify.heroic.metric.FullQuery
 import com.spotify.heroic.metric.RequestError
 import com.spotify.heroic.metric.ShardError
 import eu.toolchain.async.Collector
@@ -73,6 +75,14 @@ data class FindSeries(
     data class Request(
         val filter: Filter,
         val range: DateRange,
-        val limit: OptionalLimit
-    )
+        val limit: OptionalLimit,
+        val features: Features
+    ) {
+        companion object {
+            @JvmStatic
+            fun withLimit(request: FullQuery.Request, limit: OptionalLimit): Request {
+                return Request(request.filter(), request.range(), limit, request.features())
+            }
+        }
+    }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/metadata/FindSeriesIds.kt
+++ b/heroic-component/src/main/java/com/spotify/heroic/metadata/FindSeriesIds.kt
@@ -22,9 +22,7 @@
 package com.spotify.heroic.metadata
 
 import com.spotify.heroic.cluster.ClusterShard
-import com.spotify.heroic.common.DateRange
 import com.spotify.heroic.common.OptionalLimit
-import com.spotify.heroic.filter.Filter
 import com.spotify.heroic.metric.RequestError
 import com.spotify.heroic.metric.ShardError
 import eu.toolchain.async.Collector
@@ -64,11 +62,5 @@ data class FindSeriesIds(
             }
         }
     }
-
-    data class Request(
-        val filter: Filter,
-        val range: DateRange,
-        val limit: OptionalLimit
-    )
 }
 

--- a/heroic-component/src/main/java/com/spotify/heroic/metadata/MetadataBackend.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metadata/MetadataBackend.java
@@ -71,10 +71,8 @@ public interface MetadataBackend extends Grouped, Initializing, Collected {
     /**
      * List only the series id that match the given filter.
      */
-    AsyncFuture<FindSeriesIds> findSeriesIds(FindSeriesIds.Request request);
-    default AsyncObservable<FindSeriesIdsStream> findSeriesIdsStream(
-        FindSeriesIds.Request request
-    ) {
+    AsyncFuture<FindSeriesIds> findSeriesIds(FindSeries.Request request);
+    default AsyncObservable<FindSeriesIdsStream> findSeriesIdsStream(FindSeries.Request request) {
         return AsyncObservable.empty();
     }
 

--- a/heroic-core/src/main/java/com/spotify/heroic/http/metadata/MetadataQueryBody.kt
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/metadata/MetadataQueryBody.kt
@@ -40,7 +40,7 @@ data class MetadataQueryBody(
     // The date range to query for.
     val range: Optional<QueryDateRange>,
     val limit: Optional<Int>
-    ) {
+) {
     companion object {
         const val DEFAULT_LIMIT = 50
     }

--- a/heroic-core/src/main/java/com/spotify/heroic/http/metadata/MetadataResource.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/metadata/MetadataResource.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.spotify.heroic.QueryDateRange;
 import com.spotify.heroic.QueryManager;
 import com.spotify.heroic.common.DateRange;
+import com.spotify.heroic.common.Features;
 import com.spotify.heroic.common.JavaxRestFramework;
 import com.spotify.heroic.common.OptionalLimit;
 import com.spotify.heroic.common.Series;
@@ -113,12 +114,16 @@ public class MetadataResource {
     public void getTimeSeries(
         @Suspended final AsyncResponse response, final MetadataQueryBody request
     ) {
-        final RequestCriteria c = toCriteria(request::getFilter, request::getRange,
-            () -> OptionalLimit.of(request.getLimit().orElse(MetadataQueryBody.DEFAULT_LIMIT)));
+        RequestCriteria criteria = toCriteria(
+            request::getFilter,
+            request::getRange,
+            () -> OptionalLimit.of(request.getLimit().orElse(MetadataQueryBody.DEFAULT_LIMIT))
+        );
 
-        httpAsync.bind(response, query
-            .useDefaultGroup()
-            .findSeries(new FindSeries.Request(c.getFilter(), c.getRange(), c.getLimit())));
+        FindSeries.Request seriesRequest = new FindSeries.Request(
+            criteria.getFilter(), criteria.getRange(), criteria.getLimit(), Features.DEFAULT);
+
+        httpAsync.bind(response, query.useDefaultGroup().findSeries(seriesRequest));
     }
 
     @DELETE

--- a/heroic-core/src/main/java/com/spotify/heroic/metadata/MetadataBackendGroup.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metadata/MetadataBackendGroup.java
@@ -63,7 +63,7 @@ public class MetadataBackendGroup implements MetadataBackend {
     }
 
     @Override
-    public AsyncFuture<FindSeriesIds> findSeriesIds(final FindSeriesIds.Request request) {
+    public AsyncFuture<FindSeriesIds> findSeriesIds(final FindSeries.Request request) {
         return async.collect(run(v -> v.findSeriesIds(request)),
             FindSeriesIds.reduce(request.getLimit()));
     }
@@ -75,7 +75,7 @@ public class MetadataBackendGroup implements MetadataBackend {
 
     @Override
     public AsyncObservable<FindSeriesIdsStream> findSeriesIdsStream(
-        final FindSeriesIds.Request request
+        final FindSeries.Request request
     ) {
         return AsyncObservable.chain(run(b -> b.findSeriesIdsStream(request)));
     }

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -395,7 +395,7 @@ public class LocalMetricManager implements MetricManager {
                     findSeriesSpan);
 
             return metadata
-                .findSeries(new FindSeries.Request(request.filter(), request.range(), seriesLimit))
+                .findSeries(FindSeries.Request.withLimit(request, seriesLimit))
                 .onDone(reporter.reportFindSeries())
                 .onResolved(t -> findSeriesSpan.putAttribute(
                     "seriesCount", longAttributeValue(t.getSeries().size())))

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/MetadataFetch.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/MetadataFetch.java
@@ -22,6 +22,7 @@
 package com.spotify.heroic.shell.task;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.heroic.common.Features;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.dagger.CoreComponent;
 import com.spotify.heroic.filter.Filter;
@@ -66,10 +67,12 @@ public class MetadataFetch implements ShellTask {
         final MetadataFetchParameters params = (MetadataFetchParameters) base;
 
         final Filter filter = Tasks.setupFilter(parser, params);
+        FindSeries.Request request =
+            new FindSeries.Request(filter, params.getRange(), params.getLimit(), Features.DEFAULT);
 
         return metadata
             .useOptionalGroup(params.getGroup())
-            .findSeries(new FindSeries.Request(filter, params.getRange(), params.getLimit()))
+            .findSeries(request)
             .directTransform(result -> {
                 int i = 0;
 

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/MetadataFindSeries.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/MetadataFindSeries.java
@@ -23,6 +23,7 @@ package com.spotify.heroic.shell.task;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spotify.heroic.async.AsyncObserver;
+import com.spotify.heroic.common.Features;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.dagger.CoreComponent;
 import com.spotify.heroic.filter.Filter;
@@ -111,10 +112,12 @@ public class MetadataFindSeries implements ShellTask {
         }
 
         final ResolvableFuture<Void> future = async.future();
+        FindSeries.Request request =
+            new FindSeries.Request(filter, params.getRange(), params.getLimit(), Features.DEFAULT);
 
         group
-            .findSeriesStream(new FindSeries.Request(filter, params.getRange(), params.getLimit()))
-            .observe(new AsyncObserver<FindSeriesStream>() {
+            .findSeriesStream(request)
+            .observe(new AsyncObserver<>() {
                 @Override
                 public AsyncFuture<Void> observe(final FindSeriesStream value) {
                     value.getSeries().forEach(printer);

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/MetadataFindSeriesIds.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/MetadataFindSeriesIds.java
@@ -22,10 +22,11 @@
 package com.spotify.heroic.shell.task;
 
 import com.spotify.heroic.async.AsyncObserver;
+import com.spotify.heroic.common.Features;
 import com.spotify.heroic.dagger.CoreComponent;
 import com.spotify.heroic.filter.Filter;
 import com.spotify.heroic.grammar.QueryParser;
-import com.spotify.heroic.metadata.FindSeriesIds;
+import com.spotify.heroic.metadata.FindSeries;
 import com.spotify.heroic.metadata.FindSeriesIdsStream;
 import com.spotify.heroic.metadata.MetadataBackend;
 import com.spotify.heroic.metadata.MetadataManager;
@@ -73,10 +74,12 @@ public class MetadataFindSeriesIds implements ShellTask {
         final Consumer<String> printer = id -> io.out().println(id);
         final ResolvableFuture<Void> future = async.future();
 
+        FindSeries.Request request =
+            new FindSeries.Request(filter, params.getRange(), params.getLimit(), Features.DEFAULT);
+
         group
-            .findSeriesIdsStream(
-                new FindSeriesIds.Request(filter, params.getRange(), params.getLimit()))
-            .observe(new AsyncObserver<FindSeriesIdsStream>() {
+            .findSeriesIdsStream(request)
+            .observe(new AsyncObserver<>() {
                 @Override
                 public AsyncFuture<Void> observe(final FindSeriesIdsStream value) {
                     value.getIds().forEach(printer);

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/AbstractElasticsearchMetadataBackend.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/AbstractElasticsearchMetadataBackend.java
@@ -51,8 +51,9 @@ import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchHit;
 
-public abstract class AbstractElasticsearchMetadataBackend extends AbstractElasticsearchBackend
-    implements MetadataBackend {
+public abstract class AbstractElasticsearchMetadataBackend
+    extends AbstractElasticsearchBackend implements MetadataBackend {
+
     private static final TimeValue SCROLL_TIME = TimeValue.timeValueSeconds(5);
 
     private final String type;
@@ -131,7 +132,8 @@ public abstract class AbstractElasticsearchMetadataBackend extends AbstractElast
         int duplicates = 0;
         final Set<T> results = new HashSet<>();
         final Function<SearchHit, T> converter;
-        final BiFunction<String, SearchHit, Supplier<AsyncFuture<SearchResponse>>> searchFactory;
+        final BiFunction<String, SearchHit,
+            Supplier<AsyncFuture<SearchResponse>>> searchFactory;
         final Boolean scrolling;
 
         public SearchTransform(

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/SearchTransformResult.kt
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/SearchTransformResult.kt
@@ -23,12 +23,12 @@ package com.spotify.heroic.elasticsearch
 
 import com.google.common.collect.ImmutableSet
 
-data class ScrollTransformResult<T>(
+data class SearchTransformResult<T>(
     val set: Set<T>, val isLimited: Boolean, val lastScrollId: String?) {
 
     companion object {
-        @JvmStatic fun <T> of(): ScrollTransformResult<T> {
-            return ScrollTransformResult(ImmutableSet.of<T>(), false, null)
+        @JvmStatic fun <T> of(): SearchTransformResult<T> {
+            return SearchTransformResult(ImmutableSet.of(), false, null)
         }
     }
 }

--- a/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/SearchTransformStreamTest.java
+++ b/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/SearchTransformStreamTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.spotify.heroic.common.OptionalLimit;
-import com.spotify.heroic.elasticsearch.AbstractElasticsearchMetadataBackend.ScrollTransformStream;
+import com.spotify.heroic.elasticsearch.AbstractElasticsearchMetadataBackend.SearchTransformStream;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.LazyTransform;
@@ -33,14 +33,14 @@ import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.OngoingStubbing;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ScrollTransformStreamTest {
+public class SearchTransformStreamTest {
     private final String scrollID = "scroller1";
 
     @Mock
     private AsyncFramework async;
 
     @Mock
-    private AsyncFuture<ScrollTransformResult> resolved;
+    private AsyncFuture<SearchTransformResult> resolved;
 
     @Mock
     private Supplier<AsyncFuture<SearchResponse>> scroller;
@@ -82,12 +82,12 @@ public class ScrollTransformStreamTest {
 
         doReturn(scroller).when(scrollerFactory).apply(any(String.class));
         doReturn(response).when(scroller).get();
-        doAnswer(new Answer<AsyncFuture<ScrollTransformResult<Integer>>>() {
-            public AsyncFuture<ScrollTransformResult<Integer>> answer(
+        doAnswer(new Answer<AsyncFuture<SearchTransformResult<Integer>>>() {
+            public AsyncFuture<SearchTransformResult<Integer>> answer(
                 InvocationOnMock invocation
             ) throws Exception {
-                final LazyTransform<SearchResponse, ScrollTransformResult<Integer>> transform =
-                    (LazyTransform<SearchResponse, ScrollTransformResult<Integer>>) invocation.getArguments
+                final LazyTransform<SearchResponse, SearchTransformResult<Integer>> transform =
+                    (LazyTransform<SearchResponse, SearchTransformResult<Integer>>) invocation.getArguments
                         ()[0];
                 return transform.transform(searchResponse);
             }
@@ -101,12 +101,12 @@ public class ScrollTransformStreamTest {
             }
         }).when(seriesFunction).apply(any());
 
-        doAnswer(new Answer<AsyncFuture<ScrollTransformResult<Integer>>>() {
-            public AsyncFuture<ScrollTransformResult<Integer>> answer(
+        doAnswer(new Answer<AsyncFuture<SearchTransformResult<Integer>>>() {
+            public AsyncFuture<SearchTransformResult<Integer>> answer(
                 InvocationOnMock invocation
             ) throws Exception {
-                final LazyTransform<Void, ScrollTransformResult<Integer>> transform =
-                    (LazyTransform<Void, ScrollTransformResult<Integer>>) invocation.getArguments()[0];
+                final LazyTransform<Void, SearchTransformResult<Integer>> transform =
+                    (LazyTransform<Void, SearchTransformResult<Integer>>) invocation.getArguments()[0];
                 final Void ignore = null;
                 return transform.transform(ignore);
             }
@@ -121,12 +121,12 @@ public class ScrollTransformStreamTest {
         }
     }
 
-    public ScrollTransformStream<SearchHit> createScrollTransform(
+    public SearchTransformStream<SearchHit> createScrollTransform(
         Integer limit, Function<Set<SearchHit>, AsyncFuture<Void>> seriesFunction,
         Function<String, Supplier<AsyncFuture<SearchResponse>>> scrollerFactory
     ) {
         final OptionalLimit optionalLimit = OptionalLimit.of(limit);
-        return new ScrollTransformStream<>(optionalLimit, seriesFunction, Function.identity(),
+        return new SearchTransformStream<>(optionalLimit, seriesFunction, Function.identity(),
             scrollerFactory);
     }
 
@@ -163,7 +163,7 @@ public class ScrollTransformStreamTest {
         setSearchHitPages(searchHits1, searchHits2, emptySearchHits);
         final Integer limit = searchHits1.length - 1;
 
-        final ScrollTransformStream<SearchHit> scrollTransform =
+        final SearchTransformStream<SearchHit> scrollTransform =
             createScrollTransform(limit, seriesFunction, scrollerFactory);
 
         scroller.get().lazyTransform(scrollTransform);
@@ -177,7 +177,7 @@ public class ScrollTransformStreamTest {
         setSearchHitPages(searchHits1, emptySearchHits);
         final Integer limit = searchHits1.length;
 
-        final ScrollTransformStream<SearchHit> scrollTransform =
+        final SearchTransformStream<SearchHit> scrollTransform =
             createScrollTransform(limit, seriesFunction, scrollerFactory);
 
         scroller.get().lazyTransform(scrollTransform);
@@ -191,7 +191,7 @@ public class ScrollTransformStreamTest {
         setSearchHitPages(searchHits1, emptySearchHits);
         final Integer limit = searchHits1.length + 1;
 
-        final ScrollTransformStream<SearchHit> scrollTransform =
+        final SearchTransformStream<SearchHit> scrollTransform =
             createScrollTransform(limit, seriesFunction, scrollerFactory);
 
         scroller.get().lazyTransform(scrollTransform);
@@ -205,7 +205,7 @@ public class ScrollTransformStreamTest {
         setSearchHitPages(searchHits1, searchHits1, searchHits2, emptySearchHits);
         final Integer limit = searchHits1.length + searchHits1.length + searchHits2.length - 1;
 
-        final ScrollTransformStream<SearchHit> scrollTransform =
+        final SearchTransformStream<SearchHit> scrollTransform =
             createScrollTransform(limit, seriesFunction, scrollerFactory);
 
         scroller.get().lazyTransform(scrollTransform);
@@ -220,7 +220,7 @@ public class ScrollTransformStreamTest {
         setSearchHitPages(searchHits1, searchHits1, searchHits2, emptySearchHits);
         final Integer limit = searchHits1.length + searchHits1.length + searchHits2.length;
 
-        final ScrollTransformStream<SearchHit> scrollTransform =
+        final SearchTransformStream<SearchHit> scrollTransform =
             createScrollTransform(limit, seriesFunction, scrollerFactory);
 
         scroller.get().lazyTransform(scrollTransform);
@@ -235,7 +235,7 @@ public class ScrollTransformStreamTest {
         setSearchHitPages(searchHits1, searchHits1, searchHits2, emptySearchHits);
         final Integer limit = searchHits1.length + searchHits1.length + searchHits2.length + 1;
 
-        final ScrollTransformStream<SearchHit> scrollTransform =
+        final SearchTransformStream<SearchHit> scrollTransform =
             createScrollTransform(limit, seriesFunction, scrollerFactory);
 
         scroller.get().lazyTransform(scrollTransform);

--- a/heroic-test/src/test/java/com/spotify/heroic/metadata/elasticsearch/AbstractMetadataBackendKVIT.java
+++ b/heroic-test/src/test/java/com/spotify/heroic/metadata/elasticsearch/AbstractMetadataBackendKVIT.java
@@ -21,6 +21,8 @@
 
 package com.spotify.heroic.metadata.elasticsearch;
 
+import com.spotify.heroic.common.Feature;
+import com.spotify.heroic.common.FeatureSet;
 import com.spotify.heroic.elasticsearch.ClientWrapper;
 import com.spotify.heroic.elasticsearch.ConnectionModule;
 import com.spotify.heroic.elasticsearch.index.RotatingIndexMapping;
@@ -39,10 +41,10 @@ public abstract class AbstractMetadataBackendKVIT extends AbstractMetadataBacken
 
     @Override
     protected void setupConditions() {
-        super.setupConditions();
-
         // TODO: support findTags?
         findTagsSupport = false;
+
+        additionalFeatures = FeatureSet.of(Feature.METADATA_LIVE_CURSOR);
     }
 
     @Override

--- a/heroic-test/src/test/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKVTransportIT.java
+++ b/heroic-test/src/test/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKVTransportIT.java
@@ -22,14 +22,8 @@
 package com.spotify.heroic.metadata.elasticsearch;
 
 import com.spotify.heroic.elasticsearch.ClientWrapper;
-import com.spotify.heroic.elasticsearch.ConnectionModule;
 import com.spotify.heroic.elasticsearch.TransportClientWrapper;
-import com.spotify.heroic.elasticsearch.index.RotatingIndexMapping;
-import com.spotify.heroic.metadata.MetadataModule;
-import com.spotify.heroic.test.AbstractMetadataBackendIT;
-import com.spotify.heroic.test.ElasticSearchTestContainer;
 import java.util.List;
-import java.util.UUID;
 
 public class MetadataBackendKVTransportIT extends AbstractMetadataBackendKVIT {
     @Override

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
@@ -460,13 +460,13 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
             modifier.accept(request);
 
             if (seriesRequest.getFeatures().hasFeature(Feature.METADATA_LIVE_CURSOR)) {
+                return pageEntries(c, request, limit, converter)
+                    .directTransform(collector);
+            } else {
                 request.scroll(SCROLL_TIME);
                 return scrollEntries(c, request, limit, converter)
                     .onResolved(r ->
                         ofNullable(r.getLastScrollId()).ifPresent(c::clearSearchScroll))
-                    .directTransform(collector);
-            } else {
-                return pageEntries(c, request, limit, converter)
                     .directTransform(collector);
             }
         });

--- a/metadata/memory/src/main/java/com/spotify/heroic/metadata/memory/MemoryBackend.java
+++ b/metadata/memory/src/main/java/com/spotify/heroic/metadata/memory/MemoryBackend.java
@@ -133,7 +133,7 @@ public class MemoryBackend implements MetadataBackend {
     }
 
     @Override
-    public AsyncFuture<FindSeriesIds> findSeriesIds(final FindSeriesIds.Request request) {
+    public AsyncFuture<FindSeriesIds> findSeriesIds(final FindSeries.Request request) {
         final OptionalLimit limit = request.getLimit();
 
         final Set<String> s =
@@ -144,7 +144,7 @@ public class MemoryBackend implements MetadataBackend {
 
     @Override
     public AsyncObservable<FindSeriesIdsStream> findSeriesIdsStream(
-        final FindSeriesIds.Request request
+        final FindSeries.Request request
     ) {
         return observer -> {
             final OptionalLimit limit = request.getLimit();

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporter.java
@@ -156,14 +156,14 @@ public class SemanticMetadataBackendReporter implements MetadataBackendReporter 
 
         @Override
         public AsyncFuture<FindSeriesIds> findSeriesIds(
-            final FindSeriesIds.Request request
+            final FindSeries.Request request
         ) {
             return delegate.findSeriesIds(request).onDone(findSeriesIds.setup());
         }
 
         @Override
         public AsyncObservable<FindSeriesIdsStream> findSeriesIdsStream(
-            final FindSeriesIds.Request request
+            final FindSeries.Request request
         ) {
             return delegate.findSeriesIdsStream(request);
         }

--- a/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporterTest.java
+++ b/statistics/semantic/src/test/java/com/spotify/heroic/statistics/semantic/SemanticMetadataBackendReporterTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.verify;
 import com.spotify.heroic.async.AsyncObservable;
 import com.spotify.heroic.common.Statistics;
 import com.spotify.heroic.metadata.FindSeries;
-import com.spotify.heroic.metadata.FindSeriesIds;
 import com.spotify.heroic.metadata.FindSeriesIdsStream;
 import com.spotify.heroic.metadata.FindSeriesStream;
 import com.spotify.heroic.metadata.MetadataBackend;
@@ -29,7 +28,7 @@ public class SemanticMetadataBackendReporterTest {
 
         {
             final AsyncObservable<FindSeriesIdsStream> response = mock(AsyncObservable.class);
-            final FindSeriesIds.Request request = mock(FindSeriesIds.Request.class);
+            final FindSeries.Request request = mock(FindSeries.Request.class);
             doReturn(response).when(backend).findSeriesIdsStream(request);
             assertEquals(response, decorated.findSeriesIdsStream(request));
             verify(backend).findSeriesIdsStream(request);


### PR DESCRIPTION
This adds a new feature, `com.spotify.heroic.metadata.live_cursor`, which changes the behavior of Elasticsearch searches for metadata. When enabled the results will be paginated with a live cursor instead of a snapshotted scroll.

Most likely we want this to be the default behavior, but its disabled by default so we can roll it out and test further.

Closes #636 