### PR TITLE
GitHub action workflow to build PRs in Docker images.

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,5 +26,6 @@ jobs:
           password: ${{ secrets.GCR_JSON_KEY }}
       - uses: docker/build-push-action@v2
         with:
+          context: .
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,29 @@
+name: Docker build workflow
+# NB: This will only run on PRs from the main repo and not forks
+# https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull-request-events-for-forked-repositories
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  build-docker:
+    name: Build and push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # NB: For PRs, this will create two Docker tags: sha-${GIT_SHA} and pr-${PR_NUMBER}
+      # https://github.com/crazy-max/ghaction-docker-meta#overview
+      - id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: gcr.io/xpn-heroic-1/heroic
+          tag-sha: true
+      - uses: docker/login-action@v1
+        with:
+          registry: gcr.io
+          username: _json_key
+          password: ${{ secrets.GCR_JSON_KEY }}
+      - uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           images: gcr.io/xpn-heroic-1/heroic
           tag-sha: true
+      - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1
         with:
           registry: gcr.io


### PR DESCRIPTION
I did this as GitHub actions instead of CircleCI because of how forks are handled. We want tests to run for every PR, regardless of source. We only want these Docker images to be automatically created for PRs originating from this repo, and not for forks. Doing that in CircleCI might be possible, but this way is simpler and has the benefit of building the image in parallel with the tests running in Circle.

Assuming this works well, we might want to also move our Docker Hub build actions to GitHub actions to reduce the number of places that CI is happening.

Closes #716.