### PR TITLE
[WIP] Add distribution support to spotify100 and the ability to fetch distribution from bigTable. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -209,6 +209,7 @@ allprojects {
             dependency 'javax.mail:mail:1.4.7'
             dependency 'args4j:args4j:2.33'
             dependency 'org.apache.commons:commons-lang3:3.3.2'
+            dependency 'org.apache.commons:commons-math3:3.4.1'
             dependency 'com.google.guava:guava:28.0-jre'
             dependency 'io.thekraken:grok:0.1.1'
             dependency 'org.jfree:jfreechart:1.0.19'

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100.java
@@ -128,9 +128,11 @@ public class Spotify100 implements ConsumerSchema {
                     throw new ConsumerSchemaValidationException("Bad version: " + versionNode);
                 }
 
-                if (version.getMajor() == 1) {
+                int major = version.getMajor();
+
+                if (major == 1) {
                     return handleVersion1(tree).onFinished(span::end);
-                } else if (version.getMajor() == 2) {
+                } else if (major == 2) {
                     return handleVersion2(tree).onFinished(span::end);
                 }
 

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/spotify100/v2/JsonMetric.kt
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/spotify100/v2/JsonMetric.kt
@@ -1,0 +1,26 @@
+package com.spotify.heroic.consumer.schemas.spotify100.v2
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class JsonMetric(
+        val key: String?,
+        @Deprecated("Host should be set as a normal tag")
+        val host: String?,
+        val time: Long?,
+        @JsonProperty("attributes", access = JsonProperty.Access.WRITE_ONLY)
+        val rawAttributes: Map<String, String?> = emptyMap(),
+        @JsonProperty("resource", access = JsonProperty.Access.WRITE_ONLY)
+        val rawResource: Map<String, String?>?,
+        val value: Value?
+) {
+    @Suppress("UNCHECKED_CAST")
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    val attributes = rawAttributes.filter { it.value != null } as Map<String, String>
+
+    @Suppress("UNCHECKED_CAST")
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    val resource =
+            (rawResource ?: emptyMap()).filter { it.value != null } as Map<String, String>
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/spotify100/v2/JsonMetric.kt
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/spotify100/v2/JsonMetric.kt
@@ -3,6 +3,12 @@ package com.spotify.heroic.consumer.schemas.spotify100.v2
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
+/**
+ * Metric used by ffwd-http and ffwd-json clients.
+ * This version uses an object type value to add distribution
+ * support for http clients.
+ *
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class JsonMetric(
         val key: String?,

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/spotify100/v2/Value.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/spotify100/v2/Value.java
@@ -35,7 +35,7 @@ import com.google.protobuf.ByteString;
  */
 @JsonSerialize(using = ValueSerializer.class)
 @JsonDeserialize(using = ValueDeserializer.class)
-public  abstract class Value {
+public abstract class Value {
     @JsonProperty("value")
     public abstract Object getValue();
 
@@ -65,5 +65,4 @@ public  abstract class Value {
         @Override
         public abstract ByteString getValue();
     }
-
 }

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/spotify100/v2/Value.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/spotify100/v2/Value.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.consumer.schemas.spotify100.v2;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.auto.value.AutoValue;
+import com.google.protobuf.ByteString;
+
+/**
+ * Distribution histogram point value. Currently we
+ * support {@link Value.DoubleValue} and {@link Value.DistributionValue}
+ */
+@JsonSerialize(using = ValueSerializer.class)
+@JsonDeserialize(using = ValueDeserializer.class)
+public  abstract class Value {
+    @JsonProperty("value")
+    public abstract Object getValue();
+
+    @AutoValue
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public abstract static class DoubleValue extends Value {
+
+        @Override
+        public abstract Double  getValue();
+        @JsonCreator
+        public static Value.DoubleValue create(
+            final double value) {
+            return new AutoValue_Value_DoubleValue(value);
+        }
+    }
+
+    @AutoValue
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public abstract static  class DistributionValue extends Value {
+
+        @JsonCreator
+        public static Value.DistributionValue create(
+            final ByteString value) {
+            return new AutoValue_Value_DistributionValue(value);
+        }
+
+        @Override
+        public abstract ByteString getValue();
+    }
+
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/spotify100/v2/ValueDeserializer.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/spotify100/v2/ValueDeserializer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.consumer.schemas.spotify100.v2;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+
+/**
+ * Distribution histogram point value type deserializer
+ * This deserialize supports  {@link Value.DistributionValue}
+ * and {@link Value.DoubleValue} types.
+ */
+public class ValueDeserializer extends StdDeserializer<Value> {
+
+    private static final long serialVersionUID = 6224613339173782914L;
+
+    public ValueDeserializer() {
+        this(Value.class);
+    }
+
+
+    public ValueDeserializer(final Class<Value> classz) {
+        super(classz);
+    }
+
+    @Override
+    public Value deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+        throws IOException, JsonProcessingException {
+
+        JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+
+        if (node.get("distributionValue") != null) {
+            byte[] bytes = node.get("distributionValue").binaryValue();
+            ByteString byteString = ByteString.copyFrom(bytes);
+            return Value.DistributionValue.create(byteString);
+        }
+
+        if (node.get("doubleValue") != null) {
+            double val = node.get("doubleValue").asDouble();
+            return Value.DoubleValue.create(val);
+        }
+
+        throw new RuntimeException("Unrecognized value type");
+    }
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/spotify100/v2/ValueDeserializer.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/spotify100/v2/ValueDeserializer.java
@@ -55,8 +55,7 @@ public class ValueDeserializer extends StdDeserializer<Value> {
 
         if (node.get("distributionValue") != null) {
             byte[] bytes = node.get("distributionValue").binaryValue();
-            ByteString byteString = ByteString.copyFrom(bytes);
-            return Value.DistributionValue.create(byteString);
+            return Value.DistributionValue.create(ByteString.copyFrom(bytes));
         }
 
         if (node.get("doubleValue") != null) {

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/spotify100/v2/ValueSerializer.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/spotify100/v2/ValueSerializer.java
@@ -40,7 +40,6 @@ public class ValueSerializer extends StdSerializer<Value> {
     }
 
 
-
     public ValueSerializer(Class<Value> t) {
         super(t);
     }

--- a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/spotify100/v2/ValueSerializer.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/spotify100/v2/ValueSerializer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.consumer.schemas.spotify100.v2;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+
+/**
+ * Distribution histogram point value type serializer.
+ * This serializer supports {@link Value.DistributionValue}
+ * and {@link Value.DoubleValue} types.
+ */
+public class ValueSerializer extends StdSerializer<Value> {
+
+    private static final long serialVersionUID = 6300597228325654588L;
+
+    public ValueSerializer() {
+        this(Value.class);
+    }
+
+
+
+    public ValueSerializer(Class<Value> t) {
+        super(t);
+    }
+
+
+    @Override
+    public void serialize(Value value, JsonGenerator jsonGenerator,
+                          SerializerProvider serializerProvider) throws IOException {
+
+        if (value instanceof  Value.DistributionValue) {
+            Value.DistributionValue distributionValue = (Value.DistributionValue) value;
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeObjectField("distributionValue",
+                distributionValue.getValue().toByteArray());
+            jsonGenerator.writeEndObject();
+        } else if (value instanceof  Value.DoubleValue) {
+            Value.DoubleValue doubleValue = (Value.DoubleValue) value;
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeNumberField("doubleValue", doubleValue.getValue());
+            jsonGenerator.writeEndObject();
+        } else {
+            throw new RuntimeException("Failed to serialize. Value type is not supported " + value);
+        }
+
+    }
+}

--- a/heroic-dist/build.gradle
+++ b/heroic-dist/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     implementation 'eu.toolchain.async:tiny-async-core'
     implementation 'jline:jline:2.12'
     implementation 'com.google.protobuf:protobuf-java'
+    implementation 'org.apache.commons:commons-math3'
 
     testImplementation project(':heroic-test')
     testImplementation 'org.hamcrest:java-hamcrest'

--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractConsumerIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractConsumerIT.java
@@ -5,10 +5,15 @@ import static org.junit.Assert.assertFalse;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ByteString;
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Series;
+import com.spotify.heroic.consumer.schemas.spotify100.Version;
+import com.spotify.heroic.consumer.schemas.spotify100.v2.Value;
+import com.spotify.heroic.metric.DistributionPoint;
 import com.spotify.heroic.metric.FetchData;
 import com.spotify.heroic.metric.FetchQuotaWatcher;
+import com.spotify.heroic.metric.HeroicDistribution;
 import com.spotify.heroic.metric.Metric;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.MetricReadResult;
@@ -33,20 +38,63 @@ public abstract class AbstractConsumerIT extends AbstractSingleNodeIT {
     protected boolean expectAtLeastOneCommit = false;
 
     protected Consumer<WriteMetric.Request> consumer;
+    protected Consumer<WriteMetric.Request> consumerV2;
 
-    protected abstract Consumer<WriteMetric.Request> setupConsumer();
+    protected abstract Consumer<WriteMetric.Request> setupConsumer(Version version);
 
     @Before
     public void basicSetup() {
-        this.consumer = setupConsumer();
+        this.consumer = setupConsumer(new Version(1,0,1));
+        this.consumerV2 = setupConsumer(new Version(2,0,0));
         this.expectAtLeastOneCommit = false;
+    }
+
+    @Test
+    public void consumeOneV2Message() throws Exception {
+        final Series s1 = Series.of("s1", ImmutableMap.of("host", "localhost"));
+
+        HeroicDistribution distribution1 = HeroicDistributionGenerator.generateOne();
+        DistributionPoint point1 = DistributionPoint.create(distribution1,10);
+
+        HeroicDistribution distribution2 = HeroicDistributionGenerator.generateOne();
+        DistributionPoint point2 = DistributionPoint.create(distribution2,20);
+
+        final MetricCollection mc =
+            MetricCollection.distributionPoints(List.of(point1, point2));
+        WriteMetric.Request request = new WriteMetric.Request(s1, mc);
+
+        consumerV2.accept(request);
+
+        tryUntil(() -> {
+            final List<MetricReadResult> data = Collections.synchronizedList(new ArrayList<>());
+
+            instance.inject(coreComponent -> {
+                FetchData.Request fetchDataRequest =
+                    new FetchData.Request(MetricType.DISTRIBUTION_POINTS, s1, new DateRange(0, 100),
+                        QueryOptions.defaults());
+                return coreComponent
+                    .metricManager()
+                    .useDefaultGroup()
+                    .fetch(fetchDataRequest,
+                        FetchQuotaWatcher.NO_QUOTA,
+                        data::add,
+                        BlankSpan.INSTANCE
+                    );
+            }).get();
+
+            assertFalse(data.isEmpty());
+            final MetricCollection collection = data.iterator().next().getMetrics();
+            assertEquals(mc, collection);
+            return null;
+        });
     }
 
     @Test
     public void consumeOneMessage() throws Exception {
         final Series s1 = Series.of("s1", ImmutableMap.of("host", "localhost"));
         final MetricCollection mc =
-            MetricCollection.points(ImmutableList.of(new Point(10, 42), new Point(20, 43)));
+            MetricCollection.points(ImmutableList.of
+                (new Point(10, 42), new Point(20, 43)));
         WriteMetric.Request request = new WriteMetric.Request(s1, mc);
 
         consumer.accept(request);
@@ -74,6 +122,62 @@ public abstract class AbstractConsumerIT extends AbstractSingleNodeIT {
             return null;
         });
     }
+
+    @Test
+    public void consumeManyV2Messages() throws Exception {
+        expectAtLeastOneCommit = true;
+        final Series s1 = Series.of("s1", ImmutableMap.of("host", "localhost"));
+
+
+        int count = 10;
+        List<DistributionPoint> consumedPoints = new ArrayList<>();
+        List<HeroicDistribution> distriubtions = HeroicDistributionGenerator.GenerateMany(count);
+        long timestamp = 0L;
+        for (HeroicDistribution distribution : distriubtions) {
+
+            timestamp +=10;
+
+            DistributionPoint point = DistributionPoint.create(distribution,timestamp);
+
+            final MetricCollection mc =
+                MetricCollection.distributionPoints(ImmutableList.of(point));
+
+            consumedPoints.add(point);
+
+            WriteMetric.Request request = new WriteMetric.Request(s1, mc);
+
+            consumerV2.accept(request);
+            Thread.sleep(100);
+        }
+
+        tryUntil(() -> {
+            final List<MetricReadResult> data = Collections.synchronizedList(new ArrayList<>());
+
+            instance.inject(coreComponent -> {
+                FetchData.Request fetchDataRequest =
+                    new FetchData.Request(MetricType.DISTRIBUTION_POINTS, s1, new DateRange(0, 100),
+                        QueryOptions.defaults());
+                return coreComponent
+                    .metricManager()
+                    .useDefaultGroup()
+                    .fetch(fetchDataRequest,
+                        FetchQuotaWatcher.NO_QUOTA,
+                        data::add,
+                        BlankSpan.INSTANCE
+                    );
+            }).get();
+
+            assertFalse(data.isEmpty());
+            final MetricCollection metricCollection = data.iterator().next().getMetrics();
+            List<Metric> collection = new ArrayList<>(metricCollection.data());
+            collection.sort(Metric.comparator);
+            assertEquals(consumedPoints, collection);
+            return null;
+        });
+    }
+
+
+
 
     @Test
     public void consumeManyMessages() throws Exception {
@@ -116,6 +220,47 @@ public abstract class AbstractConsumerIT extends AbstractSingleNodeIT {
             assertEquals(consumedPoints, collection);
             return null;
         });
+    }
+
+    static List<TMetric> createTestMetricCollection(final WriteMetric.Request request ) {
+
+        List<TMetric> metrics = new ArrayList<>();
+        int n = -1;
+        while (++n < request.getData().size()) {
+            Value val = null ;
+            long timestamp = 0;
+            if (request.getData().getType().equals(MetricType.POINT)) {
+                final Point p =  request.getData().getDataAs(Point.class).get(n);
+                val = Value.DoubleValue.create(p.getValue());
+                timestamp = p.getTimestamp();
+
+            }else if (request.getData().getType().equals(MetricType.DISTRIBUTION_POINTS)) {
+                final DistributionPoint p = request.getData()
+                    .getDataAs(DistributionPoint.class).get(n);
+                val = Value.DistributionValue.create(p.value().getValue());
+                timestamp = p.getTimestamp();
+            }
+            TMetric metric = new TMetric(timestamp, val);
+            metrics.add(metric);
+        }
+        return metrics;
+    }
+
+
+    Object createJsonMetric(final TMetric metric, final Series series){
+        Object jsonMetric;
+        if (metric.getValue() instanceof  Value.DoubleValue){
+            jsonMetric =
+                new DataVersion1("1.1.0", series.getKey(), "localhost",metric.getTimestamp(),
+                    series.getTags(), series.getResource(), (Double)metric.getValue().getValue());
+        }else if ( metric.getValue() instanceof  Value.DistributionValue){
+            jsonMetric =
+                new DataVersion2("2.0.0", series.getKey(), "localhost",metric.getTimestamp(),
+                    series.getTags(), series.getResource(), metric.getValue());
+        }else {
+            throw new RuntimeException("Unsupported type");
+        }
+        return jsonMetric;
     }
 
     private void tryUntil(Callable<Void> callable) throws Exception {

--- a/heroic-dist/src/test/java/com/spotify/heroic/DataVersion2.kt
+++ b/heroic-dist/src/test/java/com/spotify/heroic/DataVersion2.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic
+
+import com.spotify.heroic.consumer.schemas.spotify100.v2.Value
+
+internal data class DataVersion2(
+    val version: String?,
+    val key: String?,
+    val host: String?,
+    val time: Long?,
+    val attributes: Map<String, String>?,
+    val resource: Map<String, String>?,
+    val value: Value
+)

--- a/heroic-dist/src/test/java/com/spotify/heroic/HeroicDistributionGenerator.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/HeroicDistributionGenerator.java
@@ -1,0 +1,53 @@
+package com.spotify.heroic;
+
+import com.google.protobuf.ByteString;
+import com.spotify.heroic.metric.HeroicDistribution;
+import com.tdunning.math.stats.TDigest;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.math3.distribution.ParetoDistribution;
+
+
+public class HeroicDistributionGenerator {
+
+  static HeroicDistribution generateOne(){
+       List<Double> data = Data.generateParetoDistribution(1000);
+       TDigest tDigest =TDigest.createMergingDigest(100);
+       recordValue(tDigest, data);
+       return HeroicDistribution.create(encode(tDigest));
+    }
+
+     static ByteString encode(final TDigest tDigest){
+        int capacity = tDigest.byteSize();
+        ByteBuffer byteBuffer = ByteBuffer.allocate(capacity);
+        tDigest.asBytes(byteBuffer);
+        return ByteString.copyFrom(byteBuffer.array());
+    }
+
+     static List<HeroicDistribution> GenerateMany(int count){
+       List<HeroicDistribution> distributions = new  ArrayList<>();
+       for(int i = 0; i < count; i++){
+           distributions.add(generateOne());
+       }
+       return List.copyOf(distributions);
+    }
+
+     static void recordValue(final TDigest tDigest, List<Double> data){
+       data.forEach(dat -> tDigest.add(dat));
+    }
+
+
+    static class Data {
+         static List<Double> generateParetoDistribution(int count) {
+            ParetoDistribution pareto = new ParetoDistribution(5, 1);
+            List<Double> list = new ArrayList<>();
+            while (count-- > 0) {
+                list.add(pareto.sample());
+            }
+            return list;
+        }
+    }
+
+
+}

--- a/heroic-dist/src/test/java/com/spotify/heroic/PubSubConsumerIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/PubSubConsumerIT.java
@@ -19,7 +19,7 @@
  * under the License.
  */
 
-    package com.spotify.heroic;
+package com.spotify.heroic;
 
 import static junit.framework.TestCase.assertEquals;
 
@@ -35,15 +35,12 @@ import com.spotify.heroic.consumer.pubsub.EmulatorHelper;
 import com.spotify.heroic.consumer.pubsub.PubSubConsumerModule;
 import com.spotify.heroic.consumer.schemas.Spotify100;
 import com.spotify.heroic.consumer.schemas.spotify100.Version;
-import com.spotify.heroic.consumer.schemas.spotify100.v2.Value;
 import com.spotify.heroic.ingestion.IngestionModule;
 import com.spotify.heroic.instrumentation.OperationsLogImpl;
-import com.spotify.heroic.metric.DistributionPoint;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.MetricManagerModule;
 import com.spotify.heroic.metric.MetricModule;
 import com.spotify.heroic.metric.MetricType;
-import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.WriteMetric;
 import com.spotify.heroic.metric.memory.MemoryMetricModule;
 import java.io.IOException;
@@ -162,8 +159,3 @@ public class PubSubConsumerIT extends AbstractConsumerIT {
         assertEquals(writeRequests, writeCompletions);
     }
 }
-
-
-
-
-

--- a/heroic-dist/src/test/java/com/spotify/heroic/PubSubConsumerIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/PubSubConsumerIT.java
@@ -19,10 +19,10 @@
  * under the License.
  */
 
-package com.spotify.heroic;
+    package com.spotify.heroic;
 
 import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assume.assumeNotNull;
+
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.pubsub.v1.Publisher;
@@ -34,8 +34,11 @@ import com.spotify.heroic.common.Series;
 import com.spotify.heroic.consumer.pubsub.EmulatorHelper;
 import com.spotify.heroic.consumer.pubsub.PubSubConsumerModule;
 import com.spotify.heroic.consumer.schemas.Spotify100;
+import com.spotify.heroic.consumer.schemas.spotify100.Version;
+import com.spotify.heroic.consumer.schemas.spotify100.v2.Value;
 import com.spotify.heroic.ingestion.IngestionModule;
 import com.spotify.heroic.instrumentation.OperationsLogImpl;
+import com.spotify.heroic.metric.DistributionPoint;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.MetricManagerModule;
 import com.spotify.heroic.metric.MetricModule;
@@ -44,6 +47,7 @@ import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.WriteMetric;
 import com.spotify.heroic.metric.memory.MemoryMetricModule;
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import net.jcip.annotations.NotThreadSafe;
@@ -97,34 +101,41 @@ public class PubSubConsumerIT extends AbstractConsumerIT {
             .metrics(MetricManagerModule.builder().backends(ImmutableList.of(metricModule)));
     }
 
+
     @Override
-    protected Consumer<WriteMetric.Request> setupConsumer() {
+    protected Consumer<WriteMetric.Request> setupConsumer(Version version) {
         return request -> {
             final MetricCollection mc = request.getData();
 
-            if (mc.getType() != MetricType.POINT) {
+            final List<MetricType> list = List.of(MetricType.POINT, MetricType.DISTRIBUTION_POINTS);
+
+            if (!list.contains(mc.getType())) {
                 throw new RuntimeException("Unsupported metric type: " + mc.getType());
             }
 
             final Series series = request.getSeries();
-            for (final Point p : mc.getDataAs(Point.class)) {
-                final DataVersion1 src =
-                    new DataVersion1("1.1.0", series.getKey(), "localhost", p.getTimestamp(),
-                        series.getTags(), series.getResource(), p.getValue());
 
-                final PubsubMessage pubsubMessage;
+            final List<TMetric> metrics = createTestMetricCollection(request);
 
-                try {
-                    String message = objectMapper.writeValueAsString(src);
-                    ByteString data = ByteString.copyFromUtf8(message);
-                    pubsubMessage = PubsubMessage.newBuilder().setData(data).build();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-
-                publisher.publish(pubsubMessage);
+            for (TMetric metric : metrics){
+                Object jsonMetric = createJsonMetric(metric, series);
+                publish(jsonMetric);
             }
         };
+    }
+
+    private void publish(Object jsonMetric){
+        final PubsubMessage pubsubMessage;
+
+        try {
+            String message = objectMapper.writeValueAsString(jsonMetric);
+            ByteString data = ByteString.copyFromUtf8(message);
+            pubsubMessage = PubsubMessage.newBuilder().setData(data).build();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        publisher.publish(pubsubMessage);
     }
 
     @Override
@@ -151,3 +162,8 @@ public class PubSubConsumerIT extends AbstractConsumerIT {
         assertEquals(writeRequests, writeCompletions);
     }
 }
+
+
+
+
+

--- a/heroic-dist/src/test/java/com/spotify/heroic/TMetric.kt
+++ b/heroic-dist/src/test/java/com/spotify/heroic/TMetric.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic
+
+import com.spotify.heroic.consumer.schemas.spotify100.v2.Value
+
+internal data class TMetric(
+    val timestamp: Long?,
+    val value: Value
+)


### PR DESCRIPTION
This PR add distribution support to spotify100 (jsonMetric) and the ability to fetch distribution metric from bigTable.
Spotify100 consumers and ingestion modules should now be able to handle new and old JsonMetric.
For more information please refer to this [issue](https://github.com/spotify/heroic/issues/695)







