### PR TITLE
Fix reflexive access warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ allprojects {
     protobuf {
         protoc {
             // Download from repositories
-            artifact = 'com.google.protobuf:protoc:3.5.1'
+            artifact = 'com.google.protobuf:protoc:3.13.0'
         }
     }
 
@@ -105,6 +105,11 @@ allprojects {
             }
         }
     }
+    configurations.all {
+        resolutionStrategy {
+            force 'com.spotify:dns:3.2.2'
+        }
+    }
 
     // Dependency management defines shared versions across all submodules to ensure consistency
     dependencyManagement {
@@ -117,14 +122,14 @@ allprojects {
             }
             
             dependency 'com.datastax.cassandra:cassandra-driver-core:3.8.0'
-            dependency 'com.spotify:folsom:1.6.2'
+            dependency 'com.spotify:folsom:1.7.4'
 
             dependencySet(group: 'com.spotify.metrics', version: '1.0.2') {
                 entry 'semantic-metrics-core'
                 entry 'semantic-metrics-ffwd-reporter'
             }
 
-            dependency 'com.google.protobuf:protobuf-java:3.5.1'
+            dependency 'com.google.protobuf:protobuf-java:3.13.0'
 
             dependency 'com.squareup.okhttp3:okhttp:3.10.0'
 


### PR DESCRIPTION
Compilation currently produces these two warnings
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.xbill.DNS.ResolverConfig (file:/Users/samanthanoellef/.gradle/caches/modules-2/files-2.1/dnsjava/dnsjava/2.1.7/a1ed0a251d22bf528cebfafb94c55e6f3f339cf/dnsjava-2.1.7.jar) to method sun.net.dns.ResolverConfiguration.open()
WARNING: Please consider reporting this to the maintainers of org.xbill.DNS.ResolverConfig
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
An illegal reflective access operation has occurred

Illegal reflective access by org.xbill.DNS.ResolverConfig (file:/Users/samanthanoellef/.gradle/caches/modules-2/files-2.1/dnsjava/dnsjava/2.1.7/a1ed0a251d22bf528cebfafb94c55e6f3f339cf/dnsjava-2.1.7.jar) to method sun.net.dns.ResolverConfiguration.open()

Please consider reporting this to the maintainers of org.xbill.DNS.ResolverConfig

Use --illegal-access=warn to enable warnings of further illegal reflective access operations

All illegal access operations will be denied in a future release
```

and 

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.protobuf.UnsafeUtil (file:/Users/samanthanoellef/.m2/repository/com/google/protobuf/protobuf-java/3.5.1/protobuf-java-3.5.1.jar) to field java.nio.Buffer.address
WARNING: Please consider reporting this to the maintainers of com.google.protobuf.UnsafeUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
An illegal reflective access operation has occurred

Illegal reflective access by com.google.protobuf.UnsafeUtil (file:/Users/samanthanoellef/.m2/repository/com/google/protobuf/protobuf-java/3.5.1/protobuf-java-3.5.1.jar) to field java.nio.Buffer.address

Please consider reporting this to the maintainers of com.google.protobuf.UnsafeUtil

Use --illegal-access=warn to enable warnings of further illegal reflective access operations

All illegal access operations will be denied in a future release
```

The first is related to this [issue](https://github.com/dnsjava/dnsjava/issues/18) with **dnsjava**. To fix this, this PR forces **com.spotify:folsom** to use the later **com.spotify:dns:3.2.2** which uses the newer version of **dnsjava** containing the fix.

The second is related [this issue](https://github.com/google/or-tools/issues/2044). To fix this, this PR uses the latest version of protobuf.