### PR TITLE
[elasticsearch-metadata] Add hash to use for sorting.

### DIFF
--- a/heroic-test/src/main/java/com/spotify/heroic/test/AbstractMetadataBackendIT.java
+++ b/heroic-test/src/main/java/com/spotify/heroic/test/AbstractMetadataBackendIT.java
@@ -82,15 +82,16 @@ public abstract class AbstractMetadataBackendIT {
 
     protected final int numSeries = 3;
 
-    private final Series s1 = Series.of("s1", ImmutableMap.of("role", "foo"));
-    private final Series s2 = Series.of("s2", ImmutableMap.of("role", "bar"));
-    private final Series s3 = Series.of("s3", ImmutableMap.of("role", "baz"));
+    protected final Series s1 = Series.of("s1", ImmutableMap.of("role", "foo"));
+    protected final Series s2 = Series.of("s2", ImmutableMap.of("role", "bar"));
+    protected final Series s3 = Series.of("s3", ImmutableMap.of("role", "baz"));
 
-    private final DateRange range = new DateRange(0L, 0L);
+    protected final DateRange range = new DateRange(0L, 0L);
 
     private HeroicCoreInstance core;
-    private MetadataBackend backend;
     private Features fullFeatures;
+
+    protected MetadataBackend backend;
 
     protected boolean deleteSupport = true;
     protected boolean findTagsSupport = true;

--- a/metadata/elasticsearch/src/main/resources/com.spotify.heroic.metadata.elasticsearch/kv/metadata.json
+++ b/metadata/elasticsearch/src/main/resources/com.spotify.heroic.metadata.elasticsearch/kv/metadata.json
@@ -11,6 +11,9 @@
     "tag_keys": {
       "type": "keyword",
       "doc_values": true
+    },
+    "hash": {
+      "type": "keyword"
     }
   }
 }


### PR DESCRIPTION
Adds the hash which was already used as `_id` for elasticsearch, but in an indexed field. This also changes the sort field for searching so it will need to be deployed to consumers before API nodes.

Close #659.