### PR TITLE
Implement new Bigtable timeout & retry settings

### DIFF
--- a/docs/content/_docs/config.md
+++ b/docs/content/_docs/config.md
@@ -132,6 +132,7 @@ Precedence for each flag is defined as the following:
 The following features are available:
 
 #### com.spotify.heroic.deterministic_aggregations
+
 {:.no_toc}
 
 Enable feature to only perform aggregations that can be performed with limited resources. Disabled by default.
@@ -139,6 +140,7 @@ Enable feature to only perform aggregations that can be performed with limited r
 Aggregations are commonly performed per-shard, and the result concatenated. This enabled experimental support for distributed aggregations which behave transparently across shards.
 
 #### com.spotify.heroic.distributed_aggregations
+
 {:.no_toc}
 
 Enable feature to perform distributed aggregations. Disabled by default.
@@ -146,6 +148,7 @@ Enable feature to perform distributed aggregations. Disabled by default.
 Aggregations are commonly performed per-shard, and the result concatenated. This enables experimental support for distributed aggregations which behave transparently across shards. Typically this will cause more data to be transported across shards for each request.
 
 #### com.spotify.heroic.shift_range
+
 {:.no_toc}
 
 Enable feature to cause range to be rounded on the current cadence. Enabled by default.
@@ -153,6 +156,7 @@ Enable feature to cause range to be rounded on the current cadence. Enabled by d
 This will assert that there are data outside of the range queried for and that the range is aligned to the queried cadence. Which is a useful feature when using a dashboarding system.
 
 #### com.spotify.heroic.sliced_data_fetch
+
 {:.no_toc}
 
 Enable feature to cause data to be fetched in slices. Enabled by default.
@@ -160,6 +164,7 @@ Enable feature to cause data to be fetched in slices. Enabled by default.
 This will cause data to be fetched and consumed by the aggregation framework in pieces avoiding having to load all data into memory before starting to consume it.
 
 #### com.spotify.heroic.end_bucket_stategy
+
 {:.no_toc}
 
 Enabled by default.
@@ -167,6 +172,7 @@ Enabled by default.
 Use the legacy bucket strategy by default where the resulting value is at the end of the timestamp of the bucket.
 
 #### com.spotify.heroic.cache_query
+
 {:.no_toc}
 
 Disabled by default.
@@ -492,6 +498,28 @@ batchSize: <int>
 # If set, the Bigtable client will be configured to use this address as a Bigtable emulator.
 # Default CBT emulator runs at: "localhost:8086"
 emulatorEndpoint: <string>
+
+# Reference: https://cloud.google.com/bigtable/docs/hbase-client/javadoc/com/google/cloud/bigtable/config/CallOptionsConfig.Builder
+# The amount of milliseconds to wait before issuing a client side timeout for mutation remote
+ procedure calls.
+# AKA
+# If timeouts are set, how many milliseconds should pass before a DEADLINE_EXCEEDED for a long mutation.
+# Currently, this feature is experimental.
+mutateRpcTimeoutMs: int
+
+# ReadRowsRpcTimeoutMs
+# The amount of milliseconds to wait before issuing a client side timeout for readRows streaming remote procedure calls.
+# AKA
+# from https://github.com/hegemonic/cloud-bigtable-client/blob/master/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java :
+# The default duration to wait before timing out read stream RPC (default value: 12 hour).
+
+readRowsRpcTimeoutMs: int
+
+# ShortRpcTimeoutMs - The amount of milliseconds to wait before issuing a client side timeout for short remote procedure calls.
+# AKA
+# The default duration to wait before timing out RPCs (default value: 60 seconds) : https://cloud.google.com/bigtable/docs/hbase-client/javadoc/com/google/cloud/bigtable/config/CallOptionsConfig#SHORT_TIMEOUT_MS_DEFAULT
+shortRpcTimeoutMs: int
+
 ```
 
 ##### `<bigtable_credentials>`
@@ -542,17 +570,15 @@ Maximum number of distinct groups a single result group may contain.
 
 ##### seriesLimit
 
-Maximum amount of time series a single request is allowed to fetch, per cluster (if federated). 
+Maximum amount of time series a single request is allowed to fetch, per cluster (if federated).
 
 A note: when using resource identifiers this limit only applies to the number of series found in the metadata backend, *not* the total series returned.
 
 It is therefore possible to have a low limit *not* be exceeded with the number of series found in metadata, however, return far more series from the metrics backend when resource identifiers are taken into account (which may trigger additional limits).
 
-##### failOnLimits 
+##### failOnLimits
 
 When true, any limits applied will be reported as a failure.
-
-
 
 ### [`<metadata_backend>`](#metadata_backend)
 
@@ -713,7 +739,6 @@ sniff: <bool> default = false
 # How often to poll for new nodes when `sniff` is enabled.
 nodeSamplerInterval: <duration> default = 30s
 ```
