### PR TITLE
[metadata] do not allow partial results from elasticsearch

### DIFF
--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
@@ -451,7 +451,9 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
         OptionalLimit limit = seriesRequest.getLimit();
 
         return doto(c -> {
-            SearchRequest request = c.getIndex().search(METADATA_TYPE);
+            SearchRequest request =
+                c.getIndex().search(METADATA_TYPE).allowPartialSearchResults(false);
+
             request.source()
                 .size(limit.asMaxInteger(scrollSize))
                 .query(new BoolQueryBuilder().must(f))


### PR DESCRIPTION
Heroic should not return partial results as it will mislead users and cause false positive alerts.

Now when an elasticsearch shard is completely unavailable (including any replicas) the search will fail.

Heroic will return this failure as part of the response body.

```
      "errors": [
        {
          "type": "shard",
          "nodes": [
            "LocalClusterNode(localMetadata=NodeMetadata(version=0, id=be4b35e7-df70-48a2-a263-1c201cdc9248, tags={site=foo}, service=ServiceInfo(name=The Heroic Time Series Database, version=0.0.1-SNAPSHOT, id=heroic, commit=ac849fac371ee142394f0f48165ce0d43c5dfb74)))"
          ],
          "shard": {
            "site": "guc"
          },
          "error": "[es01][172.21.0.3:9300][indices:data/read/search], caused by [es01][172.21.0.3:9300][indices:data/read/search], caused by Partial shards failure, caused by [es02][172.21.0.2:9300] Node not connected"
        }
      ]
```

The `what: find-series` metric will show the failures as well.

Closes https://github.com/spotify/heroic/issues/634

I can't find a way to get the single node ES cluster that is spun up as part of IT test to go red. Also writing unit tests was too much mocking for the value they added.