### PR TITLE
Add total stats across all queries in local manager

### DIFF
--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -717,7 +717,7 @@ public class LocalMetricManager implements MetricManager {
         private final long dataLimit;
         private final long retainLimit;
         private final DataInMemoryReporter dataInMemoryReporter;
-        private final long LOGLIMIT = 1_000_000;
+        private static final long LOGLIMIT = 1_000_000;
 
         private final AtomicLong read = new AtomicLong();
         private final AtomicLong retained = new AtomicLong();

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -734,7 +734,8 @@ public class LocalMetricManager implements MetricManager {
         public void readData(long n) {
             long curDataPoints = read.addAndGet(n);
             if (curDataPoints > 1_000_000) {
-                long total = quotaWatchers.stream().map(QuotaWatcher::getReadData).reduce(0L, Long::sum);
+                long total = quotaWatchers.stream().map(QuotaWatcher::getReadData)
+                    .reduce(0L, Long::sum);
                 log.info("Total: {}; watchers: {}; Data points: {}; added: {}", total,
                     quotaWatchers.size(), curDataPoints, n);
             }
@@ -747,7 +748,8 @@ public class LocalMetricManager implements MetricManager {
         public void retainData(final long n) {
             long curRetainedDataPoints = retained.addAndGet(n);
             if (curRetainedDataPoints > 500_000) {
-                long total = quotaWatchers.stream().map(QuotaWatcher::getRetainData).reduce(0L, Long::sum);
+                long total = quotaWatchers.stream().map(QuotaWatcher::getRetainData)
+                    .reduce(0L, Long::sum);
                 log.info("Total: {}; watchers: {}; Data points retained: {}; added: {}", total,
                     quotaWatchers.size(), curRetainedDataPoints, n);
             }
@@ -775,11 +777,11 @@ public class LocalMetricManager implements MetricManager {
             rowsAccessed.add(n);
         }
 
-        public long getReadData(){
+        public long getReadData() {
             return read.get();
         }
 
-        public long getRetainData(){
+        public long getRetainData() {
             return retained.get();
         }
 

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -717,7 +717,7 @@ public class LocalMetricManager implements MetricManager {
         private final long dataLimit;
         private final long retainLimit;
         private final DataInMemoryReporter dataInMemoryReporter;
-        private final long LOG_LIMIT = 1_000_000;
+        private final long LOGLIMIT = 1_000_000;
 
         private final AtomicLong read = new AtomicLong();
         private final AtomicLong retained = new AtomicLong();
@@ -734,7 +734,7 @@ public class LocalMetricManager implements MetricManager {
         @Override
         public void readData(long n) {
             long curDataPoints = read.addAndGet(n);
-            if (curDataPoints > LOG_LIMIT) {
+            if (curDataPoints > LOGLIMIT) {
                 long total = quotaWatchers.stream().map(QuotaWatcher::getReadData)
                     .reduce(0L, Long::sum);
                 log.info("Data Points READ: Instance {}; This Query: {}; Delta: {}" +
@@ -749,7 +749,7 @@ public class LocalMetricManager implements MetricManager {
         @Override
         public void retainData(final long n) {
             long curRetainedDataPoints = retained.addAndGet(n);
-            if (curRetainedDataPoints > LOG_LIMIT) {
+            if (curRetainedDataPoints > LOGLIMIT) {
                 long total = quotaWatchers.stream().map(QuotaWatcher::getRetainData)
                     .reduce(0L, Long::sum);
                 log.info("Data Points RETAINED: Instance {}; This Query: {}; Delta: {} " +

--- a/metric/bigtable/src/test/java/com/spotify/heroic/metric/bigtable/BigtableBackendIT.java
+++ b/metric/bigtable/src/test/java/com/spotify/heroic/metric/bigtable/BigtableBackendIT.java
@@ -8,9 +8,10 @@ import org.junit.ClassRule;
 import org.testcontainers.containers.GenericContainer;
 
 public class BigtableBackendIT extends AbstractMetricBackendIT {
+    // TODO reverse emulator image to bigtruedata/gcloud-bigtable-emulator when they fix it
     @ClassRule
     public static GenericContainer container =
-        new GenericContainer("bigtruedata/gcloud-bigtable-emulator")
+        new GenericContainer("malish8632/bigtable-emulator:latest")
             .withExposedPorts(8086)
             .withCommand("start", "--host-port", "0.0.0.0:8086");
 

--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -40,7 +40,8 @@ services:
       - 0.0.0.0:8085
 
   bigtable:
-    image: bigtruedata/gcloud-bigtable-emulator
+    # TODO reverse emulator image to bigtruedata/gcloud-bigtable-emulator when they fix it
+    image: malish8632/bigtable-emulator:latest
     ports:
       - '8086:8086'
     command:


### PR DESCRIPTION
This should help understand the behavior of heroic under pressure.
Next step would be to add these stats as Gauges to SemanticRegistry and use them also to reject queries if above global limit.
Currently each query is responsible for exiting in case limits are breached.