-
 
 #### [Memory](#memory)
 
@@ -967,6 +992,7 @@ level: <string> default = TRACE
 ```
 
 #### Query log output
+
 {:.no_toc}
 
 Each successful query will result in several output entries in the query log. Entries from different stages of the query. Example output:
@@ -993,6 +1019,7 @@ Each successful query will result in several output entries in the query log. En
 | `data` | Contains data relevant to this query stage. This might for example be the original query, a partial response or the final response.
 
 #### Contextual information
+
 {:.no_toc}
 
 It's possible to supply contextual information in the query. This information will then be included in the query log, to ease mapping of performed query to the query log output.
@@ -1029,7 +1056,6 @@ You'll get the following output in the query log:
 Enable distributed tracing output of Heroic's operations. Tracing is instrumented using [OpenCensus](https://opencensus.io/).
 
 A few tags are added to incoming requests such as the java version. If running on GCP, zone and region tags are added as well.
-
 
 ```yaml
 # Probability, between 0.0 and 1.0, of sampling each trace.

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/consts/ApiQueryConsts.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/consts/ApiQueryConsts.java
@@ -1,0 +1,19 @@
+package com.spotify.heroic.metric.consts;
+
+public class ApiQueryConsts {
+    // TODO refactor these with BigtableMetricModule's copies of these consts
+    /**
+     * TODO describe reasoning
+     */
+    public static final int DEFAULT_MUTATE_RPC_TIMEOUT_MS = 4_000;
+
+    /**
+     * TODO describe reasoning
+     */
+    public static final int DEFAULT_READ_ROWS_RPC_TIMEOUT_MS = 4_000;
+
+    /**
+     * TODO describe reasoning
+     */
+    public static final int DEFAULT_SHORT_RPC_TIMEOUT_MS = 4_000 * 3;
+}

