### PR TITLE
[WIP]Add distribution support to spotify100_proto and BigtableBackend writer

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/AggregationSession.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/AggregationSession.java
@@ -22,6 +22,7 @@
 package com.spotify.heroic.aggregation;
 
 import com.spotify.heroic.common.Series;
+import com.spotify.heroic.metric.DistributionPoint;
 import com.spotify.heroic.metric.Payload;
 import com.spotify.heroic.metric.MetricGroup;
 import com.spotify.heroic.metric.Point;
@@ -32,13 +33,18 @@ import java.util.Map;
 import java.util.Set;
 
 public interface AggregationSession {
-    void updatePoints(Map<String, String> key, Set<Series> series, List<Point> values);
+    void updatePoints(Map<String, String> key, Set<Series> series, List<Point> points);
 
     void updateSpreads(Map<String, String> key, Set<Series> series, List<Spread> values);
 
     void updateGroup(Map<String, String> key, Set<Series> series, List<MetricGroup> values);
 
     void updatePayload(Map<String, String> key, Set<Series> series, List<Payload> values);
+
+    default void updateDistributionPoints(Map<String, String> key,
+                                          Set<Series> series, List<DistributionPoint> points) {
+           throw new RuntimeException("Not yet implemented");
+    }
 
     /**
      * Get the result of this aggregator.

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/Distribution.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/Distribution.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.metric;
+
+import com.google.protobuf.ByteString;
+
+public interface Distribution {
+   ByteString getValue();
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/DistributionPoint.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/DistributionPoint.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.metric;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.hash.Hasher;
+import org.jetbrains.annotations.NotNull;
+
+
+@AutoValue
+public abstract class DistributionPoint implements Metric {
+
+    public abstract long getTimestamp();
+    public abstract Distribution value();
+
+    public static DistributionPoint create(final Distribution value, final long timestamp) {
+        return new AutoValue_DistributionPoint(timestamp, value);
+    }
+
+    @Override
+    public boolean valid() {
+        return value().getValue() != null &&  !value().getValue().isEmpty();
+    }
+
+    @Override
+    public void hash(@NotNull Hasher hasher) {
+        hasher.putInt(this.hashCode());
+    }
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/HeroicDistribution.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/HeroicDistribution.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.metric;
+
+import com.google.auto.value.AutoValue;
+import com.google.protobuf.ByteString;
+
+@AutoValue
+public abstract class HeroicDistribution implements Distribution {
+    public abstract ByteString getValue();
+    public static HeroicDistribution create(final ByteString byteString) {
+        return new AutoValue_HeroicDistribution(byteString);
+    }
+
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/MetricCollection.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/MetricCollection.java
@@ -72,6 +72,7 @@ import java.util.Set;
     @JsonSubTypes.Type(MetricCollection.SpreadCollection.class),
     @JsonSubTypes.Type(MetricCollection.GroupCollection.class),
     @JsonSubTypes.Type(MetricCollection.CardinalityCollection.class),
+    @JsonSubTypes.Type(MetricCollection.DistributionPointCollection.class),
 })
 public interface MetricCollection {
     /**
@@ -159,6 +160,16 @@ public interface MetricCollection {
     }
 
     /**
+     * Create a new distribution point collection
+     *
+     * @param metric distribution points
+     * @return a new collection of distribution point
+     */
+    static MetricCollection distributionPoints(List<DistributionPoint> metric) {
+        return DistributionPointCollection.create(metric);
+    }
+
+    /**
      * Build a new spreads collection.
      *
      * @param metrics spreads to include in the collection
@@ -197,6 +208,8 @@ public interface MetricCollection {
                 return SpreadCollection.create((List<Spread>) metrics);
             case POINT:
                 return PointCollection.create((List<Point>) metrics);
+            case DISTRIBUTION_POINTS:
+                return DistributionPointCollection.create((List<DistributionPoint>) metrics);
             default:
                 throw new RuntimeException("unsupported metric collection");
         }
@@ -228,7 +241,7 @@ public interface MetricCollection {
         }
 
         @JsonProperty
-        public abstract List<Point> data();
+        public abstract  List<Point> data();
 
         @Override
         public MetricType getType() {
@@ -240,6 +253,31 @@ public interface MetricCollection {
             AggregationSession session, Map<String, String> key, Set<Series> series
         ) {
             session.updatePoints(key, series, data());
+        }
+    }
+
+    @AutoValue
+    @JsonTypeName("distributionPoints")
+    abstract class DistributionPointCollection implements MetricCollection {
+        @JsonCreator
+        public static PointCollection create(
+            @JsonProperty("data") final List<DistributionPoint> data) {
+            return new AutoValue_MetricCollection_PointCollection(data);
+        }
+
+        @JsonProperty
+        public abstract  List<DistributionPoint> data();
+
+        @Override
+        public MetricType getType() {
+            return MetricType.DISTRIBUTION_POINTS;
+        }
+
+        @Override
+        public void updateAggregation(
+            AggregationSession session, Map<String, String> key, Set<Series> series
+        ) {
+            session.updateDistributionPoints(key, series, data());
         }
     }
 

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/MetricCollection.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/MetricCollection.java
@@ -260,9 +260,9 @@ public interface MetricCollection {
     @JsonTypeName("distributionPoints")
     abstract class DistributionPointCollection implements MetricCollection {
         @JsonCreator
-        public static PointCollection create(
+        public static DistributionPointCollection create(
             @JsonProperty("data") final List<DistributionPoint> data) {
-            return new AutoValue_MetricCollection_PointCollection(data);
+            return new AutoValue_MetricCollection_DistributionPointCollection(data);
         }
 
         @JsonProperty

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/MetricType.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/MetricType.java
@@ -41,7 +41,8 @@ public enum MetricType {
     SPREAD(Spread.class, "spreads"),
     GROUP(MetricGroup.class, "groups"),
     // TODO: rename to PAYLOAD.
-    CARDINALITY(Payload.class, "cardinality");
+    CARDINALITY(Payload.class, "cardinality"),
+    DISTRIBUTION_POINTS(DistributionPoint.class, "distributionPoints");
     // @formatter:on
 
     private final Class<? extends Metric> type;

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100Proto.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100Proto.java
@@ -30,6 +30,9 @@ import com.spotify.heroic.consumer.SchemaScope;
 import com.spotify.heroic.ingestion.Ingestion;
 import com.spotify.heroic.ingestion.IngestionGroup;
 import com.spotify.heroic.ingestion.Request;
+import com.spotify.heroic.metric.Distribution;
+import com.spotify.heroic.metric.DistributionPoint;
+import com.spotify.heroic.metric.HeroicDistribution;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.statistics.ConsumerReporter;
@@ -53,70 +56,96 @@ import org.xerial.snappy.Snappy;
  */
 public class Spotify100Proto implements ConsumerSchema {
 
-  @SchemaScope
-  public static class Consumer implements ConsumerSchema.Consumer {
+    @SchemaScope
+    public static class Consumer implements ConsumerSchema.Consumer {
 
-    private final Clock clock;
-    private final IngestionGroup ingestion;
-    private final ConsumerReporter reporter;
-    private final AsyncFramework async;
+        private final Clock clock;
+        private final IngestionGroup ingestion;
+        private final ConsumerReporter reporter;
+        private final AsyncFramework async;
 
-    @Inject
-    public Consumer(
-      Clock clock,
-      IngestionGroup ingestion,
-      ConsumerReporter reporter,
-      AsyncFramework async
-    ) {
-      this.clock = clock;
-      this.ingestion = ingestion;
-      this.reporter = reporter;
-      this.async = async;
-    }
-
-    @Override
-    public AsyncFuture<Void> consume(final byte[] message) throws ConsumerSchemaException {
-      final List<Spotify100.Metric> metrics;
-      try {
-        metrics = Spotify100.Batch.parseFrom(Snappy.uncompress(message)).getMetricList();
-      } catch (IOException e) {
-        throw new ConsumerSchemaValidationException("Invalid batch of metrics", e);
-      }
-
-      final List<AsyncFuture<Ingestion>> ingestions = new ArrayList<>();
-      for (Spotify100.Metric metric : metrics) {
-
-        if (metric.getTime() <= 0) {
-          throw new ConsumerSchemaValidationException(
-            "time: field must be a positive number: " + metric.toString());
+        @Inject
+        public Consumer(
+            Clock clock,
+            IngestionGroup ingestion,
+            ConsumerReporter reporter,
+            AsyncFramework async
+        ) {
+            this.clock = clock;
+            this.ingestion = ingestion;
+            this.reporter = reporter;
+            this.async = async;
         }
 
-        final Series s = Series.of(metric.getKey(), metric.getTagsMap(), metric.getResourceMap());
-        final Point p = new Point(metric.getTime(), metric.getValue());
-        final List<Point> points = ImmutableList.of(p);
+        @Override //TODO why is consume static
+        public AsyncFuture<Void> consume(final byte[] message) throws ConsumerSchemaException {
+            final List<Spotify100.Metric> metrics;
+            try {
+                metrics = Spotify100.Batch.parseFrom(Snappy.uncompress(message)).getMetricList();
+            } catch (IOException e) {
+                throw new ConsumerSchemaValidationException("Invalid batch of metrics", e);
+            }
 
-        reporter.reportMessageDrift(clock.currentTimeMillis() - p.getTimestamp());
+            final List<AsyncFuture<Ingestion>> ingestions = new ArrayList<>();
+            for (Spotify100.Metric metric : metrics) {
 
-        ingestions.add(ingestion.write(new Request(s, MetricCollection.points(points))));
-      }
+                if (metric.getTime() <= 0) {
+                    throw new ConsumerSchemaValidationException(
+                        "time: field must be a positive number: " + metric.toString());
+                }
+                reporter.reportMessageDrift(clock.currentTimeMillis() - metric.getTime());
 
-      reporter.reportMetricsIn(metrics.size());
+                final Series s = Series.of(metric.getKey(), metric.getTagsMap(),
+                    metric.getResourceMap());
 
-      // Return Void future, to not leak unnecessary information from the backend but just
-      // allow monitoring of when the consumption is done.
-      return async.collectAndDiscard(ingestions);
+
+                Spotify100.Value distributionTypeValue = metric.getDistributionTypeValue();
+
+                Point point = null;
+
+                if (!metric.hasDistributionTypeValue()) {
+                    point = new Point(metric.getTime(), metric.getValue());
+                } else if (distributionTypeValue != null) {
+                    if (distributionTypeValue.getDoubleValue() != 0) {
+                        point = new Point(metric.getTime(), distributionTypeValue.getDoubleValue());
+                    } else {
+                        Distribution distribution = HeroicDistribution.
+                            create(distributionTypeValue.getDistributionValue());
+                        DistributionPoint distributionPoint =
+                            DistributionPoint.create(distribution, metric.getTime());
+                        final List<DistributionPoint> distributionPoints =
+                            ImmutableList.of(distributionPoint);
+                        ingestions
+                            .add(ingestion.write(new Request(s,
+                                MetricCollection.distributionPoints(distributionPoints))));
+                    }
+                }
+
+                if (point != null) {
+                    List<Point> points = ImmutableList.of(point);
+                    ingestions
+                        .add(ingestion.write(new Request(s, MetricCollection.points(points))));
+                }
+
+            }
+
+            reporter.reportMetricsIn(metrics.size());
+
+            // Return Void future, to not leak unnecessary information from the backend but just
+            // allow monitoring of when the consumption is done.
+            return async.collectAndDiscard(ingestions);
+        }
     }
-  }
 
-  @Override
-  public Exposed setup(final Depends depends) {
-    return DaggerSpotify100Proto_C.builder().depends(depends).build();
-  }
-
-  @SchemaScope
-  @Component(dependencies = Depends.class)
-  interface C extends Exposed {
     @Override
-    Spotify100Proto.Consumer consumer();
-  }
+    public Exposed setup(final Depends depends) {
+        return DaggerSpotify100Proto_C.builder().depends(depends).build();
+    }
+
+    @SchemaScope
+    @Component(dependencies = Depends.class)
+    interface C extends Exposed {
+        @Override
+        Spotify100Proto.Consumer consumer();
+    }
 }

--- a/heroic-core/src/main/proto/spotify_100.proto
+++ b/heroic-core/src/main/proto/spotify_100.proto
@@ -20,8 +20,24 @@ message Metric {
 
   // resource "tags" associated to metric.
   map<string, string> resource = 5;
+
+  // Distribution type value
+  Value distribution_type_value = 6;
+}
+
+message Message {
+  Metric metric = 1;
 }
 
 message Batch {
   repeated Metric metric = 1;
 }
+
+
+message Value {
+  oneof value {
+    double double_value = 1;
+    bytes distribution_value= 2;
+  }
+}
+

--- a/heroic-core/src/main/proto/spotify_100.proto
+++ b/heroic-core/src/main/proto/spotify_100.proto
@@ -25,10 +25,6 @@ message Metric {
   Value distribution_type_value = 6;
 }
 
-message Message {
-  Metric metric = 1;
-}
-
 message Batch {
   repeated Metric metric = 1;
 }

--- a/heroic-core/src/test/java/com/spotify/heroic/consumer/schemas/Spotify100ProtoTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/consumer/schemas/Spotify100ProtoTest.java
@@ -26,19 +26,24 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.consumer.ConsumerSchemaValidationException;
 import com.spotify.heroic.ingestion.Ingestion;
 import com.spotify.heroic.ingestion.IngestionGroup;
 import com.spotify.heroic.ingestion.Request;
+import com.spotify.heroic.metric.DistributionPoint;
+import com.spotify.heroic.metric.HeroicDistribution;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.statistics.ConsumerReporter;
 import com.spotify.heroic.time.Clock;
+import com.spotify.proto.Spotify100;
 import com.spotify.proto.Spotify100.Batch;
 import com.spotify.proto.Spotify100.Metric;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
+import io.opencensus.metrics.export.Value;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
@@ -101,17 +106,96 @@ public class Spotify100ProtoTest {
     verify(ingestion).write(new Request(s, MetricCollection.points(points)));
   }
 
+    @Test
+    public void testConsumeBatchMetricWithDistributionDouble() throws Exception {
+        final Metric metric = Metric.newBuilder()
+            .setKey("foo")
+            .setDistributionTypeValue(Spotify100.Value.newBuilder()
+                .setDoubleValue(1.0).build())
+            .setTime(1542830480000L)
+            .putTags("tag1", "foo")
+            .putResource("resource", "bar")
+            .build();
+
+        final Batch batch = Batch.newBuilder().addMetric(metric).build();
+
+        consumer.consume(Snappy.compress(batch.toByteArray()));
+
+        final Series s = Series.of(metric.getKey(), metric.getTagsMap(), metric.getResourceMap());
+        final Point p = new Point(metric.getTime(), metric.getDistributionTypeValue().getDoubleValue());
+        final List<Point> points = ImmutableList.of(p);
+
+        verify(reporter).reportMessageDrift(5000);
+        verify(ingestion).write(new Request(s, MetricCollection.points(points)));
+    }
+
+
+    @Test
+    public void testConsumeBatchMetricwithDistribution() throws Exception {
+
+        final Metric metric = Metric.newBuilder()
+            .setKey("foo")
+            .setDistributionTypeValue(Spotify100.Value.newBuilder()
+                .setDistributionValue(ByteString.copyFromUtf8("xxxxxx")).build())
+            .setTime(1542830480000L)
+            .putTags("tag1", "foo")
+            .putResource("resource", "bar")
+            .build();
+
+
+        final Batch batch = Batch.newBuilder().addMetric(metric).build();
+
+        consumer.consume(Snappy.compress(batch.toByteArray()));
+
+        final Series s = Series.of(metric.getKey(), metric.getTagsMap(), metric.getResourceMap());
+        final DistributionPoint p = DistributionPoint.create(HeroicDistribution
+                .create(metric.getDistributionTypeValue().getDistributionValue()),
+            metric.getTime());
+        final List<DistributionPoint> points = ImmutableList.of(p);
+
+        verify(reporter).reportMessageDrift(5000);
+        verify(ingestion).write(new Request(s, MetricCollection.distributionPoints(points)));
+    }
+
+    @Test
+    public void testInvalidDistributionBatchMetrics() throws Exception {
+        exceptionRule.expect(ConsumerSchemaValidationException.class);
+        exceptionRule.expectMessage("Invalid batch of metrics");
+
+        final Metric metric = Metric.newBuilder().setTime(-1542830480000L).build();
+
+        consumer.consume(metric.toByteArray());
+    }
+
   @Test
-  public void testInvalidBatchMetrics() throws Exception {
+  public void testInvalidBatchMetricsWithDistribution() throws Exception {
     exceptionRule.expect(ConsumerSchemaValidationException.class);
     exceptionRule.expectMessage("Invalid batch of metrics");
 
-    final Metric metric = Metric.newBuilder().setTime(-1542830480000L).build();
+      final Metric metric = Metric.newBuilder()
+          .setKey("foo")
+          .setDistributionTypeValue(Spotify100.Value.newBuilder()
+              .setDistributionValue(ByteString.EMPTY).build())
+          .setTime(1542830480000L)
+          .putTags("tag1", "foo")
+          .putResource("resource", "bar")
+          .build();
 
     consumer.consume(metric.toByteArray());
   }
 
-  @Test
+    @Test
+    public void testInvalidBatchMetrics() throws Exception {
+        exceptionRule.expect(ConsumerSchemaValidationException.class);
+        exceptionRule.expectMessage("Invalid batch of metrics");
+
+        final Metric metric = Metric.newBuilder().setTime(-1542830480000L).build();
+
+        consumer.consume(metric.toByteArray());
+    }
+
+
+    @Test
   public void testTimeValidationError() throws Exception {
     exceptionRule.expect(ConsumerSchemaValidationException.class);
     exceptionRule.expectMessage("time: field must be a positive number");


### PR DESCRIPTION
This is the first of several PRs  that will add distribution support to heroic.  With Distribution support heroic will be able to provide histogram data based on data distribution. Distribution support will also enable Opencensus metric import. 
This PR  implements Spotify100Proto consumer and BigtableBackend(ingestion).
**What is New:**
1. Spotify100 Proto Consumer:
  This PR introduces a new dataPoint type.
  ```
@AutoValue
public abstract class DistributionPoint implements Metric {

    public abstract long getTimestamp();
    public abstract Distribution value();

    public static DistributionPoint create(final Distribution value, final long timestamp) {
        return new AutoValue_DistributionPoint(timestamp, value);
    }

    @Override
    public boolean valid() {
        return value().getValue() != null &&  !value().getValue().isEmpty();
    }

    @Override
    public void hash(@NotNull Hasher hasher) {
        hasher.putInt(this.hashCode());
    }
} 
```
2. BigTableBackend
This PR introduces a mechanism to insert DistributionPoint into Bigtable. 
The overall structure of the BigTableBackend does not change. 
But this PR introduces a new column family "DistributionPoint"


Referecence:
https://github.com/spotify/heroic/issues/695


