### PR TITLE
Fix log4j in shaded jar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,20 +61,13 @@ jobs:
       - run: ./gradlew --info check jacocoRootReport
       - run: 'bash <(curl -s https://codecov.io/bash)'
 
-  docker_build:
-    docker:
-      - image: cimg/base:2020.01
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run: docker build -t spotify/heroic .
-
   system_test:
     executor: ubuntu
     steps:
       - run: pyenv global 3.8.2
       - checkout
       - run: pip install -r system-tests/requirements.txt
+      - run: docker build -t spotify/heroic .
       - run: cd system-tests && pytest
 
 workflows:
@@ -90,11 +83,6 @@ workflows:
             - build
             - validate_branch
 
-      - docker_build:
-          requires:
-            - validate_branch
-
       - system_test:
           requires:
-            - docker_build
             - validate_branch

--- a/heroic-dist/build.gradle
+++ b/heroic-dist/build.gradle
@@ -12,6 +12,10 @@ shadowJar {
     classifier 'shaded'
     zip64 true
 
+    // Log4j2 plugins get lost/overwritten when creating a shaded jar. This transformer merges
+    // them.
+    transform(com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer)
+
     append 'META-INF/services/org.eclipse.jetty.http.HttpFieldPreEncoder'
     // required for lucene
     append 'META-INF/services/org.apache.lucene.codecs.Codec'


### PR DESCRIPTION
The shaded jar stomps all over log4j plugins, which is only recently broken because of #653 . The transformation merges the plugins together properly.

Also, the Circle system_test job wasn't using the locally built docker image. It was pulling the latest image from the Docker Hub, which meant that PRs were testing against the code in master instead of the local code.