### PR TITLE
Debug QuotaWatchers creation and cleaning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.5.4-jdk-11 as builder
+FROM maven:3.6.3-jdk-11 as builder
 LABEL maintainer="prism <prism@spotify.com>"
 
 RUN apt-get update && apt-get install -y git

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -107,7 +107,7 @@ public class LocalMetricManager implements MetricManager {
     private final MetricBackendReporter reporter;
     private final QueryLogger queryLogger;
     private final Semaphore concurrentQueries;
-    private static final ConcurrentMap<Integer, QuotaWatcher> quotaWatchers =
+    private static final ConcurrentMap<QuotaWatcher, QuotaWatcher> quotaWatchers =
         new ConcurrentHashMap<>();
 
     /**
@@ -371,15 +371,6 @@ public class LocalMetricManager implements MetricManager {
 
             final DataInMemoryReporter dataInMemoryReporter = reporter.newDataInMemoryReporter();
 
-            final QuotaWatcher quotaWatcher = new QuotaWatcher(
-                options.dataLimit().orElse(dataLimit).asLong().orElse(Long.MAX_VALUE),
-                options.aggregationLimit().orElse(aggregationLimit).asLong().orElse(Long.MAX_VALUE),
-                dataInMemoryReporter
-            );
-
-            // Add watcher to set to compute stats across all queries
-            quotaWatchers.put(System.identityHashCode(quotaWatcher), quotaWatcher);
-
             final OptionalLimit seriesLimit =
                 options.seriesLimit().orElse(LocalMetricManager.this.seriesLimit);
 
@@ -392,65 +383,68 @@ public class LocalMetricManager implements MetricManager {
             final Span findSeriesSpan = tracer.spanBuilderWithExplicitParent(
                 "localMetricsManager.findSeries", parentSpan).startSpan();
 
-            // Transform that takes the result from ES metadata lookup to fetch from backend
-            final LazyTransform<FindSeries, FullQuery> transform =
-                new Transform(request,
-                    failOnLimits,
-                    seriesLimit,
-                    groupLimit,
-                    quotaWatcher,
-                    dataInMemoryReporter,
-                    findSeriesSpan);
+            final QuotaWatcher quotaWatcher = new QuotaWatcher(
+                options.dataLimit().orElse(dataLimit).asLong().orElse(Long.MAX_VALUE),
+                options.aggregationLimit().orElse(aggregationLimit).asLong().orElse(Long.MAX_VALUE),
+                dataInMemoryReporter
+            );
 
-            return metadata
-                .findSeries(FindSeries.Request.withLimit(request, seriesLimit))
-                .onDone(reporter.reportFindSeries())
-                .onResolved(t -> findSeriesSpan.putAttribute(
-                    "seriesCount", longAttributeValue(t.getSeries().size())))
-                .lazyTransform(transform)
-                .directTransform(fullQuery -> {
-                    queryLogger.logOutgoingResponseAtNode(queryContext, fullQuery);
-                    return fullQuery;
-                })
-                .onDone(reporter.reportQueryMetrics())
-                .onDone(new EndSpanFutureReporter(findSeriesSpan))
-                .onDone(new FutureDone<>() {
-                    @Override
-                    public void failed(final Throwable cause) throws Exception {
-                        QuotaWatcher removed = quotaWatchers.remove(System.identityHashCode(quotaWatcher));
-                        cleanQuotaWatchers(quotaWatcher);
-                        log.info("onDone.failed {}; removed: {}", quotaWatchers.size(), removed);
-                    }
+            try {
 
-                    @Override
-                    public void resolved(final FullQuery result) throws Exception {
-                        QuotaWatcher removed = quotaWatchers.remove(System.identityHashCode(quotaWatcher));
-                        cleanQuotaWatchers(quotaWatcher);
-                        log.info("onDone.resolved {}; removed: {}", quotaWatchers.size(), removed);
-                    }
+                // Transform that takes the result from ES metadata lookup to fetch from backend
+                final LazyTransform<FindSeries, FullQuery> transform =
+                    new Transform(request,
+                        failOnLimits,
+                        seriesLimit,
+                        groupLimit,
+                        quotaWatcher,
+                        dataInMemoryReporter,
+                        findSeriesSpan);
 
-                    @Override
-                    public void cancelled() throws Exception {
-                        QuotaWatcher removed = quotaWatchers.remove(System.identityHashCode(quotaWatcher));
-                        cleanQuotaWatchers(quotaWatcher);
-                        log.info("onDone.cancelled {}; removed: {}", quotaWatchers.size(), removed);
-                    }
-                });
-        }
+                // Add watcher to set to compute stats across all queries
+                quotaWatchers.put(quotaWatcher, quotaWatcher);
 
-        private void cleanQuotaWatchers(QuotaWatcher quotaWatcher) {
-            // Let's find any old watchers based on start timestamp
-            log.info("Millis QuotaWatcher was alive: {}",
-                (System.currentTimeMillis() - quotaWatcher.startMS));
+                return metadata
+                    .findSeries(FindSeries.Request.withLimit(request, seriesLimit))
+                    .onDone(reporter.reportFindSeries())
+                    .onResolved(t -> findSeriesSpan.putAttribute(
+                        "seriesCount", longAttributeValue(t.getSeries().size())))
+                    .lazyTransform(transform)
+                    .directTransform(fullQuery -> {
+                        queryLogger.logOutgoingResponseAtNode(queryContext, fullQuery);
+                        return fullQuery;
+                    })
+                    .onDone(reporter.reportQueryMetrics())
+                    .onDone(new EndSpanFutureReporter(findSeriesSpan))
+                    .onDone(new FutureDone<>() {
+                        @Override
+                        public void failed(final Throwable cause) throws Exception {
+                            QuotaWatcher removed = quotaWatchers.remove(quotaWatcher);
+                            log.info("onDone.failed {}; removed: {}",
+                                quotaWatchers.size(), removed);
+                        }
 
-            quotaWatchers.entrySet().removeIf(qw -> {
-                if (System.currentTimeMillis() - qw.getValue().startMS > 120_000) {
-                    log.info("Removing QuotaWatcher with MS alive: {}",
-                        (System.currentTimeMillis() - qw.getValue().startMS));
-                    return true;
-                }
-                return false;
-            });
+                        @Override
+                        public void resolved(final FullQuery result) throws Exception {
+                            QuotaWatcher removed = quotaWatchers.remove(quotaWatcher);
+                            log.info("onDone.resolved {}; removed: {}",
+                                quotaWatchers.size(), removed);
+                        }
+
+                        @Override
+                        public void cancelled() throws Exception {
+                            QuotaWatcher removed = quotaWatchers.remove(quotaWatcher);
+                            log.info("onDone.cancelled {}; removed: {}",
+                                quotaWatchers.size(), removed);
+                        }
+                    });
+            } catch (Exception e) {
+                log.error("Transform exception", e);
+                QuotaWatcher removed = quotaWatchers.remove(quotaWatcher);
+                log.info("Transform exception {}; removed: {}",
+                    quotaWatchers.size(), removed);
+                throw e;
+            }
         }
 
         @Override

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -772,7 +772,8 @@ public class LocalMetricManager implements MetricManager {
         @Override
         public void readData(long n) {
             long curDataPoints = read.addAndGet(n);
-            long total = quotaWatchers.values().stream().map(QuotaWatcher::getReadData)
+            List<QuotaWatcher> watchers = new ArrayList<>(quotaWatchers.values());
+            long total = watchers.stream().map(QuotaWatcher::getReadData)
                 .reduce(0L, Long::sum);
             reporter.reportTotalReadDataPoints(total);
             if (curDataPoints > LOGLIMIT) {
@@ -788,7 +789,8 @@ public class LocalMetricManager implements MetricManager {
         @Override
         public void retainData(final long n) {
             long curRetainedDataPoints = retained.addAndGet(n);
-            long total = quotaWatchers.values().stream().map(QuotaWatcher::getRetainData)
+            List<QuotaWatcher> watchers = new ArrayList<>(quotaWatchers.values());
+            long total = watchers.stream().map(QuotaWatcher::getRetainData)
                 .reduce(0L, Long::sum);
             reporter.reportTotalRetainedDataPoints(total);
             if (curRetainedDataPoints > LOGLIMIT) {

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -378,7 +378,7 @@ public class LocalMetricManager implements MetricManager {
             );
 
             // Add watcher to set to compute stats across all queries
-            quotaWatchers.put(quotaWatcher.hashCode(), quotaWatcher);
+            quotaWatchers.put(System.identityHashCode(quotaWatcher), quotaWatcher);
 
             final OptionalLimit seriesLimit =
                 options.seriesLimit().orElse(LocalMetricManager.this.seriesLimit);
@@ -417,23 +417,23 @@ public class LocalMetricManager implements MetricManager {
                 .onDone(new FutureDone<>() {
                     @Override
                     public void failed(final Throwable cause) throws Exception {
-                        quotaWatchers.remove(quotaWatcher.hashCode());
+                        QuotaWatcher removed = quotaWatchers.remove(System.identityHashCode(quotaWatcher));
                         cleanQuotaWatchers(quotaWatcher);
-                        log.info("onDone.failed {}", quotaWatchers.size());
+                        log.info("onDone.failed {}; removed: {}", quotaWatchers.size(), removed);
                     }
 
                     @Override
                     public void resolved(final FullQuery result) throws Exception {
-                        quotaWatchers.remove(quotaWatcher.hashCode());
+                        QuotaWatcher removed = quotaWatchers.remove(System.identityHashCode(quotaWatcher));
                         cleanQuotaWatchers(quotaWatcher);
-                        log.info("onDone.resolved {}", quotaWatchers.size());
+                        log.info("onDone.resolved {}; removed: {}", quotaWatchers.size(), removed);
                     }
 
                     @Override
                     public void cancelled() throws Exception {
-                        quotaWatchers.remove(quotaWatcher.hashCode());
+                        QuotaWatcher removed = quotaWatchers.remove(System.identityHashCode(quotaWatcher));
                         cleanQuotaWatchers(quotaWatcher);
-                        log.info("onDone.cancelled {}", quotaWatchers.size());
+                        log.info("onDone.cancelled {}; removed: {}", quotaWatchers.size(), removed);
                     }
                 });
         }


### PR DESCRIPTION
This change moving creation of QuotaWatcher closer to its usage minimizing chance of exceptional exit before it is used.
Wraps main call to try/catch in order to properly clean QuotaWatcher map.
It also uses QuotaWatcher as key in ConcurrentMap.
