### PR TITLE
Reword introduction in overview

### DIFF
--- a/docs/content/_docs/overview.html
+++ b/docs/content/_docs/overview.html
@@ -5,8 +5,8 @@ title: Overview
 
 <p>
   Heroic is an open-source monitoring system originally built at
-  <a href="https://spotify.com">Spotify</a> to address the problems that were
-  facing with large scale gathering and near real-time analysis of metrics.
+  <a href="https://spotify.com">Spotify</a> to address problems faced
+  with large scale gathering and near real-time analysis of metrics.
 </p>
 
 <p>


### PR DESCRIPTION
The original wasn't quite worded clearly. This new version tries to make the focus more broad, to move Spotify from a singular focus, into just one of the community members. It also drops the definite article on problems, since presumably there are problems that Heroic did not address.