### PR TITLE
Ensure has has "doc_values": true

### DIFF
--- a/metadata/elasticsearch/src/main/resources/com.spotify.heroic.metadata.elasticsearch/kv/metadata.json
+++ b/metadata/elasticsearch/src/main/resources/com.spotify.heroic.metadata.elasticsearch/kv/metadata.json
@@ -13,7 +13,8 @@
       "doc_values": true
     },
     "hash": {
-      "type": "keyword"
+      "type": "keyword",
+      "doc_values": true
     }
   }
 }


### PR DESCRIPTION
So I'm not 100% on this, but when trying to roll out the hash change the api will throw this error (even after the consumers have been running with the hashes rolled out):

```
"type":"illegal_argument_exception","reason":"Fielddata is disabled on text fields by default. Set fielddata=true on [hash] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead."}],"type":"search_phase_execution_exception","reason":"Partial shards failure","phase":"query","grouped":true,"failed_shards":[{"","reason":{"type":"illegal_argument_exception","reason":"Fielddata is disabled on text fields by default. Set fielddata=true on [hash] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead."}}]},"status":400}"
```

https://www.elastic.co/guide/en/elasticsearch/reference/current/fielddata.html#before-enabling-fielddata
Has some suggestions
```
Before you enable fielddata, consider why you are using a text field for aggregations, sorting, or in a script. It usually doesn’t make sense to do so.

A text field is analyzed before indexing so that a value like New York can be found by searching for new or for york. A terms aggregation on this field will return a new bucket and a york bucket, when you probably want a single bucket called New York.

Instead, you should have a text field for full text searches, and an unanalyzed keyword field with doc_values enabled for aggregations.
```

https://www.elastic.co/guide/en/elasticsearch/reference/current/doc-values.html
States `All fields which support doc values have them enabled by default.` which makes me think that the hash field isn't implemented properly or can't be? So I'm not sure this PR in it's current state is a viable solution.

Looking for feedback on this one. But seems like this either ends up as:
```
   "hash": {
      "type": "text",
      "fields": {
        "keyword": {
          "type": "keyword"
        }
      }
    }
```
or this which could cause issues?
```
   "hash": {
      "type": "text",
      "fielddata": true
      }
    }
```