### PR TITLE
Drop metric with row key length bigger then BT limit

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/MetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/MetricBackendReporter.java
@@ -32,5 +32,5 @@ public interface MetricBackendReporter {
 
     FutureReporter.Context reportQueryMetrics();
 
-    void reportWriteDroppedBySize();
+    void reportWritesDroppedBySize();
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/MetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/MetricBackendReporter.java
@@ -31,4 +31,6 @@ public interface MetricBackendReporter {
     FutureReporter.Context reportFindSeries();
 
     FutureReporter.Context reportQueryMetrics();
+
+    void reportWriteDroppedBySize();
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
@@ -78,7 +78,7 @@ public class NoopMetricBackendReporter implements MetricBackendReporter {
     }
 
     @Override
-    public void reportWriteDroppedBySize() {
+    public void reportWritesDroppedBySize() {
 
     }
 

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
@@ -77,6 +77,11 @@ public class NoopMetricBackendReporter implements MetricBackendReporter {
         return NoopFutureReporterContext.get();
     }
 
+    @Override
+    public void reportWriteDroppedBySize() {
+
+    }
+
     private static final NoopMetricBackendReporter instance = new NoopMetricBackendReporter();
 
     public static NoopMetricBackendReporter get() {

--- a/heroic-test/src/main/java/com/spotify/heroic/test/AbstractMetricBackendIT.java
+++ b/heroic-test/src/main/java/com/spotify/heroic/test/AbstractMetricBackendIT.java
@@ -380,8 +380,8 @@ public abstract class AbstractMetricBackendIT {
         assumeTrue("Test huge row key write", hugeRowKey);
         final MetricCollection points = new Points().p(100000L, 42D).build();
         Map<String, String> tags = new HashMap<>();
-        for(int i=0; i<110; i++){
-            tags.put("VeryLongTagName"+i, "VeryLongValueName"+i);
+        for (int i = 0; i < 110; i++) {
+            tags.put("VeryLongTagName" + i, "VeryLongValueName" + i);
         }
         final Series hugeSeries = new Series("s1",
             ImmutableSortedMap.copyOf(tags),

--- a/heroic-test/src/main/java/com/spotify/heroic/test/AbstractMetricBackendIT.java
+++ b/heroic-test/src/main/java/com/spotify/heroic/test/AbstractMetricBackendIT.java
@@ -83,6 +83,7 @@ public abstract class AbstractMetricBackendIT {
     protected boolean brokenSegmentsPr208 = false;
     protected boolean eventSupport = false;
     protected Optional<Integer> maxBatchSize = Optional.empty();
+    protected boolean hugeRowKey = true;
 
     @Rule
     public TestRule setupBackend = (base, description) -> new Statement() {
@@ -376,6 +377,7 @@ public abstract class AbstractMetricBackendIT {
 
     @Test
     public void testWriteHugeMetric() throws Exception {
+        assumeTrue("Test huge row key write", hugeRowKey);
         final MetricCollection points = new Points().p(100000L, 42D).build();
         Map<String, String> tags = new HashMap<>();
         for(int i=0; i<110; i++){

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
@@ -97,8 +97,9 @@ import org.slf4j.LoggerFactory;
 public class BigtableBackend extends AbstractMetricBackend implements LifeCycles {
     private static final Logger log = LoggerFactory.getLogger(BigtableBackend.class);
 
+    /* maximum number of bytes of BigTable row key size allowed*/
     public static final int MAX_KEY_ROW_SIZE = 4000;
-    /* maxmimum number of cells supported for each batch mutation */
+    /* maximum number of cells supported for each batch mutation */
     public static final int MAX_BATCH_SIZE = 10000;
 
     public static final QueryTrace.Identifier FETCH_SEGMENT =

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
@@ -97,6 +97,7 @@ import org.slf4j.LoggerFactory;
 public class BigtableBackend extends AbstractMetricBackend implements LifeCycles {
     private static final Logger log = LoggerFactory.getLogger(BigtableBackend.class);
 
+    public static final int MAX_KEY_ROW_SIZE = 4000;
     /* maxmimum number of cells supported for each batch mutation */
     public static final int MAX_BATCH_SIZE = 10000;
 
@@ -390,6 +391,14 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
 
         for (final Pair<RowKey, Mutations> e : saved) {
             final ByteString rowKeyBytes = rowKeySerializer.serializeFull(e.getKey());
+
+            if(rowKeyBytes.size() >= MAX_KEY_ROW_SIZE){
+                reporter.reportWriteDroppedBySize();
+                log.error("Row key length greater than 4096 bytes (2): " + rowKeyBytes.size()
+                    + " " + rowKeyBytes);
+                continue;
+            }
+
             writes.add(client
                 .mutateRow(table, rowKeyBytes, e.getValue())
                 .directTransform(result -> timer.end()));
@@ -419,6 +428,13 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
         final RequestTimer<WriteMetric> timer = WriteMetric.timer();
 
         final ByteString rowKeyBytes = rowKeySerializer.serializeFull(rowKey);
+
+        if(rowKeyBytes.size() >= MAX_KEY_ROW_SIZE){
+            reporter.reportWriteDroppedBySize();
+            log.error("Row key length greater than 4096 bytes (1): " + rowKeyBytes.size() + " " + rowKey);
+            return async.resolved().directTransform(result -> timer.end());
+        }
+
         return client
             .mutateRow(table, rowKeyBytes, builder.build())
             .directTransform(result -> timer.end());

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
@@ -392,7 +392,7 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
         for (final Pair<RowKey, Mutations> e : saved) {
             final ByteString rowKeyBytes = rowKeySerializer.serializeFull(e.getKey());
 
-            if(rowKeyBytes.size() >= MAX_KEY_ROW_SIZE){
+            if (rowKeyBytes.size() >= MAX_KEY_ROW_SIZE) {
                 reporter.reportWriteDroppedBySize();
                 log.error("Row key length greater than 4096 bytes (2): " + rowKeyBytes.size()
                     + " " + rowKeyBytes);
@@ -429,9 +429,10 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
 
         final ByteString rowKeyBytes = rowKeySerializer.serializeFull(rowKey);
 
-        if(rowKeyBytes.size() >= MAX_KEY_ROW_SIZE){
+        if (rowKeyBytes.size() >= MAX_KEY_ROW_SIZE) {
             reporter.reportWriteDroppedBySize();
-            log.error("Row key length greater than 4096 bytes (1): " + rowKeyBytes.size() + " " + rowKey);
+            log.error("Row key length greater than 4096 bytes (1): " +
+                rowKeyBytes.size() + " " + rowKey);
             return async.resolved().directTransform(result -> timer.end());
         }
 

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
@@ -394,7 +394,7 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
             final ByteString rowKeyBytes = rowKeySerializer.serializeFull(e.getKey());
 
             if (rowKeyBytes.size() >= MAX_KEY_ROW_SIZE) {
-                reporter.reportWriteDroppedBySize();
+                reporter.reportWritesDroppedBySize();
                 log.error("Row key length greater than 4096 bytes (2): " + rowKeyBytes.size()
                     + " " + rowKeyBytes);
                 continue;
@@ -431,7 +431,7 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
         final ByteString rowKeyBytes = rowKeySerializer.serializeFull(rowKey);
 
         if (rowKeyBytes.size() >= MAX_KEY_ROW_SIZE) {
-            reporter.reportWriteDroppedBySize();
+            reporter.reportWritesDroppedBySize();
             log.error("Row key length greater than 4096 bytes (1): " +
                 rowKeyBytes.size() + " " + rowKey);
             return async.resolved().directTransform(result -> timer.end());

--- a/metric/datastax/src/test/java/com/spotify/heroic/metric/datastax/NextGenDatastaxBackendIT.java
+++ b/metric/datastax/src/test/java/com/spotify/heroic/metric/datastax/NextGenDatastaxBackendIT.java
@@ -21,5 +21,6 @@ public class NextGenDatastaxBackendIT extends AbstractDatastaxBackendIT {
         super.setupSupport();
 
         this.brokenSegmentsPr208 = true;
+        this.hugeRowKey = false;
     }
 }

--- a/metric/memory/src/test/java/com/spotify/heroic/metric/memory/MemoryBackendIT.java
+++ b/metric/memory/src/test/java/com/spotify/heroic/metric/memory/MemoryBackendIT.java
@@ -11,6 +11,7 @@ public class MemoryBackendIT extends AbstractMetricBackendIT {
         super.setupSupport();
 
         this.eventSupport = true;
+        this.hugeRowKey = false;
     }
 
     @Override

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
@@ -192,7 +192,7 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
     }
 
     @Override
-    public void reportWriteDroppedBySize() {
+    public void reportWritesDroppedBySize() {
         writesDroppedBySize.inc();
     }
 

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
@@ -81,6 +81,8 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
     private final Histogram queryRowMsBetweenSamples;
     // Average samples per mega-seconds :)
     private final Histogram queryRowDensity;
+    // Counter of dropped writes due to row key size
+    private final Counter writesDroppedBySize;
 
     public SemanticMetricBackendReporter(SemanticMetricRegistry registry) {
         final MetricId base = MetricId.build().tagged("component", COMPONENT);
@@ -118,6 +120,9 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
             base.tagged("what", "query-metrics-row-metric-distance", "unit", Units.MILLISECOND));
         queryRowDensity = registry.histogram(
             base.tagged("what", "query-metrics-row-density", "unit", Units.COUNT));
+
+        writesDroppedBySize = registry.counter(
+            base.tagged("what", "writes-dropped-by-size", "unit", Units.COUNT));
     }
 
     @Override
@@ -184,6 +189,11 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
                 }
             }
         };
+    }
+
+    @Override
+    public void reportWriteDroppedBySize() {
+        writesDroppedBySize.inc();
     }
 
     @Override


### PR DESCRIPTION
This change will drop metric with row key length longer than 4096 bytes.
It will also create counter metric so we could alert on high numbers.