### PR TITLE
Improve tracing and logging for write errors.

### DIFF
--- a/consumer/pubsub/src/main/java/com/spotify/heroic/consumer/pubsub/PubSubConsumer.java
+++ b/consumer/pubsub/src/main/java/com/spotify/heroic/consumer/pubsub/PubSubConsumer.java
@@ -47,9 +47,12 @@ public class PubSubConsumer implements Consumer, LifeCycles {
 
     @Inject
     PubSubConsumer(
-        AsyncFramework async, Managed<Connection> connection,
-        @Named("consuming") AtomicInteger consuming, @Named("total") AtomicInteger total,
-        @Named("errors") AtomicLong errors, @Named("consumed") LongAdder consumed
+        AsyncFramework async,
+        Managed<Connection> connection,
+        @Named("consuming") AtomicInteger consuming,
+        @Named("total") AtomicInteger total,
+        @Named("errors") AtomicLong errors,
+        @Named("consumed") LongAdder consumed
     ) {
         this.async = async;
         this.connection = connection;

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -60,9 +60,9 @@ import com.spotify.heroic.statistics.MetricBackendReporter;
 import com.spotify.heroic.tracing.EndSpanFutureReporter;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
+import eu.toolchain.async.FutureDone;
 import eu.toolchain.async.LazyTransform;
 import eu.toolchain.async.StreamCollector;
-import eu.toolchain.async.FutureDone;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Tracer;
 import java.util.ArrayList;
@@ -71,12 +71,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.inject.Inject;
@@ -472,7 +472,7 @@ public class LocalMetricManager implements MetricManager {
 
         @Override
         public AsyncFuture<WriteMetric> write(final WriteMetric.Request request) {
-            return write(request, io.opencensus.trace.Tracing.getTracer().getCurrentSpan());
+            return write(request);
         }
 
         @Override

--- a/heroic-core/src/test/java/com/spotify/heroic/consumer/schemas/Spotify100ProtoTest.java
+++ b/heroic-core/src/test/java/com/spotify/heroic/consumer/schemas/Spotify100ProtoTest.java
@@ -21,7 +21,7 @@
 
 package com.spotify.heroic.consumer.schemas;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,7 +44,6 @@ import com.spotify.proto.Spotify100.Batch;
 import com.spotify.proto.Spotify100.Metric;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
-import io.opencensus.metrics.export.Value;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
@@ -52,7 +51,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.xerial.snappy.Snappy;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -73,6 +72,9 @@ public class Spotify100ProtoTest {
   @Mock
   private AsyncFuture<Ingestion> resolved;
 
+  @Mock
+  private AsyncFuture<Void> discardedFuture;
+
   private Spotify100Proto.Consumer consumer;
 
   @Rule
@@ -81,6 +83,7 @@ public class Spotify100ProtoTest {
   @Before
   public void setup() {
     when(clock.currentTimeMillis()).thenReturn(1542830485000L);
+    when(async.collectAndDiscard(any())).thenReturn(discardedFuture);
     when(ingestion.write(any(Request.class))).thenReturn(resolved);
     consumer = new Spotify100Proto.Consumer(clock, ingestion, reporter, async);
   }

--- a/heroic-dist/src/test/java/com/spotify/heroic/analytics/bigtable/HeroicMetricsConfigurationTest.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/analytics/bigtable/HeroicMetricsConfigurationTest.java
@@ -3,16 +3,9 @@ package com.spotify.heroic.analytics.bigtable;
 import static com.spotify.heroic.HeroicConfigurationTestUtils.testConfiguration;
 import static org.junit.Assert.assertEquals;
 
-import com.spotify.heroic.dagger.DaggerCoreComponent;
 import com.spotify.heroic.metric.LocalMetricManager;
 import com.spotify.heroic.metric.bigtable.BigtableBackend;
 import com.spotify.heroic.metric.bigtable.BigtableMetricModule;
-import com.spotify.heroic.metric.bigtable.MetricsRowKeySerializer;
-import eu.toolchain.async.TinyAsync;
-import eu.toolchain.serializer.TinySerializer;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 /**
@@ -28,16 +21,6 @@ import org.junit.Test;
 public class HeroicMetricsConfigurationTest {
 
     public static final int EXPECTED_MAX_WRITE_BATCH_SIZE = 250;
-
-    @NotNull
-    private static BigtableBackend getBigtableBackend(int maxWriteBatchSize) {
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
-        final TinyAsync async = TinyAsync.builder().executor(executor).build();
-        var serializer = TinySerializer.builder().build();
-
-        var bigtableBackend = new BigtableBackend(async, serializer, new MetricsRowKeySerializer(), null, null, "bananas", false, maxWriteBatchSize, null, null);
-        return bigtableBackend;
-    }
 
     private static BigtableMetricModule getBigtableMetricModule(int maxWriteBatchSize) {
         return new BigtableMetricModule.Builder()
@@ -57,7 +40,7 @@ public class HeroicMetricsConfigurationTest {
         instance.inject(
             coreComponent -> {
                 var metricManager =
-                    (LocalMetricManager) ((DaggerCoreComponent) coreComponent).metricManager();
+                    (LocalMetricManager) coreComponent.metricManager();
                 var analyticsBackend =
                     metricManager
                         .groupSet()

--- a/heroic-test/src/main/java/com/spotify/heroic/test/AbstractMetricBackendIT.java
+++ b/heroic-test/src/main/java/com/spotify/heroic/test/AbstractMetricBackendIT.java
@@ -22,6 +22,7 @@
 package com.spotify.heroic.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 
 import com.google.common.collect.ImmutableList;
@@ -82,7 +83,7 @@ public abstract class AbstractMetricBackendIT {
      * See: https://github.com/spotify/heroic/pull/208 */
     protected boolean brokenSegmentsPr208 = false;
     protected boolean eventSupport = false;
-    protected Optional<Integer> maxBatchSize = Optional.empty();
+    protected Integer maxBatchSize = null;
     protected boolean hugeRowKey = true;
 
     @Rule
@@ -165,8 +166,7 @@ public abstract class AbstractMetricBackendIT {
      */
     @Test
     public void testMaxBatchSize() throws Exception {
-        assumeTrue("max batch size", maxBatchSize.isPresent());
-        final int maxBatchSize = this.maxBatchSize.get();
+        assumeNotNull("max batch size", maxBatchSize);
         DateRange range = new DateRange(99L, 100L + (maxBatchSize * 4));
 
         new TestCase()

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
@@ -23,9 +23,8 @@ package com.spotify.heroic.metric.bigtable;
 
 import static io.opencensus.trace.AttributeValue.booleanAttributeValue;
 import static io.opencensus.trace.AttributeValue.longAttributeValue;
+import static io.opencensus.trace.AttributeValue.stringAttributeValue;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.util.RowKeyUtil;
 import com.google.common.base.Function;
@@ -69,11 +68,10 @@ import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.Managed;
 import eu.toolchain.async.RetryPolicy;
 import eu.toolchain.async.RetryResult;
-import eu.toolchain.serializer.Serializer;
-import eu.toolchain.serializer.SerializerFramework;
 import io.opencensus.common.Scope;
 import io.opencensus.trace.AttributeValue;
 import io.opencensus.trace.Span;
+import io.opencensus.trace.Status;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
 import java.io.IOException;
@@ -100,33 +98,25 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
     private static final Logger log = LoggerFactory.getLogger(BigtableBackend.class);
 
     /* maximum number of bytes of BigTable row key size allowed*/
-    public static final int MAX_KEY_ROW_SIZE = 4000;
-
-    public static final QueryTrace.Identifier FETCH_SEGMENT =
+    private static final int MAX_KEY_ROW_SIZE = 4000;
+    private static final QueryTrace.Identifier FETCH_SEGMENT =
         QueryTrace.identifier(BigtableBackend.class, "fetch_segment");
-    public static final QueryTrace.Identifier FETCH =
+    private static final QueryTrace.Identifier FETCH =
         QueryTrace.identifier(BigtableBackend.class, "fetch");
+    private static final String POINTS = "points";
+    private static final String DISTRIBUTION_POINTS = "distributionPoints";
+    private static final String EVENTS = "events";
 
-    public static final String POINTS = "points";
-    public static final String DISTRIBUTION_POINTS = "distributionPoints";
-    public static final String EVENTS = "events";
     public static final long PERIOD = 0x100_000_000L;
 
     private final AsyncFramework async;
-    private final SerializerFramework serializer;
     private final RowKeySerializer rowKeySerializer;
-    private final Serializer<SortedMap<String, String>> sortedMapSerializer;
     private final Managed<BigtableConnection> connection;
     private final Groups groups;
     private final String table;
     private final boolean configure;
     private final MetricBackendReporter reporter;
-    private final ObjectMapper mapper;
     private final Tracer tracer = Tracing.getTracer();
-
-    private static final TypeReference<Map<String, String>> PAYLOAD_TYPE =
-        new TypeReference<Map<String, String>>() {
-        };
 
     private final Meter written = new Meter();
     private final int maxWriteBatchSize;
@@ -134,28 +124,23 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
     @Inject
     public BigtableBackend(
         final AsyncFramework async,
-        @Named("common") final SerializerFramework serializer,
         final RowKeySerializer rowKeySerializer,
         final Managed<BigtableConnection> connection,
         final Groups groups,
         @Named("table") final String table,
         @Named("configure") final boolean configure,
         @Named("maxWriteBatchSize") final int maxWriteBatchSize,
-        MetricBackendReporter reporter,
-        @Named("application/json") ObjectMapper mapper
+        MetricBackendReporter reporter
     ) {
         super(async);
         this.async = async;
-        this.serializer = serializer;
         this.rowKeySerializer = rowKeySerializer;
-        this.sortedMapSerializer = serializer.sortedMap(serializer.string(), serializer.string());
         this.connection = connection;
         this.maxWriteBatchSize = maxWriteBatchSize;
         this.groups = groups;
         this.table = table;
         this.configure = configure;
         this.reporter = reporter;
-        this.mapper = mapper;
     }
 
     @Override
@@ -250,17 +235,15 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
     }
 
     @Override
-    public AsyncFuture<WriteMetric> write(
-        final WriteMetric.Request request, final Span parentSpan
-    ) {
-        return connection.doto(c -> {
+    public AsyncFuture<WriteMetric> write(final WriteMetric.Request request, final Span span) {
+        return connection.doto(conn -> {
             final Series series = request.getSeries();
             final List<AsyncFuture<WriteMetric>> results = new ArrayList<>();
 
-            final BigtableDataClient client = c.getDataClient();
+            final BigtableDataClient client = conn.getDataClient();
 
-            final MetricCollection g = request.getData();
-            results.add(writeTyped(series, client, g, parentSpan));
+            final MetricCollection collection = request.getData();
+            results.add(writeTyped(series, client, collection, span));
             return async.collect(results, WriteMetric.reduce());
         });
     }
@@ -336,20 +319,24 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
     private AsyncFuture<WriteMetric> writeTyped(
         final Series series,
         final BigtableDataClient client,
-        final MetricCollection g,
-        final Span parentSpan
+        final MetricCollection collection,
+        final Span span
     ) throws IOException {
-        switch (g.getType()) {
+        var type = collection.getType();
+        span.putAttribute("metric_type", stringAttributeValue(type.toString()));
+        switch (type) {
             case POINT:
-                return writeBatch(POINTS, series, client, g.getDataAs(Point.class),
-                    d -> serializeValue(d.getValue()), parentSpan);
+                return writeBatch(POINTS, series, client, collection.getDataAs(Point.class),
+                    d -> serializeValue(d.getValue()), span);
             case DISTRIBUTION_POINTS:
-                return writeBatch(DISTRIBUTION_POINTS, series, client, g.getDataAs(
+                return writeBatch(DISTRIBUTION_POINTS, series, client, collection.getDataAs(
                     DistributionPoint.class),
-                    d -> d.value().getValue(), parentSpan);
+                    d -> d.value().getValue(), span);
             default:
+                span.setStatus(
+                    Status.INVALID_ARGUMENT.withDescription("Unsupported metric type"));
                 return async.resolved(new WriteMetric(
-                    new QueryError("Unsupported metric type: " + g.getType())));
+                    new QueryError("Unsupported metric type: " + collection.getType())));
         }
     }
 
@@ -363,6 +350,7 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
         final Scope scope = tracer.withSpan(span);
         span.putAttribute("type", AttributeValue.stringAttributeValue(columnFamily));
         span.putAttribute("batchSize", longAttributeValue(batch.size()));
+        span.putAttribute("table", stringAttributeValue(table));
 
         // common case for consumers
         if (batch.size() == 1) {
@@ -371,6 +359,11 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
                     .onFinished(() -> {
                         written.mark();
                         span.end();
+                    })
+                    .onFailed(error -> {
+                        log.error("Bigtable writeOne failed: ", error);
+                        span.putAttribute("error", booleanAttributeValue(true));
+                        span.addAnnotation(error.getMessage());
                     });
             scope.close();
             return future;
@@ -415,8 +408,8 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
 
         final RequestTimer<WriteMetric> timer = WriteMetric.timer();
 
-        for (final Pair<RowKey, Mutations> e : saved) {
-            final ByteString rowKeyBytes = rowKeySerializer.serializeFull(e.getKey());
+        for (final Pair<RowKey, Mutations> mutationsPair : saved) {
+            final ByteString rowKeyBytes = rowKeySerializer.serializeFull(mutationsPair.getKey());
 
             if (rowKeyBytes.size() >= MAX_KEY_ROW_SIZE) {
                 reporter.reportWritesDroppedBySize();
@@ -426,12 +419,18 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
             }
 
             writes.add(client
-                .mutateRow(table, rowKeyBytes, e.getValue())
+                .mutateRow(table, rowKeyBytes, mutationsPair.getValue())
                 .directTransform(result -> timer.end()));
         }
 
         scope.close();
-        return async.collect(writes.build(), WriteMetric.reduce()).onFinished(span::end);
+        return async.collect(writes.build(), WriteMetric.reduce())
+            .onFinished(span::end)
+            .onFailed(error -> {
+                log.error("Bigtable write batch failed: ", error);
+                span.putAttribute("error", booleanAttributeValue(true));
+                span.addAnnotation(error.getMessage());
+            });
     }
 
     private <T extends Metric> AsyncFuture<WriteMetric> writeOne(

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableDataClientImpl.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/api/BigtableDataClientImpl.java
@@ -103,7 +103,7 @@ public class BigtableDataClientImpl implements BigtableDataClient {
             final ResultScanner<com.google.bigtable.v2.Row> s =
                 session.getDataClient().readRows(request.toPb(Table.toURI(clusterUri, tableName)));
 
-            final ResultScanner<Row> scanner = new ResultScanner<Row>() {
+            final ResultScanner<Row> scanner = new ResultScanner<>() {
                 @Override
                 public void close() throws IOException {
                     s.close();

--- a/metric/bigtable/src/test/java/com/spotify/heroic/metric/bigtable/BigtableBackendIT.java
+++ b/metric/bigtable/src/test/java/com/spotify/heroic/metric/bigtable/BigtableBackendIT.java
@@ -25,7 +25,7 @@ public class BigtableBackendIT extends AbstractMetricBackendIT {
         super.setupSupport();
 
         this.eventSupport = true;
-        this.maxBatchSize = Optional.of(BigtableMetricModule.DEFAULT_MUTATION_BATCH_SIZE);
+        this.maxBatchSize = BigtableMetricModule.DEFAULT_MUTATION_BATCH_SIZE;
         this.brokenSegmentsPr208 = true;
     }
 

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
@@ -46,7 +46,6 @@ import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricRegistry;
 import eu.toolchain.async.AsyncFuture;
 import io.opencensus.trace.Span;
-import io.opencensus.trace.Tracing;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -255,7 +254,7 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
 
         @Override
         public AsyncFuture<WriteMetric> write(final WriteMetric.Request request) {
-            return write(request, Tracing.getTracer().getCurrentSpan());
+            return write(request);
         }
 
         @Override


### PR DESCRIPTION
This adds error flags and exception messages to the spans for
metadata, suggest, and bigtable writes when the chain of futures
fails. The same exceptions are also logged. Previously some
exceptions, such as grpc errors, could be masked by sl4j settings.

The trace for a metric write was cleaned up to remove several
intermediary spans. These spans did not have useful information and
had no branching paths, so they were just clutter in the overall
trace.

Closes #724.