### PR TITLE
Add global data points stats

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/MetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/MetricBackendReporter.java
@@ -33,4 +33,8 @@ public interface MetricBackendReporter {
     FutureReporter.Context reportQueryMetrics();
 
     void reportWritesDroppedBySize();
+
+    void reportGlobalReadDataPoints(long points);
+
+    void reportGlobalRetainedDataPoints(long points);
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/MetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/MetricBackendReporter.java
@@ -34,7 +34,7 @@ public interface MetricBackendReporter {
 
     void reportWritesDroppedBySize();
 
-    void reportGlobalReadDataPoints(long points);
+    void reportTotalReadDataPoints(long points);
 
-    void reportGlobalRetainedDataPoints(long points);
+    void reportTotalRetainedDataPoints(long points);
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
@@ -83,12 +83,12 @@ public class NoopMetricBackendReporter implements MetricBackendReporter {
     }
 
     @Override
-    public void reportGlobalReadDataPoints(long points) {
+    public void reportTotalReadDataPoints(long points) {
 
     }
 
     @Override
-    public void reportGlobalRetainedDataPoints(long points) {
+    public void reportTotalRetainedDataPoints(long points) {
 
     }
 

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
@@ -82,6 +82,16 @@ public class NoopMetricBackendReporter implements MetricBackendReporter {
 
     }
 
+    @Override
+    public void reportGlobalReadDataPoints(long points) {
+
+    }
+
+    @Override
+    public void reportGlobalRetainedDataPoints(long points) {
+
+    }
+
     private static final NoopMetricBackendReporter instance = new NoopMetricBackendReporter();
 
     public static NoopMetricBackendReporter get() {

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -436,11 +436,13 @@ public class LocalMetricManager implements MetricManager {
         private void cleanQuotaWatchers(QuotaWatcher quotaWatcher) {
             // Let's find any old watchers based on start timestamp
             quotaWatchers.remove(quotaWatcher);
-            log.info("Millis QuotaWatcher was alive: {}", (System.currentTimeMillis() - quotaWatcher.startMS));
+            log.info("Millis QuotaWatcher was alive: {}",
+                (System.currentTimeMillis() - quotaWatcher.startMS));
 
             quotaWatchers.removeIf(qw -> {
                 if (System.currentTimeMillis() - qw.startMS > 120_000) {
-                    log.info("Removing QuotaWatcher with MS alive: {}", (System.currentTimeMillis() - qw.startMS));
+                    log.info("Removing QuotaWatcher with MS alive: {}",
+                        (System.currentTimeMillis() - qw.startMS));
                     return true;
                 }
                 return false;

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -67,13 +67,16 @@ import io.opencensus.trace.Span;
 import io.opencensus.trace.Tracer;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.inject.Inject;
@@ -104,7 +107,8 @@ public class LocalMetricManager implements MetricManager {
     private final MetricBackendReporter reporter;
     private final QueryLogger queryLogger;
     private final Semaphore concurrentQueries;
-    private static final ConcurrentMap<Integer, QuotaWatcher> quotaWatchers = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<Integer, QuotaWatcher> quotaWatchers =
+        new ConcurrentHashMap<>();
 
     /**
      * @param groupLimit The maximum amount of groups this manager will allow to be generated.

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -415,18 +415,21 @@ public class LocalMetricManager implements MetricManager {
                 .onDone(new FutureDone<>() {
                     @Override
                     public void failed(final Throwable cause) throws Exception {
+                        quotaWatchers.remove(quotaWatcher);
                         cleanQuotaWatchers(quotaWatcher);
                         log.info("onDone.failed {}", quotaWatchers.size());
                     }
 
                     @Override
                     public void resolved(final FullQuery result) throws Exception {
+                        quotaWatchers.remove(quotaWatcher);
                         cleanQuotaWatchers(quotaWatcher);
                         log.info("onDone.resolved {}", quotaWatchers.size());
                     }
 
                     @Override
                     public void cancelled() throws Exception {
+                        quotaWatchers.remove(quotaWatcher);
                         cleanQuotaWatchers(quotaWatcher);
                         log.info("onDone.cancelled {}", quotaWatchers.size());
                     }
@@ -435,7 +438,6 @@ public class LocalMetricManager implements MetricManager {
 
         private void cleanQuotaWatchers(QuotaWatcher quotaWatcher) {
             // Let's find any old watchers based on start timestamp
-            quotaWatchers.remove(quotaWatcher);
             log.info("Millis QuotaWatcher was alive: {}",
                 (System.currentTimeMillis() - quotaWatcher.startMS));
 
@@ -769,7 +771,7 @@ public class LocalMetricManager implements MetricManager {
             long curDataPoints = read.addAndGet(n);
             long total = quotaWatchers.stream().map(QuotaWatcher::getReadData)
                 .reduce(0L, Long::sum);
-            reporter.reportGlobalReadDataPoints(total);
+            reporter.reportTotalReadDataPoints(total);
             if (curDataPoints > LOGLIMIT) {
                 log.info("Data Points READ: Instance {}; This Query: {}; Delta: {}" +
                     " (# Watchers: {})", total, curDataPoints,
@@ -785,7 +787,7 @@ public class LocalMetricManager implements MetricManager {
             long curRetainedDataPoints = retained.addAndGet(n);
             long total = quotaWatchers.stream().map(QuotaWatcher::getRetainData)
                 .reduce(0L, Long::sum);
-            reporter.reportGlobalRetainedDataPoints(total);
+            reporter.reportTotalRetainedDataPoints(total);
             if (curRetainedDataPoints > LOGLIMIT) {
                 log.info("Data Points RETAINED: Instance {}; This Query: {}; Delta: {} " +
                     "(# Watchers: {})", total, curRetainedDataPoints,

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
@@ -212,12 +212,12 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
     }
 
     @Override
-    public void reportGlobalReadDataPoints(long points) {
+    public void reportTotalReadDataPoints(long points) {
         globalReadDataPoints.set(points);
     }
 
     @Override
-    public void reportGlobalRetainedDataPoints(long points) {
+    public void reportTotalRetainedDataPoints(long points) {
         globalRetainedDataPoints.set(points);
     }
 

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
@@ -135,7 +135,8 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
         globalDataPointsGauge = registry.register(base.tagged("what", "read-data-points"),
             (Gauge<Long>) () -> (long) globalReadDataPoints.get());
 
-        globalRetainedDataPointsGauge = registry.register(base.tagged("what", "retained-data-points"),
+        globalRetainedDataPointsGauge = registry.register(
+            base.tagged("what", "retained-data-points"),
             (Gauge<Long>) () -> (long) globalRetainedDataPoints.get());
     }
 


### PR DESCRIPTION
This will allow us to observe the data points via Grafana and also via logs.
The premise of this to identify global limits we could use to protect Heroic from OOMing by rejecting requests in case current global data points are above the limits.