### PR TITLE
Run system tests in a docker full environment.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,16 +90,11 @@ workflows:
             - build
             - validate_branch
 
-  daily:
-    jobs:
-      - docker_build
+      - docker_build:
+          requires:
+            - validate_branch
+
       - system_test:
           requires:
             - docker_build
-    triggers:
-      - schedule:
-          cron: '0 9 * * *'
-          filters:
-            branches:
-              only:
-                - master
+            - validate_branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,24 @@
 version: 2.1
 
-jobs:
-  validate_branch:
+executors:
+  java:
     docker:
       - image: circleci/openjdk:11
+  ubuntu:
+    # Due to remote docker limitations, some jobs require a machine image
+    # https://circleci.com/docs/2.0/building-docker-images/#accessing-services
+    machine:
+      image: ubuntu-1604:202004-01
+
+jobs:
+  validate_branch:
+    executor: java
     steps:
       # CircleCI has terrible support for filtering PRs/branches, this is a hacky workaround
       - run: ([[ $CIRCLE_PULL_REQUESTS == "" ]]) && echo $CIRCLE_BRANCH | grep -Evq "^(master)|([0-9]+\.[0-9]+\.[0-9]+)$" && echo "not a PR / branch to build" && circleci step halt || echo "will build"
 
   build:
-    docker:
-      - image: circleci/openjdk:11
+    executor: java
     steps:
       - checkout
       # Restore gradle deps
@@ -33,9 +41,7 @@ jobs:
             - '*/*/out'
 
   test:
-    machine:
-      # Required for running testcontainer docker images
-      image: ubuntu-1604:201903-01
+    executor: ubuntu
     steps:
       - run:
           name: Install Java 11
@@ -55,6 +61,21 @@ jobs:
       - run: ./gradlew --info check jacocoRootReport
       - run: 'bash <(curl -s https://codecov.io/bash)'
 
+  docker_build:
+    docker:
+      - image: cimg/base:2020.01
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: docker build -t spotify/heroic .
+
+  system_test:
+    executor: ubuntu
+    steps:
+      - run: pyenv global 3.8.2
+      - checkout
+      - run: pip install -r system-tests/requirements.txt
+      - run: cd system-tests && pytest
 
 workflows:
   version: 2
@@ -68,3 +89,17 @@ workflows:
           requires:
             - build
             - validate_branch
+
+  daily:
+    jobs:
+      - docker_build
+      - system_test:
+          requires:
+            - docker_build
+    triggers:
+      - schedule:
+          cron: '0 9 * * *'
+          filters:
+            branches:
+              only:
+                - master

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
 Dockerfile
 .dockerignore
 .gitignore
+.github/
+.circleci/
+
 /docs/
 /.idea/
 *.png
@@ -8,3 +11,6 @@ Dockerfile
 build/
 out/
 .gradle
+
+/system-tests/
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ build/
 out/
 gradle-app.setting
 .gradle
+
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@ dependency-reduced-pom.xml
 target
 *.log
 *~
+
 *.pyc
