### PR TITLE
[heroic-component] remove warnings around deprecated methods

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/QueryBuilder.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/QueryBuilder.java
@@ -60,8 +60,6 @@ public class QueryBuilder {
      */
     @Deprecated
     public QueryBuilder key(Optional<String> key) {
-        log.warn("key is deprecated, use #filter(java.util.Optional) with the appropriate filter"
-                 + " instead");
         this.key = key;
         return this;
     }
@@ -74,8 +72,6 @@ public class QueryBuilder {
      */
     @Deprecated
     public QueryBuilder tags(Optional<Map<String, String>> tags) {
-        log.warn("tags is deprecated, use #filter(java.util.Optional) with the appropriate filter"
-               + " instead");
         checkNotNull(tags, "tags must not be null");
         this.tags = pickOptional(this.tags, tags);
         return this;

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryTrace.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryTrace.java
@@ -62,7 +62,6 @@ public interface QueryTrace {
      */
     @Deprecated
     static QueryTrace of(final Identifier what) {
-        log.warn("of is deprecated, use #watch(com.spotify.heroic.metric.QueryTrace.Identifier)");
         return ActiveTrace.create(what, 0L, ImmutableList.of());
     }
 
@@ -76,7 +75,6 @@ public interface QueryTrace {
      */
     @Deprecated
     static QueryTrace of(final Identifier what, final long elapsed) {
-        log.warn("of is deprecated, use #watch(com.spotify.heroic.metric.QueryTrace.Identifier)");
         return ActiveTrace.create(what, elapsed, ImmutableList.of());
     }
 
@@ -93,7 +91,6 @@ public interface QueryTrace {
     static QueryTrace of(
         final Identifier what, final long elapsed, final List<QueryTrace> children
     ) {
-        log.warn("of is deprecated, use #watch(com.spotify.heroic.metric.QueryTrace.Identifier)");
         return ActiveTrace.create(what, elapsed, children);
     }
 
@@ -136,7 +133,6 @@ public interface QueryTrace {
      */
     @Deprecated
     static Watch watch() {
-        log.warn("watch is deprecated, use Tracing#watch()");
         return ActiveWatch.create(Stopwatch.createStarted());
     }
 
@@ -148,7 +144,6 @@ public interface QueryTrace {
      */
     @Deprecated
     static NamedWatch watch(final Identifier what) {
-        log.warn("watch is deprecated, use Tracing#watch(Identifier)");
         return ActiveNamedWatch.create(what, Stopwatch.createStarted());
     }
 


### PR DESCRIPTION
The annotation is enough to alert the developer (us) to move away from the deprecated methods.

I tried to spend some time migrating the QueryTrace methods but had a hard time following all the involved code. Since we want to do a heroic release soon this will at least cut down on the amount of logging being done in production internally.

Related to https://github.com/spotify/heroic/issues/638