--- a/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
@@ -122,7 +122,28 @@ public class CoreQueryManager implements QueryManager {
     private final Optional<ConditionalFeatures> conditionalFeatures;
 
     private final long smallQueryThreshold;
+    private final int mutateRpcTimeoutMs;
+    private final int shortRpcTimeoutMs;
+    private final int readRowsRpcTimeoutMs;
 
+
+    /**
+     * Instantiates a new Core query manager.
+     *
+     * @param features            the features
+     * @param async               the async
+     * @param clock               the clock
+     * @param cluster             the cluster
+     * @param parser              the parser
+     * @param queryCache          the query cache
+     * @param aggregations        the aggregations
+     * @param groupLimit          the group limit
+     * @param smallQueryThreshold the small query threshold
+     * @param reporter            the reporter
+     * @param conditionalFeatures the conditional features
+     * @param queryLoggerFactory  the query logger factory
+     */
+    @SuppressWarnings({"LineLength"})
     @Inject
     public CoreQueryManager(
         @Named("features") final Features features,
@@ -134,6 +155,40 @@ public class CoreQueryManager implements QueryManager {
         final AggregationFactory aggregations,
         @Named("groupLimit") final OptionalLimit groupLimit,
         @Named("smallQueryThreshold") final long smallQueryThreshold,
+        /* Reference: https://cloud.google.com/bigtable/docs/hbase-client/javadoc/com/google/cloud/bigtable/config/CallOptionsConfig.Builder */
+
+        /* MutateRpcTimeoutMs
+        - The amount of milliseconds to wait before issuing a client side timeout for mutation remote
+        procedure calls.
+        AKA
+        If timeouts are set, how many milliseconds should pass before a DEADLINE_EXCEEDED for a long
+        mutation. Currently, this feature is experimental.
+        */
+        @Named("mutateRpcTimeoutMs") final int mutateRpcTimeoutMs,
+
+        /* ReadRowsRpcTimeoutMs
+        - The amount of milliseconds to wait before issuing a client side timeout for readRows streaming
+        remote procedure calls.
+        AKA
+        from https://github.com/hegemonic/cloud-bigtable-client/blob/master/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java :
+
+        The default duration to wait before timing out read stream RPC (default value: 12 hour).
+
+        The amount of time in millisecond to wait before issuing a client side timeout for readRows
+        streaming RPCs.
+        */
+        @Named("readRowsRpcTimeoutMs") final int readRowsRpcTimeoutMs,
+
+        /* shortRpcTimeoutMs
+        https://cloud.google.com/bigtable/docs/hbase-client/javadoc/com/google/cloud/bigtable/config/CallOptionsConfig.html#short_timeout_ms_default
+        ShortRpcTimeoutMs - The amount of milliseconds to wait before issuing a client side timeout for
+        short remote procedure calls.
+        AKA
+        The default duration to wait before timing out RPCs (default value: 60 seconds) : https://cloud.google.com/bigtable/docs/hbase-client/javadoc/com/google/cloud/bigtable/config/CallOptionsConfig#SHORT_TIMEOUT_MS_DEFAULT
+        */
+        @Named("shortRpcTimeoutMs") final int shortRpcTimeoutMs,
+
+
         final QueryReporter reporter,
         final Optional<ConditionalFeatures> conditionalFeatures,
         final QueryLoggerFactory queryLoggerFactory
@@ -148,6 +203,9 @@ public class CoreQueryManager implements QueryManager {
         this.groupLimit = groupLimit;
         this.reporter = reporter;
         this.smallQueryThreshold = smallQueryThreshold;
+        this.mutateRpcTimeoutMs = mutateRpcTimeoutMs;
+        this.readRowsRpcTimeoutMs = readRowsRpcTimeoutMs;
+        this.shortRpcTimeoutMs = shortRpcTimeoutMs;
         this.conditionalFeatures = conditionalFeatures;
         this.queryLogger = queryLoggerFactory.create("CoreQueryManager");
     }

--- a/heroic-core/src/main/java/com/spotify/heroic/HeroicCore.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/HeroicCore.java
@@ -575,7 +575,8 @@ public class HeroicCore implements HeroicConfiguration {
         final QueryComponent query = DaggerCoreQueryComponent
             .builder()
             .queryModule(new QueryModule(config.metric().groupLimit(),
-                config.metric().smallQueryThreshold()))
+                config.metric().smallQueryThreshold(), config.metric().mutateRpcTimeoutMs(),
+                    config.metric().readRowsRpcTimeoutMs(), config.metric().shortRpcTimeoutMs()))
             .corePrimaryComponent(primary)
             .clusterComponent(cluster)
             .cacheComponent(cache)

--- a/heroic-core/src/main/java/com/spotify/heroic/QueryModule.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/QueryModule.java
@@ -32,10 +32,19 @@ import javax.inject.Named;
 public class QueryModule {
     private final OptionalLimit groupLimit;
     private final long smallQueryThreshold;
+    private final int mutateRpcTimeoutMs;
+    private final int shortRpcTimeoutMs;
+    private final int readRowsRpcTimeoutMs;
 
-    public QueryModule(OptionalLimit groupLimit, long smallQueryThreshold) {
+
+    public QueryModule(OptionalLimit groupLimit, long smallQueryThreshold,
+                       int mutateRpcTimeoutMs, int shortRpcTimeoutMs,
+                       int readRowsRpcTimeoutMs) {
         this.groupLimit = groupLimit;
         this.smallQueryThreshold = smallQueryThreshold;
+        this.mutateRpcTimeoutMs = mutateRpcTimeoutMs;
+        this.readRowsRpcTimeoutMs = readRowsRpcTimeoutMs;
+        this.shortRpcTimeoutMs = shortRpcTimeoutMs;
     }
 
     @Provides
@@ -51,6 +60,21 @@ public class QueryModule {
     public long smallQueryThreshold() {
         return smallQueryThreshold;
     }
+
+    @Provides
+    @QueryScope
+    @Named("mutateRpcTimeoutMs")
+    public int mutateRpcTimeoutMs() { return mutateRpcTimeoutMs; }
+
+    @Provides
+    @QueryScope
+    @Named("readRowsRpcTimeoutMs")
+    public int readRowsRpcTimeoutMs() { return readRowsRpcTimeoutMs; }
+
+    @Provides
+    @QueryScope
+    @Named("shortRpcTimeoutMs")
+    public int shortRpcTimeoutMs() { return shortRpcTimeoutMs; }
 
     @Provides
     @QueryScope

--- a/heroic-core/src/main/java/com/spotify/heroic/http/tracing/OpenCensusUtils.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/http/tracing/OpenCensusUtils.java
@@ -39,7 +39,7 @@ class OpenCensusUtils {
             .collect(Collectors.joining(", "));
     }
 
-    @SuppressWarnings("checkstyle:LineLength")
+    @SuppressWarnings("LineLength")
     static Status mapStatusCode(int status) {
         // @formatter:off
         //

--- a/heroic-core/src/test/java/com/spotify/heroic/CoreQueryManagerTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/CoreQueryManagerTest.java
@@ -47,14 +47,16 @@ public class CoreQueryManagerTest {
     public void setup() {
         QueryReporter queryReporter = mock(QueryReporter.class);
         long smallQueryThreshold = 0;
+        int timeoutMs = 300;
 
         QueryLogger queryLogger = mock(QueryLogger.class);
         QueryLoggerFactory queryLoggerFactory = mock(QueryLoggerFactory.class);
         when(queryLoggerFactory.create(any())).thenReturn(queryLogger);
 
         manager = new CoreQueryManager(Features.empty(), async, Clock.system(), cluster, parser,
-            queryCache, aggregations, OptionalLimit.empty(), smallQueryThreshold, queryReporter,
-            Optional.empty(), queryLoggerFactory);
+                queryCache, aggregations, OptionalLimit.empty(), smallQueryThreshold,
+                timeoutMs, timeoutMs, timeoutMs, queryReporter,
+                Optional.empty(), queryLoggerFactory);
     }
 
     @Test

--- a/heroic-dist/src/test/java/com/spotify/heroic/analytics/bigtable/HeroicMetricsConfigurationTest.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/analytics/bigtable/HeroicMetricsConfigurationTest.java
@@ -1,14 +1,13 @@
 package com.spotify.heroic.analytics.bigtable;
 
-import static com.spotify.heroic.HeroicConfigurationTestUtils.testConfiguration;
 import static org.junit.Assert.assertEquals;
 
+import com.spotify.heroic.HeroicConfigurationTestUtils;
 import com.spotify.heroic.dagger.DaggerCoreComponent;
 import com.spotify.heroic.metric.LocalMetricManager;
 import com.spotify.heroic.metric.bigtable.BigtableBackend;
 import com.spotify.heroic.metric.bigtable.BigtableMetricModule;
 import com.spotify.heroic.metric.bigtable.MetricsRowKeySerializer;
-import eu.toolchain.async.TinyAsync;
 import eu.toolchain.serializer.TinySerializer;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -25,32 +24,73 @@ import org.junit.Test;
  *       maxWriteBatchSize: 250
  * </pre>
  */
+@SuppressWarnings({"LineLength"})
 public class HeroicMetricsConfigurationTest {
 
     public static final int EXPECTED_MAX_WRITE_BATCH_SIZE = 250;
+    public static final int DEFAULT_TIMEOUT = 250;
+    public static final int EXPECTED_MUTATE_RPC_TIMEOUT_MS = 135;
+    public static final int EXPECTED_READ_ROWS_RPC_TIMEOUT_MS = 136;
+    public static final int EXPECTED_SHORT_RPC_TIMEOUT_MS = 137;
 
     @NotNull
     private static BigtableBackend getBigtableBackend(int maxWriteBatchSize) {
+        return getBigtableBackend(maxWriteBatchSize, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT,
+                DEFAULT_TIMEOUT);
+    }
+
+    @NotNull
+    private static BigtableBackend getBigtableBackend(int maxWriteBatchSize, int mutateRpcTimeoutMs,
+                                                      int readRowsRpcTimeoutMs,
+                                                      int shortRpcTimeoutMs) {
         final ExecutorService executor = Executors.newSingleThreadExecutor();
-        final TinyAsync async = TinyAsync.builder().executor(executor).build();
         var serializer = TinySerializer.builder().build();
 
-        var bigtableBackend = new BigtableBackend(async, serializer, new MetricsRowKeySerializer(), null, null, "bananas", false, maxWriteBatchSize, null, null);
+        var bigtableBackend = new BigtableBackend(null,
+                serializer,
+                new MetricsRowKeySerializer(),
+                null,
+                null,
+                "bananas",
+                false,
+                maxWriteBatchSize,
+                mutateRpcTimeoutMs,
+                readRowsRpcTimeoutMs,
+                shortRpcTimeoutMs,
+                null,
+                null);
         return bigtableBackend;
     }
 
+    /**
+     * Use this convenience overload if you don't care about *timeoutMs.
+     * @param maxWriteBatchSize max size of each written batch of metrics
+     * @return a bigtable module object
+     */
     private static BigtableMetricModule getBigtableMetricModule(int maxWriteBatchSize) {
+        return getBigtableMetricModule(maxWriteBatchSize, DEFAULT_TIMEOUT,
+                DEFAULT_TIMEOUT, DEFAULT_TIMEOUT);
+    }
+
+    private static BigtableMetricModule getBigtableMetricModule(
+            int maxWriteBatchSize,
+            int mutateRpcTimeoutMs,
+            int readRowsRpcTimeoutMs,
+            int shortRpcTimeoutMs) {
         return new BigtableMetricModule.Builder()
-            .maxWriteBatchSize(maxWriteBatchSize)
-            .batchSize(1000)
-            .project("banana_count")
-            .build();
+                .maxWriteBatchSize(maxWriteBatchSize)
+                .mutateRpcTimeoutMs(mutateRpcTimeoutMs)
+                .readRowsRpcTimeoutMs(readRowsRpcTimeoutMs)
+                .shortRpcTimeoutMs(shortRpcTimeoutMs)
+                .batchSize(1000)
+                .project("banana_count")
+                .build();
     }
 
     @Test
-    public void testMaxWriteBatchSizeConfig() throws Exception {
+    public void testBigtableLimitsConfig() throws Exception {
 
-        final var instance = testConfiguration("heroic-all.yml");
+        final var instance = HeroicConfigurationTestUtils.testConfiguration("heroic-all.yml");
 
         // Check that the BigTableBackend's maxWriteBatchSize was picked up
         // from the heroic-all.yml config file
@@ -66,10 +106,17 @@ public class HeroicMetricsConfigurationTest {
                         .toArray(new BigtableAnalyticsMetricBackend[0])[0];
                 var bigtableBackend = (BigtableBackend) analyticsBackend.getBackend();
 
-                assertEquals(EXPECTED_MAX_WRITE_BATCH_SIZE, bigtableBackend.getMaxWriteBatchSize());
+                    assertEquals(EXPECTED_MAX_WRITE_BATCH_SIZE,
+                            bigtableBackend.getMaxWriteBatchSize());
+                    assertEquals(EXPECTED_MUTATE_RPC_TIMEOUT_MS,
+                            bigtableBackend.getMutateRpcTimeoutMs());
+                    assertEquals(EXPECTED_READ_ROWS_RPC_TIMEOUT_MS,
+                            bigtableBackend.getReadRowsRpcTimeoutMs());
+                    assertEquals(EXPECTED_SHORT_RPC_TIMEOUT_MS,
+                            bigtableBackend.getShortRpcTimeoutMs());
 
-                return null;
-            });
+                    return null;
+                });
     }
 
     @Test
@@ -78,13 +125,15 @@ public class HeroicMetricsConfigurationTest {
             final int tooBigBatchSize = 5_000_000;
             var bigtableBackend = getBigtableMetricModule(tooBigBatchSize);
 
-            assertEquals(BigtableMetricModule.MAX_MUTATION_BATCH_SIZE, bigtableBackend.getMaxWriteBatchSize());
+            assertEquals(BigtableMetricModule.MAX_MUTATION_BATCH_SIZE,
+                    bigtableBackend.getMaxWriteBatchSize());
         }
         {
             final int tooSmallBatchSize = 1;
             var bigtableBackend = getBigtableMetricModule(tooSmallBatchSize);
 
-            assertEquals(BigtableMetricModule.MIN_MUTATION_BATCH_SIZE, bigtableBackend.getMaxWriteBatchSize());
+            assertEquals(BigtableMetricModule.MIN_MUTATION_BATCH_SIZE,
+                    bigtableBackend.getMaxWriteBatchSize());
         }
         {
             final int validSize = 500_000;

--- a/heroic-dist/src/test/resources/heroic-all.yml
+++ b/heroic-dist/src/test/resources/heroic-all.yml
@@ -21,6 +21,9 @@ metrics:
     - type: bigtable
       project: project
       maxWriteBatchSize: 250
+      mutateRpcTimeoutMs: 135
+      readRowsRpcTimeoutMs: 136
+      shortRpcTimeoutMs: 137
     - type: datastax
     - type: memory
 

--- a/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsModule.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/analytics/bigtable/BigtableAnalyticsModule.java
@@ -21,6 +21,10 @@
 
 package com.spotify.heroic.analytics.bigtable;
 
+import static com.spotify.heroic.metric.consts.ApiQueryConsts.DEFAULT_MUTATE_RPC_TIMEOUT_MS;
+import static com.spotify.heroic.metric.consts.ApiQueryConsts.DEFAULT_READ_ROWS_RPC_TIMEOUT_MS;
+import static com.spotify.heroic.metric.consts.ApiQueryConsts.DEFAULT_SHORT_RPC_TIMEOUT_MS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.heroic.analytics.AnalyticsComponent;
@@ -100,9 +104,19 @@ public class BigtableAnalyticsModule implements AnalyticsModule {
             @Override
             public AsyncFuture<BigtableConnection> construct() {
                 return async.call(
-                    new BigtableConnectionBuilder(project, instance, profile, credentials,
-                        emulatorEndpoint, async, DEFAULT_DISABLE_BULK_MUTATIONS,
-                        DEFAULT_FLUSH_INTERVAL_SECONDS, Optional.empty()));
+                    new BigtableConnectionBuilder(
+                            project,
+                            instance,
+                            profile,
+                            credentials,
+                            emulatorEndpoint,
+                            async,
+                            DEFAULT_DISABLE_BULK_MUTATIONS,
+                            DEFAULT_FLUSH_INTERVAL_SECONDS,
+                            Optional.empty(),
+                            DEFAULT_MUTATE_RPC_TIMEOUT_MS,
+                            DEFAULT_READ_ROWS_RPC_TIMEOUT_MS,
+                            DEFAULT_SHORT_RPC_TIMEOUT_MS));
             }
 
             @Override

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
@@ -130,6 +130,9 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
 
     private final Meter written = new Meter();
     private final int maxWriteBatchSize;
+    private final int mutateRpcTimeoutMs;
+    private final int readRowsRpcTimeoutMs;
+    private final int shortRpcTimeoutMs;
 
     @Inject
     public BigtableBackend(
@@ -141,6 +144,9 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
         @Named("table") final String table,
         @Named("configure") final boolean configure,
         @Named("maxWriteBatchSize") final int maxWriteBatchSize,
+        @Named("mutateRpcTimeoutMs") final int mutateRpcTimeoutMs,
+        @Named("readRowsRpcTimeoutMs") final int readRowsRpcTimeoutMs,
+        @Named("shortRpcTimeoutMs") final int shortRpcTimeoutMs,
         MetricBackendReporter reporter,
         @Named("application/json") ObjectMapper mapper
     ) {
@@ -151,6 +157,9 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
         this.sortedMapSerializer = serializer.sortedMap(serializer.string(), serializer.string());
         this.connection = connection;
         this.maxWriteBatchSize = maxWriteBatchSize;
+        this.mutateRpcTimeoutMs = mutateRpcTimeoutMs;
+        this.readRowsRpcTimeoutMs = readRowsRpcTimeoutMs;
+        this.shortRpcTimeoutMs = shortRpcTimeoutMs;
         this.groups = groups;
         this.table = table;
         this.configure = configure;
@@ -656,6 +665,18 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
 
     public int getMaxWriteBatchSize() {
         return maxWriteBatchSize;
+    }
+
+    public int getMutateRpcTimeoutMs() {
+        return mutateRpcTimeoutMs;
+    }
+
+    public int getReadRowsRpcTimeoutMs() {
+        return readRowsRpcTimeoutMs;
+    }
+
+    public int getShortRpcTimeoutMs() {
+        return shortRpcTimeoutMs;
     }
 
     private static final class PreparedQuery {

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnectionBuilder.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableConnectionBuilder.java
@@ -23,14 +23,11 @@ package com.spotify.heroic.metric.bigtable;
 
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.BulkOptions;
-import com.google.cloud.bigtable.config.CredentialOptions;
+import com.google.cloud.bigtable.config.CallOptionsConfig;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.grpc.BigtableSession;
-import com.spotify.heroic.metric.bigtable.api.BigtableDataClient;
 import com.spotify.heroic.metric.bigtable.api.BigtableDataClientImpl;
-import com.spotify.heroic.metric.bigtable.api.BigtableMutator;
 import com.spotify.heroic.metric.bigtable.api.BigtableMutatorImpl;
-import com.spotify.heroic.metric.bigtable.api.BigtableTableAdminClient;
 import com.spotify.heroic.metric.bigtable.api.BigtableTableTableAdminClientImpl;
 import eu.toolchain.async.AsyncFramework;
 import io.grpc.Status;
@@ -58,6 +55,10 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
     private final boolean disableBulkMutations;
     private final int flushIntervalSeconds;
     private final Optional<Integer> batchSize;
+    private final int mutateRpcTimeoutMs;
+    private final int readRowsRpcTimeoutMs;
+    private final int shortRpcTimeoutMs;
+
     private final String emulatorEndpoint;
 
     public BigtableConnectionBuilder(
@@ -69,7 +70,10 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
         final AsyncFramework async,
         final boolean disableBulkMutations,
         final int flushIntervalSeconds,
-        final Optional<Integer> batchSize
+        final Optional<Integer> batchSize,
+        final int mutateRpcTimeoutMs,
+        final int readRowsRpcTimeoutMs,
+        final int shortRpcTimeoutMs
     ) {
         this.project = project;
         this.instance = instance;
@@ -80,30 +84,40 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
         this.disableBulkMutations = disableBulkMutations;
         this.flushIntervalSeconds = flushIntervalSeconds;
         this.batchSize = batchSize;
+        this.mutateRpcTimeoutMs = mutateRpcTimeoutMs;
+        this.readRowsRpcTimeoutMs = readRowsRpcTimeoutMs;
+        this.shortRpcTimeoutMs = shortRpcTimeoutMs;
     }
 
     @Override
     public BigtableConnection call() throws Exception {
-        final CredentialOptions credentials = this.credentials.build();
+        final var credentials = this.credentials.build();
 
-        final RetryOptions retryOptions = RetryOptions.builder()
+        final var retryOptions = RetryOptions.builder()
             .addStatusToRetryOn(Status.Code.UNKNOWN)
             .addStatusToRetryOn(Status.Code.UNAVAILABLE)
             .setAllowRetriesWithoutTimestamp(true)
             .build();
 
-        final BulkOptions bulkOptions = batchSize
+        final var bulkOptions = batchSize
             .map(integer ->  BulkOptions.builder().setBulkMaxRowKeyCount(integer).build())
             .orElseGet(() -> BulkOptions.builder().build());
 
-        BigtableOptions.Builder builder = BigtableOptions.builder()
+        var callOptionsConfig = CallOptionsConfig.builder()
+                .setReadRowsRpcTimeoutMs(readRowsRpcTimeoutMs)
+                .setMutateRpcTimeoutMs(mutateRpcTimeoutMs)
+                .setShortRpcTimeoutMs(shortRpcTimeoutMs)
+                .setUseTimeout(true).build();
+
+        var builder = BigtableOptions.builder()
             .setProjectId(project)
             .setInstanceId(instance)
             .setUserAgent(USER_AGENT)
             .setDataChannelCount(64)
             .setCredentialOptions(credentials)
             .setRetryOptions(retryOptions)
-            .setBulkOptions(bulkOptions);
+            .setBulkOptions(bulkOptions)
+            .setCallOptionsConfig(callOptionsConfig);
 
         if (profile != null) {
             builder.setAppProfileId(profile);
@@ -113,22 +127,23 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
             builder.enableEmulator(emulatorEndpoint);
         }
 
-        final BigtableOptions bigtableOptions = builder.build();
+        final var bigtableOptions = builder.build();
 
         log.info("Retry Options: {}", retryOptions.toString());
         log.info("Bulk Options: {}", bulkOptions.toString());
         log.info("Bigtable Options: {}", bigtableOptions.toString());
+        log.info("Call Options: {}", callOptionsConfig.toString());
         log.info("BigTable Connection Builder: \n{}", toString());
 
-        final BigtableSession session = new BigtableSession(bigtableOptions);
+        final var session = new BigtableSession(bigtableOptions);
 
-        final BigtableTableAdminClient adminClient =
+        final var adminClient =
             new BigtableTableTableAdminClientImpl(session.getTableAdminClient(), project, instance);
 
-        final BigtableMutator mutator =
+        final var mutator =
             new BigtableMutatorImpl(async, session, disableBulkMutations, flushIntervalSeconds);
 
-        final BigtableDataClient client =
+        final var client =
             new BigtableDataClientImpl(async, session, mutator, project, instance);
 
         return new BigtableConnection(async, project, instance, session, mutator, adminClient,
@@ -146,6 +161,9 @@ public class BigtableConnectionBuilder implements Callable<BigtableConnection> {
             .append("flushIntervalSeconds", flushIntervalSeconds)
             .append("batchSize", batchSize.orElse(-1))
             .append("emulatorEndpoint", emulatorEndpoint)
+            .append("mutateRpcTimeoutMs", mutateRpcTimeoutMs)
+            .append("readRowsRpcTimeoutMs", readRowsRpcTimeoutMs)
+            .append("shortRpcTimeoutMs", shortRpcTimeoutMs)
             .toString();
     }
 }

--- a/metric/bigtable/src/test/java/com/spotify/heroic/metric/bigtable/HeroicConfigurationTestUtils.java
+++ b/metric/bigtable/src/test/java/com/spotify/heroic/metric/bigtable/HeroicConfigurationTestUtils.java
@@ -1,0 +1,26 @@
+package com.spotify.heroic.metric.bigtable;
+
+//import com.spotify.heroic.HeroicCore;
+//import com.spotify.heroic.HeroicCore.Builder;
+//import com.spotify.heroic.HeroicCoreInstance;
+//import java.io.InputStream;
+//import java.util.function.Supplier;
+//import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+/**
+ * Provides utility functions for testing the processing of heroic.yaml.
+ */
+public class HeroicConfigurationTestUtils {
+
+//    public static HeroicCoreInstance testConfiguration(final String name) throws Exception {
+//        final Builder builder = HeroicCore.builder();
+//        builder.modules(ImmutableList.of(new Module()));
+//        builder.configStream(stream(name));
+//        return builder.build().newInstance();
+//    }
+//
+//    public static Supplier<InputStream> stream(String name) {
+//        return () -> HeroicConfigurationTestUtils.class.getClassLoader().getResourceAsStream(name);
+//    }
+}
+


### PR DESCRIPTION
#### Use Case Resolved: Heroic pipeline instability and poor user experience for Grafana

- I am a Heroic developer
- who wants to armour up Heroic so that we get fewer alerts
- so that we can focus on features

#### Plan

* look at the [spotify-bigtable-client](https://ghe.spotify.net/bases/bigtable-client-wrapper) repo for "inspiration"
* don't implement a whole new layer of configuration. Focus on the 2 or 3 settings we're immediately interested in.

#### Notes for Reviewer

- only read requests are affected (i.e. Heroic API but not metric Ingestion)
- a maxMutateRowTimeout *is* implemented but will be deployed with the default setting value so as not to change Ingestion at all. This is done for development efficiency reasons i.e. it would have been foolish not to add support for it whilst I was changing the exact same files in the exact same places. Here is the [heroic-gke](https://ghe.spotify.net/monitoring/heroic-gke/pull/111) PR that puts `mutateRpcTimeoutMs` back to 10 minutes.