### PR TITLE
Add Bigtable profile to metrics and analytics modules

### DIFF
--- a/heroic-dist/src/main/java/com/spotify/heroic/profile/BigtableProfile.java
+++ b/heroic-dist/src/main/java/com/spotify/heroic/profile/BigtableProfile.java
@@ -48,6 +48,7 @@ public class BigtableProfile extends HeroicProfileBase {
 
         params.get("project").map(module::project);
         params.get("instance").map(module::instance);
+        params.get("profile").map(module::profile);
 
         final String credentials = params.get("credential").orElse(DEFAULT_CREDENTIALS);
 
@@ -101,6 +102,7 @@ public class BigtableProfile extends HeroicProfileBase {
                     "configured"),
             parameter("project", "Bigtable project to use", "<project>"),
             parameter("instance", "Bigtable instance to use", "<instance>"),
+            parameter("profile", "Bigtable profile to use", "<profile>"),
             parameter("credentials", "Credentials implementation to use, must be one of:" +
                     " default, compute-engine, json, service-account", "<credentials>"),
             parameter("json", "Json file to use when using json credentials", "<file>"),

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnection.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnection.java
@@ -76,6 +76,7 @@ public class BigtableConnection {
 
     public String toString() {
         return "BigtableConnectionBuilder.GrpcBigtableConnection(project=" + this.project
-               + ", instance=" + this.instance + ")";
+               + ", instance=" + this.instance
+               + ", profile=" + this.session.getOptions().getAppProfileId() + ")";
     }
 }

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnectionBuilder.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnectionBuilder.java
@@ -124,7 +124,6 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
 
     public String toString() {
         return "BigtableConnectionBuilder(project=" + this.project + ", instance=" + this.instance
-            + ", profile=" + (this.profile != null ? this.profile : "null")
-            + ", credentials=" + this.credentials + ")";
+            + ", profile=" + this.profile + ", credentials=" + this.credentials + ")";
     }
 }

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnectionBuilder.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnectionBuilder.java
@@ -43,6 +43,7 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
 
     private final String project;
     private final String instance;
+    private final String profile;
 
     private final CredentialsBuilder credentials;
 
@@ -56,6 +57,7 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
     public BigtableConnectionBuilder(
         final String project,
         final String instance,
+        final String profile,
         final CredentialsBuilder credentials,
         @Nullable final String emulatorEndpoint,
         final AsyncFramework async,
@@ -65,6 +67,7 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
     ) {
         this.project = project;
         this.instance = instance;
+        this.profile = profile;
         this.credentials = credentials;
         this.emulatorEndpoint = emulatorEndpoint;
         this.async = async;
@@ -96,6 +99,10 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
             .setRetryOptions(retryOptions)
             .setBulkOptions(bulkOptions);
 
+        if (profile != null) {
+            builder.setAppProfileId(profile);
+        }
+
         if (emulatorEndpoint != null) {
             builder.enableEmulator(emulatorEndpoint);
         }
@@ -117,6 +124,7 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
 
     public String toString() {
         return "BigtableConnectionBuilder(project=" + this.project + ", instance=" + this.instance
-               + ", credentials=" + this.credentials + ")";
+            + ", profile=" + (this.profile != null ? this.profile : "null")
+            + ", credentials=" + this.credentials + ")";
     }
 }

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableMetricModule.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableMetricModule.java
@@ -61,6 +61,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
     private final Groups groups;
     private final String project;
     private final String instance;
+    private final String profile;
     private final String table;
     private final CredentialsBuilder credentials;
     private final boolean configure;
@@ -75,6 +76,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         @JsonProperty("groups") Optional<Groups> groups,
         @JsonProperty("project") Optional<String> project,
         @JsonProperty("instance") Optional<String> instance,
+        @JsonProperty("profile") Optional<String> profile,
         @JsonProperty("table") Optional<String> table,
         @JsonProperty("credentials") Optional<CredentialsBuilder> credentials,
         @JsonProperty("configure") Optional<Boolean> configure,
@@ -87,6 +89,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         this.groups = groups.orElseGet(Groups::empty).or(DEFAULT_GROUP);
         this.project = project.orElseThrow(() -> new NullPointerException("project"));
         this.instance = instance.orElse(DEFAULT_INSTANCE);
+        this.profile = profile.orElse(null);
         this.table = table.orElse(DEFAULT_TABLE);
         this.credentials = credentials.orElse(DEFAULT_CREDENTIALS);
         this.configure = configure.orElse(DEFAULT_CONFIGURE);
@@ -126,7 +129,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
                 public AsyncFuture<BigtableConnection> construct() {
                     return async.call(
                         new BigtableConnectionBuilder(
-                            project, instance, credentials, emulatorEndpoint,
+                            project, instance, profile, credentials, emulatorEndpoint,
                             async, disableBulkMutations, flushIntervalSeconds, batchSize));
                 }
 
@@ -188,6 +191,7 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         private Optional<Groups> groups = empty();
         private Optional<String> project = empty();
         private Optional<String> instance = empty();
+        private Optional<String> profile = empty();
         private Optional<String> table = empty();
         private Optional<CredentialsBuilder> credentials = empty();
         private Optional<Boolean> configure = empty();
@@ -213,6 +217,11 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
 
         public Builder instance(String instance) {
             this.instance = of(instance);
+            return this;
+        }
+
+        public Builder profile(String profile) {
+            this.profile = of(profile);
             return this;
         }
 
@@ -252,8 +261,9 @@ public final class BigtableMetricModule implements MetricModule, DynamicModuleId
         }
 
         public BigtableMetricModule build() {
-            return new BigtableMetricModule(id, groups, project, instance, table, credentials,
-                configure, disableBulkMutations, flushIntervalSeconds, batchSize, emulatorEndpoint);
+            return new BigtableMetricModule(id, groups, project, instance, profile,
+                table, credentials, configure, disableBulkMutations, flushIntervalSeconds,
+                batchSize, emulatorEndpoint);
         }
     }
 }


### PR DESCRIPTION
This is required to configure Heroic to use different clusters specifically to separate read and writes after introducing replica.
[App profiles](https://cloud.google.com/bigtable/docs/app-profiles) are used to route clients to different clusters on the same instance. 
Bigtable instances could have multiple clusters.

All tests are successful as well locally verified configuration with and without application `profile` ID.