### PR TITLE
Remove experimental warning from HQL docs.

### DIFF
--- a/docs/content/_docs/query_language.html
+++ b/docs/content/_docs/query_language.html
@@ -9,13 +9,6 @@ title: Heroic Query Language
   (Heroic Query Language).
 </p>
 
-<div class="callout callout-danger">
-  <h4>Experimental</h4>
-  <p>
-    The HQL should currently be considered experimental and might be subject to future changes.
-  </p>
-</div>
-
 <p>
   Queries have the following structure.
 </p>


### PR DESCRIPTION
HQL has been stable for quite some time. Depending on the result of #481, we may decide to replace HQL. But for now it is disingenuous to list it as experimental.