+venv/
+
 bin
 /*.json
 /*.png
@@ -27,5 +30,3 @@ build/
 out/
 gradle-app.setting
 .gradle
-
-venv/

--- a/docs/content/_docs/config.md
+++ b/docs/content/_docs/config.md
@@ -87,8 +87,7 @@ consumers:
   - ...
 
 # Caching for aggregations.
-cache:
-  backend: <cache_backend>
+cache: <cache_backend>
 
 # Binding settings for the Heroic shell server. This allows full control over the Heroic node and should
 # be restricted.
@@ -804,7 +803,9 @@ threadsPerTopic: <int> default = 2
 # An object that will be provided to the Kafka consumer as configuration.
 # See the official documentation for what is expected:
 # https://kafka.apache.org/08/configuration.html#consumerconfigs
-config: {}
+config:
+  zookeeper.connect: <string> required
+  group.id: <string> required
 
 # If enabled, consumer offsets will be committed periodically. All threads are paused so there are no in-progress
 # requests while the commit is occurring.

--- a/system-tests/.dockerignore
+++ b/system-tests/.dockerignore
@@ -1,0 +1,4 @@
+venv/
+__pycache__/
+.pytest_cache/
+Dockerfile

--- a/system-tests/.dockerignore
+++ b/system-tests/.dockerignore
@@ -1,4 +1,0 @@
-venv/
-__pycache__/
-.pytest_cache/
-Dockerfile

--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -1,0 +1,62 @@
+version: '3.7'
+services:
+  cassandra:
+    image: cassandra:3
+    ports:
+      - '7000:7000'
+      - '9160:9160'
+      - '9042:9042'
+
+  elasticsearch:
+    image: elasticsearch:7.6.0
+    environment:
+      discovery.type: single-node
+      cluster.name: heroic
+    ports:
+      - '9200:9200'
+      - '9300:9300'
+
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - '2181:2181'
+  kafka:
+    image: wurstmeister/kafka
+    ports:
+      - '9092:9092'
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_CREATE_TOPICS: 'metrics:1:1'
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+    restart: on-failure
+
+  pubsub:
+    image: bigtruedata/gcloud-pubsub-emulator
+    ports:
+      - '8085:8085'
+    command:
+      - start
+      - --host-port
+      - 0.0.0.0:8085
+
+  bigtable:
+    image: bigtruedata/gcloud-bigtable-emulator
+    ports:
+      - '8086:8086'
+    command:
+      - start
+      - --host-port
+      - 0.0.0.0:8086
+
+  heroic:
+    image: spotify/heroic:latest
+    environment:
+      PUBSUB_EMULATOR_HOST: pubsub:8085
+      BIGTABLE_EMULATOR_HOST: bigtable:8086
+    ports:
+      - '8080:8080'
+    volumes:
+      - ./heroic.yaml:/heroic.yaml
+    command:
+      - /heroic.yaml
+    restart: on-failure

--- a/system-tests/heroic.yaml
+++ b/system-tests/heroic.yaml
@@ -1,0 +1,80 @@
+host: 0.0.0.0
+port: 8080
+
+cluster:
+  # TODO: test srv discovery
+  discovery:
+    type: static
+    nodes:
+      - grpc://127.0.0.1:9698
+  protocols:
+    - type: grpc
+    - type: jvm
+  tags:
+    site: nyc
+
+metrics:
+  backends:
+    - type: datastax
+      seeds:
+        - cassandra:9042
+      configure: true
+    - type: memory
+    - type: bigtable
+      project: test
+      emulatorEndpoint: 0.0.0.0:8086
+
+metadata:
+  backends:
+    - type: memory
+    - type: elasticsearch
+      configure: true
+      connection:
+        client:
+          type: transport
+          seeds:
+            - elasticsearch:9300
+
+suggest:
+  backends:
+    - type: memory
+    - type: elasticsearch
+      configure: true
+      connection:
+        client:
+          type: transport
+          seeds:
+            - elasticsearch:9300
+
+consumers:
+  - type: kafka
+    schema: com.spotify.heroic.consumer.schemas.Spotify100Proto
+    topics:
+      - metrics
+    config:
+      zookeeper.connect: zookeeper:2181
+      group.id: heroic
+  - type: pubsub
+    schema: com.spotify.heroic.consumer.schemas.Spotify100Proto
+    project: heroic
+    topic: metrics
+    subscription: metrics
+
+cache:
+  # TODO: test memcached
+  type: memory
+
+shellServer:
+  host: 127.0.0.1
+  port: 9190
+
+analytics:
+  type: bigtable
+  project: test-analytics
+  emulatorEndpoint: 0.0.0.0:8086
+
+statistics:
+  type: semantic
+
+queryLogging:
+  type: slf4j

--- a/system-tests/requirements.txt
+++ b/system-tests/requirements.txt
@@ -1,0 +1,2 @@
+pytest-docker-compose
+requests

--- a/system-tests/test_heroic.py
+++ b/system-tests/test_heroic.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+import pytest
+import requests
+from requests.adapters import HTTPAdapter
+import urllib.parse
+from urllib3.util.retry import Retry
+import time
+
+pytest_plugins = ['docker_compose']
+
+
+class HeroicSession(requests.Session):
+    def __init__(self, prefix_url=None, *args, **kwargs):
+        super(HeroicSession, self).__init__(*args, **kwargs)
+        self.prefix_url = prefix_url
+
+    def request(self, method, url, *args, **kwargs):
+        url = urllib.parse.urljoin(self.prefix_url, url)
+        return super(HeroicSession, self).request(method, url, *args, **kwargs)
+
+
+@pytest.fixture(scope='session')
+def api_session(session_scoped_container_getter):
+    """Wait for the Heroic container to become available and return a requests session."""
+
+    container = session_scoped_container_getter.get('heroic')
+    assert container.is_running
+
+    # Wait for Heroic to startup within 2 minutes
+    timeout = 120
+    max_time = time.time() + 120
+    while time.time() < max_time:
+        if 'Startup finished, hello' in container.logs().decode():
+            break
+        else:
+            time.sleep(2)
+    else:
+        raise TimeoutError('Heroic did not start within {} seconds'.format(timeout))
+
+    api_url = 'http://127.0.0.1:{}/'.format(container.network_info[0].host_port)
+    request_session = HeroicSession(api_url)
+    retries = Retry(total=5,
+                    backoff_factor=0.1,
+                    status_forcelist=[500, 502, 503, 504])
+    request_session.mount('http://', HTTPAdapter(max_retries=retries))
+    return request_session
+
+
+def test_loading(api_session):
+    resp = api_session.get('/status', timeout=10)
+    assert resp.ok
+    status = resp.json()
+
+    assert status['ok']
+    assert status['consumers']['ok']
+    assert status['backends']['ok']
+    assert status['metadataBackend']['ok']
+    assert status['cluster']['ok']


### PR DESCRIPTION
I setup the workflow to run in a nightly job, but while testing I temporarily had an always-run workflow. Here's the output of it: https://circleci.com/workflow-run/fd3d0ff0-fd70-462c-937b-ffdb160db110

I think it makes sense to add this to the normal PR CI. The docker build takes about 6 minutes and could/should replace the Docker Hub build. The docker-compose setup and tests take another ~5 minutes on top of that.

Right now the docker-compose setup runs all possible modules except SRV cluster discovery and memcached for caching. As we add tests we might need to spin up multiple clusters with different configurations, but I think that should be pretty straight forward.