### PR TITLE
Add a simple group combiners and additional IT tests. 

### DIFF
--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/TdigestInstance.kt
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/TdigestInstance.kt
@@ -46,7 +46,9 @@ data class TdigestInstance (
     }
 
     override fun build(bucket: TDigestBucket): Metric {
-        if ( bucket.value().size() == 0L ) return Metric.invalid
-        else return TdigestPoint.create(bucket.value(), bucket.timestamp)
+        if ( bucket.value().size() == 0L ) {
+            return Metric.invalid
+        }
+        return TdigestPoint.create(bucket.value(), bucket.timestamp)
     }
 }

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/TdigestInstanceUtils.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/TdigestInstanceUtils.java
@@ -38,6 +38,10 @@ public class TdigestInstanceUtils {
         return new AtomicReference<>(tDigest);
     }
 
+    public static TDigest inital() {
+        return MergingDigest.createDigest(TDIGEST_COMPRESSION_LEVEL);
+    }
+
     public static UnaryOperator<TDigest> getOp(final ByteBuffer serializedTDigest) {
         TDigest input = MergingDigest.fromBytes(serializedTDigest);
         return t -> {

--- a/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/TdigestBucketIntegrationTest.java
+++ b/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/TdigestBucketIntegrationTest.java
@@ -1,0 +1,26 @@
+package com.spotify.heroic.aggregation.simple;
+
+
+import com.google.common.collect.ImmutableList;
+import com.spotify.heroic.aggregation.DoubleBucket;
+import com.spotify.heroic.aggregation.TDigestBucket;
+import java.util.Collection;
+import java.util.List;
+
+public class TdigestBucketIntegrationTest extends ValueBucketIntegrationTest {
+
+
+    public TdigestBucketIntegrationTest() {
+        super(Double.NEGATIVE_INFINITY, null);
+    }
+
+    @Override
+    public Collection<DoubleBucket> buckets() {
+        return List.of();
+    }
+
+    @Override
+    public Collection<? extends TDigestBucket> tDigestBuckets(){
+        return ImmutableList.<TDigestBucket>of(new TdigestMergingBucket(0L));
+    }
+}

--- a/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/TdigestBucketTest.java
+++ b/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/TdigestBucketTest.java
@@ -26,6 +26,14 @@ public class TdigestBucketTest {
          Assert.assertEquals(0,val.size());
      }
 
+    @Test(expected = java.nio.BufferUnderflowException.class)
+     public void testNullValue(){
+         final TdigestMergingBucket b = new TdigestMergingBucket(timeStamp);
+         DistributionPoint dp = DistributionPoint.create(HeroicDistribution.create(ByteString.EMPTY),
+             System.currentTimeMillis());
+         b.updateDistributionPoint(TAGS, dp);
+     }
+
 
     @Test
     public void testCount()  {

--- a/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/ValueBucketIntegrationTest.java
+++ b/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/ValueBucketIntegrationTest.java
@@ -4,7 +4,13 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
 import com.spotify.heroic.aggregation.DoubleBucket;
+import com.spotify.heroic.aggregation.TDigestBucket;
+import com.spotify.heroic.metric.DistributionPoint;
+import com.spotify.heroic.metric.HeroicDistribution;
 import com.spotify.heroic.metric.Point;
+import com.tdunning.math.stats.MergingDigest;
+import com.tdunning.math.stats.TDigest;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -19,6 +25,7 @@ import java.util.function.DoubleBinaryOperator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import com.google.protobuf.ByteString;
 
 public abstract class ValueBucketIntegrationTest {
     private static final int NCPU = Runtime.getRuntime().availableProcessors();
@@ -62,6 +69,62 @@ public abstract class ValueBucketIntegrationTest {
     }
 
     public abstract Collection<? extends DoubleBucket> buckets();
+
+    public Collection<? extends TDigestBucket> tDigestBuckets(){
+        return List.of();
+    }
+
+
+    @Test(timeout = 10000)
+    public void testTDigestBucket() throws InterruptedException, ExecutionException {
+        final Random rnd = new Random();
+
+
+
+        for (final TDigestBucket bucket : tDigestBuckets()) {
+            final List<Future<Void>> futures = new ArrayList<>();
+
+            TDigest expected = TDigest.createDigest(100.0);
+
+            for (int iteration = 0; iteration < iterations; iteration++) {
+                final List<DistributionPoint> updates = new ArrayList<>();
+                for (int i = 0; i< 10; i++) {
+                    int count = 5;
+                    double [] data = new double[count];
+                    while (count-- > 0) {
+                        double sample = rnd.nextDouble();
+                        data[count] = sample;
+                        expected.add(sample);
+                    }
+                    DistributionPoint dp =  DistributionPointUtils
+                        .createDistributionPoint(data, System.currentTimeMillis());
+                    updates.add(dp);
+                }
+
+                for (int thread = 0; thread < threadCount; thread++) {
+                    futures.add(service.submit(new Callable<Void>() {
+                        @Override
+                        public Void call() throws Exception {
+                            for (final DistributionPoint d : updates) {
+                                bucket.updateDistributionPoint(tags, d);
+                            }
+
+                            return null;
+                        }
+                    }));
+                }
+
+                for (final Future<Void> f : futures) {
+                    f.get();
+                }
+            }
+
+            assertEquals(bucket.getClass().getSimpleName(), expected.size()*threadCount,
+                bucket.value().size());
+
+        }
+    }
+
 
     @Test(timeout = 10000)
     public void testExpectedValue() throws InterruptedException, ExecutionException {

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/AggregationCombiner.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/AggregationCombiner.java
@@ -22,24 +22,11 @@
 package com.spotify.heroic.aggregation;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.spotify.heroic.common.Series;
-import com.spotify.heroic.metric.MetricCollection;
-import com.spotify.heroic.metric.MetricType;
-import com.spotify.heroic.metric.Point;
 import com.spotify.heroic.metric.ShardedResultGroup;
-
-import com.spotify.heroic.metric.TdigestPoint;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
+
 
 public interface AggregationCombiner {
-    ImmutableList<MetricType> TDIGEST_TYPE = ImmutableList.of(MetricType.TDIGEST_POINT,
-        MetricType.DISTRIBUTION_POINTS);
 
     List<ShardedResultGroup> combine(List<List<ShardedResultGroup>> all);
 
@@ -63,41 +50,18 @@ public interface AggregationCombiner {
         }
     };
 
-    default void compute(final ImmutableList.Builder<ShardedResultGroup> groups,
-                         final AggregationOutput out,
-                         final long cadence) {
-        final List<TdigestPoint> metrics = out.getMetrics().getDataAs(TdigestPoint.class);
-        final Map<ComputeDistributionStat.Percentile, List<Point>> resMap = new HashMap<>();
-        for (TdigestPoint tdigestPoint : metrics) {
-            ComputeDistributionStat
-                .Percentile
-                .DEFAULT
-                .forEach(p -> compute(tdigestPoint, resMap, p));
-        }
-        for (Map.Entry<ComputeDistributionStat.Percentile,
-            List<Point>> entry : resMap.entrySet()) {
-            Set<Series> newSet = new HashSet<>();
-            out.getSeries().forEach(s -> updateMetadata(s, entry.getKey(), newSet));
-            groups.add(new ShardedResultGroup(ImmutableMap.of(), out.getKey(), newSet,
-                MetricCollection.points(entry.getValue()), cadence));
-        }
-    }
 
-    private void updateMetadata(final Series s,
-                                final ComputeDistributionStat.Percentile percentile,
-                                final Set<Series> newSet) {
-        Map<String, String> tags = new HashMap<>(s.getTags());
-        tags.put("tdigeststat", percentile.getName());
-        Series newSeries = Series.of(s.getKey(), tags, s.getResource());
-        newSet.add(newSeries);
-    }
+    AggregationCombiner TDIGEST_DEFAULT = new AggregationCombiner() {
+        @Override
+        public List<ShardedResultGroup> combine(
+            final List<List<ShardedResultGroup>> all
+        ) {
+            return TDigestAggregationCombiner.simpleCombine(all);
+        }
 
-    private void compute(final TdigestPoint tdigestPoint,
-                         final Map<ComputeDistributionStat.Percentile, List<Point>> resMap,
-                         final ComputeDistributionStat.Percentile percentile) {
-        Point point = ComputeDistributionStat.computePercentile(tdigestPoint, percentile);
-        List<Point> points = resMap.getOrDefault(percentile, new ArrayList<>());
-        points.add(point);
-        resMap.put(percentile, points);
-    }
+        @Override
+        public String toString() {
+            return "TDIGESGT_DEFAULT";
+        }
+    };
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/AggregationCombiner.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/AggregationCombiner.java
@@ -61,7 +61,7 @@ public interface AggregationCombiner {
 
         @Override
         public String toString() {
-            return "TDIGESGT_DEFAULT";
+            return "TDIGEST_DEFAULT";
         }
     };
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/DistributedAggregationCombiner.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/DistributedAggregationCombiner.java
@@ -78,14 +78,9 @@ public class DistributedAggregationCombiner implements AggregationCombiner {
         final AggregationResult result = session.result();
 
         for (final AggregationOutput out : result.getResult()) {
-            if (TDIGEST_TYPE.contains(out.getMetrics().getType())) {
-                compute(groups, out, cadence);
-            } else {
-                groups.add(new ShardedResultGroup(ImmutableMap.of(), out.getKey(), out.getSeries(),
-                    out.getMetrics(), cadence));
-            }
+            groups.add(new ShardedResultGroup(ImmutableMap.of(), out.getKey(), out.getSeries(),
+                out.getMetrics(), cadence));
         }
-
         return groups.build();
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/EmptyInstance.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/EmptyInstance.java
@@ -179,6 +179,11 @@ public class EmptyInstance implements AggregationInstance {
                         MetricCollection::distributionPoints));
                 }
 
+                if (!sub.tDigestPoints.isEmpty()) {
+                    groups.add(collectGroup(group, sub.tDigestPoints,
+                        MetricCollection::tdigestPoints));
+                }
+
                 if (!sub.spreads.isEmpty()) {
                     groups.add(collectGroup(group, sub.spreads, MetricCollection::spreads));
                 }

--- a/heroic-component/src/main/java/com/spotify/heroic/aggregation/TDigestAggregationCombiner.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/aggregation/TDigestAggregationCombiner.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2020 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ByteString;
+import com.spotify.heroic.common.DateRange;
+import com.spotify.heroic.common.Series;
+import com.spotify.heroic.metric.DistributionPoint;
+import com.spotify.heroic.metric.HeroicDistribution;
+import com.spotify.heroic.metric.MetricCollection;
+import com.spotify.heroic.metric.Point;
+import com.spotify.heroic.metric.ShardedResultGroup;
+import com.spotify.heroic.metric.TdigestPoint;
+import com.tdunning.math.stats.MergingDigest;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class TDigestAggregationCombiner implements AggregationCombiner {
+    private final AggregationInstance reducer;
+    private final DateRange range;
+    private final BucketStrategy bucketStrategy;
+    private final long cadence;
+
+    private TDigestAggregationCombiner(
+        final AggregationInstance reducer,
+        final DateRange range,
+        final BucketStrategy bucketStrategy,
+        final long cadence
+    ) {
+        this.reducer = reducer;
+        this.range = range;
+        this.bucketStrategy = bucketStrategy;
+        this.cadence = cadence;
+    }
+
+    public static TDigestAggregationCombiner create(
+        final AggregationInstance root,
+        final DateRange range,
+        final BucketStrategy bucketStrategy
+    ) {
+        return new TDigestAggregationCombiner(root.reducer(), range, bucketStrategy,
+            root.cadence());
+    }
+
+    @Override
+    public List<ShardedResultGroup> combine(List<List<ShardedResultGroup>> all) {
+        return distributedCombine(all);
+    }
+
+    @Override
+    public String toString() {
+        return "DISTRIBUTED_TDIGESGT_COMBINER";
+    }
+
+    private List<ShardedResultGroup> distributedCombine(List<List<ShardedResultGroup>> all) {
+        final AggregationSession session =
+            reducer.session(range, RetainQuotaWatcher.NO_QUOTA, bucketStrategy);
+
+        for (List<ShardedResultGroup> groups : all) {
+            for (final ShardedResultGroup g : groups) {
+                g.getMetrics().updateAggregation(session, g.getKey(), g.getSeries());
+            }
+        }
+
+        final ImmutableList.Builder<ShardedResultGroup> groups = ImmutableList.builder();
+
+        final AggregationResult result = session.result();
+
+        for (final AggregationOutput out : result.getResult()) {
+            compute(groups, out, cadence);
+        }
+        return groups.build();
+    }
+
+    private void compute(final ImmutableList.Builder<ShardedResultGroup> groups,
+                         final AggregationOutput out,
+                         final long cadence) {
+        final List<TdigestPoint> metrics = out.getMetrics().getDataAs(TdigestPoint.class);
+        final Map<ComputeDistributionStat.Percentile, List<Point>> resMap = new HashMap<>();
+        for (TdigestPoint tdigestPoint : metrics) {
+            ComputeDistributionStat
+                .Percentile
+                .DEFAULT
+                .forEach(p -> compute(tdigestPoint, resMap, p));
+        }
+        for (Map.Entry<ComputeDistributionStat.Percentile,
+            List<Point>> entry : resMap.entrySet()) {
+            Set<Series> newSet = new HashSet<>();
+            out.getSeries().forEach(s -> updateMetadata(s, entry.getKey(), newSet));
+            groups.add(new ShardedResultGroup(ImmutableMap.of(), out.getKey(), newSet,
+                MetricCollection.points(entry.getValue()), cadence));
+        }
+    }
+
+    private void updateMetadata(final Series s,
+                                final ComputeDistributionStat.Percentile percentile,
+                                final Set<Series> newSet) {
+        Map<String, String> tags = new HashMap<>(s.getTags());
+        tags.put("tdigeststat", percentile.getName());
+        Series newSeries = Series.of(s.getKey(), tags, s.getResource());
+        newSet.add(newSeries);
+    }
+
+    private void compute(final TdigestPoint tdigestPoint,
+                         final Map<ComputeDistributionStat.Percentile, List<Point>> resMap,
+                         final ComputeDistributionStat.Percentile percentile) {
+        Point point = ComputeDistributionStat.computePercentile(tdigestPoint, percentile);
+        List<Point> points = resMap.getOrDefault(percentile, new ArrayList<>());
+        points.add(point);
+        resMap.put(percentile, points);
+    }
+
+    public static List<ShardedResultGroup> simpleCombine(List<List<ShardedResultGroup>> all) {
+        List<ShardedResultGroup> groups = AggregationCombiner.DEFAULT.combine(all);
+        return computeCount(groups);
+    }
+
+    private static List<ShardedResultGroup> computeCount(List<ShardedResultGroup> groups) {
+        return groups.parallelStream().map(grp -> new ShardedResultGroup(grp.getShard(),
+            grp.getKey(), grp.getSeries(),
+            compute(grp.getMetrics()
+                .getDataAs(DistributionPoint.class)),
+            grp.getCadence()))
+            .collect(Collectors.toList());
+    }
+
+    private  static MetricCollection compute(List<DistributionPoint> datapoints) {
+        List<Point> points = new ArrayList<>();
+        for (DistributionPoint dp : datapoints) {
+            if (dp.value().getValue() == null ||
+                dp.value().getValue().equals(ByteString.EMPTY)) {
+                points.add(new Point(dp.getTimestamp(), -1));
+            } else if (dp.value() instanceof HeroicDistribution) {
+                HeroicDistribution heroicDistribution = (HeroicDistribution) dp.value();
+                MergingDigest mergingDigest = MergingDigest
+                    .fromBytes(heroicDistribution.toByteBuffer());
+                points.add(new Point(dp.getTimestamp(), mergingDigest.size()));
+            }
+        }
+        return MetricCollection.points(points);
+    }
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/DistributionPoint.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/DistributionPoint.java
@@ -21,11 +21,14 @@
 
 package com.spotify.heroic.metric;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.hash.Hasher;
 import org.jetbrains.annotations.NotNull;
 
-
+@JsonSerialize(using = DistributionPointSerializer.class)
+@JsonDeserialize(using = DistributionPointDeserialize.class)
 @AutoValue
 public abstract class DistributionPoint implements Metric {
 

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/DistributionPointDeserialize.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/DistributionPointDeserialize.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.metric;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+
+
+public class DistributionPointDeserialize extends StdDeserializer<DistributionPoint> {
+
+    protected DistributionPointDeserialize(Class<?> vc) {
+        super(vc);
+    }
+
+    public DistributionPointDeserialize() {
+        this(TdigestPoint.class);
+    }
+
+    @Override
+    public DistributionPoint deserialize(JsonParser jsonParser,
+                                    DeserializationContext ctxt)
+        throws IOException, JsonProcessingException {
+        JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+        Distribution value = HeroicDistribution.create(ByteString.EMPTY);
+        if (node != null) {
+            if (node.get("value") != null) {
+                byte[] bytes = node.get("value").binaryValue();
+                ByteString byteString = ByteString.copyFrom(bytes);
+                value = HeroicDistribution.create(byteString);
+            }
+        }
+        long timestamp = node.get("timestamp").asLong();
+        return DistributionPoint.create(value, timestamp);
+    }
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/DistributionPointSerializer.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/DistributionPointSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.metric;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+
+
+public class DistributionPointSerializer extends StdSerializer<DistributionPoint> {
+
+    protected DistributionPointSerializer(Class<DistributionPoint> t) {
+        super(t);
+    }
+
+    public DistributionPointSerializer() {
+        this(DistributionPoint.class);
+    }
+
+    @Override
+    public void serialize(DistributionPoint point,
+                          JsonGenerator gen,
+                          SerializerProvider provider) throws IOException {
+
+        gen.writeStartObject();
+        gen.writeObjectField("value",
+            serialize(point.value().getValue()));
+        gen.writeNumberField("timestamp", point.getTimestamp());
+        gen.writeEndObject();
+    }
+
+    private byte[] serialize(final ByteString byteString) {
+        return byteString.toByteArray();
+    }
+}

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/MetricCollection.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/MetricCollection.java
@@ -171,6 +171,16 @@ public interface MetricCollection {
     }
 
     /**
+     * Create a new TdigestPoint collection
+     *
+     * @param metric TdigestPoint
+     * @return a new collection of TdigestPoint
+     */
+    static MetricCollection tdigestPoints(List<TdigestPoint> metric) {
+        return TDigestPointCollection.create(metric);
+    }
+
+    /**
      * Build a new spreads collection.
      *
      * @param metrics spreads to include in the collection

--- a/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/CoreQueryManager.java
@@ -25,6 +25,7 @@ import static io.opencensus.trace.AttributeValue.booleanAttributeValue;
 import static io.opencensus.trace.AttributeValue.longAttributeValue;
 import static io.opencensus.trace.AttributeValue.stringAttributeValue;
 
+
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableSortedSet;
 import com.spotify.heroic.aggregation.Aggregation;
@@ -35,6 +36,7 @@ import com.spotify.heroic.aggregation.AggregationInstance;
 import com.spotify.heroic.aggregation.BucketStrategy;
 import com.spotify.heroic.aggregation.DistributedAggregationCombiner;
 import com.spotify.heroic.aggregation.Empty;
+import com.spotify.heroic.aggregation.TDigestAggregationCombiner;
 import com.spotify.heroic.cache.QueryCache;
 import com.spotify.heroic.cluster.ClusterManager;
 import com.spotify.heroic.cluster.ClusterNode;
@@ -239,12 +241,14 @@ public class CoreQueryManager implements QueryManager {
             final MetricType source = q.getSource().orElse(MetricType.POINT);
 
             final Aggregation aggregation = q.getAggregation().orElse(Empty.INSTANCE);
+
             final DateRange rawRange = buildRange(q);
 
             final Filter filter = q.getFilter().orElseGet(TrueFilter::get);
 
             final AggregationContext context =
                 AggregationContext.defaultInstance(cadenceFromRange(rawRange));
+
             final AggregationInstance root = aggregation.apply(context);
 
             final AggregationInstance aggregationInstance;
@@ -277,10 +281,14 @@ public class CoreQueryManager implements QueryManager {
 
             final AggregationCombiner combiner;
 
+
             if (isDistributed) {
-                combiner = DistributedAggregationCombiner.create(root, range, bucketStrategy);
+                combiner = (source.equals(MetricType.POINT)) ?
+                    DistributedAggregationCombiner.create(root, range, bucketStrategy) :
+                    TDigestAggregationCombiner.create(root, range, bucketStrategy);
             } else {
-                combiner = AggregationCombiner.DEFAULT;
+                combiner = (source.equals(MetricType.DISTRIBUTION_POINTS)) ?
+                    AggregationCombiner.TDIGEST_DEFAULT : AggregationCombiner.DEFAULT;
             }
 
             final FullQuery.Request request =

--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
@@ -68,11 +68,13 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
     private final Series s3 = new Series("key1", ImmutableSortedMap.of("shared", "a", "diff", "c"),
         ImmutableSortedMap.of("resource", "c"));
 
-    private final RandomData randDataset1 = HeroicDistributionGenerator.generateRandomDataset(10000);
-    private final RandomData randDataset2 = HeroicDistributionGenerator.generateRandomDataset(1000);
-    private final RandomData randDataset3 = HeroicDistributionGenerator.generateRandomDataset(100000);
+    private final static int RECORD_COUNT = 100_000; // Number of datapoint recorded in each tdigest
 
-    private static double EXPECTED_ERROR_RATE = 0.03d;
+    private final RandomData randDataset1 = HeroicDistributionGenerator.generateRandomDataset(RECORD_COUNT);
+    private final RandomData randDataset2 = HeroicDistributionGenerator.generateRandomDataset(RECORD_COUNT);
+    private final RandomData randDataset3 = HeroicDistributionGenerator.generateRandomDataset(RECORD_COUNT);
+
+    private static double EXPECTED_ERROR_RATE = 0.01d;
 
     /* the number of queries run */
     private int queryCount = 0;
@@ -158,26 +160,35 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
         return async.collectAndDiscard(writes);
     }
 
-    public QueryResult query(final String queryString, final MetricType metricType) throws Exception {
+    public QueryResult query(final String queryString) throws Exception {
         return query(query.newQueryFromString(queryString), builder -> {
-        }, metricType);
+        }, MetricType.POINT, true);
     }
 
     public QueryResult query(final String queryString,
-                             final Consumer<QueryBuilder> modifier, final MetricType metricType)
+                             final Consumer<QueryBuilder> modifier)
         throws Exception {
-        return query(query.newQueryFromString(queryString), modifier, metricType);
+        return query(query.newQueryFromString(queryString),
+            modifier,
+            MetricType.POINT,
+            true);
     }
 
     public QueryResult query(final QueryBuilder builder,
-                             final Consumer<QueryBuilder> modifier, final MetricType metricType)
+                             final Consumer<QueryBuilder> modifier,
+                             final MetricType metricType,
+                             final boolean isDistributed)
         throws Exception {
         queryCount += 1;
 
         builder
-            .features(Optional.of(FeatureSet.of(Feature.DISTRIBUTED_AGGREGATIONS)))
             .source(Optional.of(metricType))
             .rangeIfAbsent(Optional.of(new QueryDateRange.Absolute(0, 40)));
+
+        if ( isDistributed) {
+            builder
+                .features(Optional.of(FeatureSet.of(Feature.DISTRIBUTED_AGGREGATIONS)));
+        }
 
         modifier.accept(builder);
         return query.useDefaultGroup().query(builder.build(), queryContext).get();
@@ -191,7 +202,12 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
      */
     @Test
     public void testSimpleTdigestAggregation() throws Exception {
-        final QueryResult result = query("tdigest(10ms)", MetricType.DISTRIBUTION_POINTS);
+        final QueryResult result =
+            query(query.newQueryFromString("tdigest(10ms)"),
+                builder -> {
+                },
+                MetricType.DISTRIBUTION_POINTS,
+                true);
         final int numberSeries = 2; // s1 and s2
         final int datapointCount = 3;
         final long expectedCadence = 10L;
@@ -217,7 +233,12 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
 
     @Test
     public void testDistributedTdigestAggregation() throws Exception {
-        final QueryResult result = query("tdigest(10ms) by diff", MetricType.DISTRIBUTION_POINTS);
+        final QueryResult result =
+            query(query.newQueryFromString("tdigest(10ms) by diff"),
+                builder -> {
+                },
+                MetricType.DISTRIBUTION_POINTS,
+                true);
         final int expectedGroupCount = 6;
         final int numberSeries = 1;
         final int datapointCount = 2;
@@ -241,11 +262,43 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
         validateStatAccuracy(mapRes);
     }
 
+    @Test
+    public void testDistributionWithNoAggregation() throws Exception {
+        final int expectedGroupCount = 2; // m1 and m2
+        final QueryResult result =
+            query(query.newQueryFromString("empty"),
+                builder -> {
+                },
+                MetricType.DISTRIBUTION_POINTS,
+                false);
+
+        assertEquals(expectedGroupCount,result.getGroups().size());
+
+        //Validate record count
+        for(ShardedResultGroup group : result.getGroups()) {
+            List<Point> metrics = group.getMetrics().getDataAs(Point.class);
+            metrics.forEach(p-> assertEquals(RECORD_COUNT, p.getValue(),0));
+        }
+    }
+
+    @Test
+    public void testbasicWithNoDistribution() throws Exception {
+        final int expectedGroupCount = 2; // m1 and m2
+        final QueryResult result =
+            query(query.newQueryFromString("empty"),
+                builder -> {
+                },
+                MetricType.POINT,
+                false);
+
+        assertEquals(expectedGroupCount,result.getGroups().size());
+    }
+
 
 
     @Test
     public void basicQueryTest() throws Exception {
-        final QueryResult result = query("sum(10ms)", MetricType.POINT);
+        final QueryResult result = query("sum(10ms)");
 
         // check the number of ShardedResultGroup
         assertEquals(1,result.getGroups().size());
@@ -264,7 +317,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
 
     @Test
     public void distributedQueryTest() throws Exception {
-        final QueryResult result = query("sum(10ms) by shared", MetricType.POINT);
+        final QueryResult result = query("sum(10ms) by shared");
 
         final Set<MetricCollection> m = getResults(result);
         final List<Long> cadences = getCadences(result);
@@ -276,7 +329,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
 
     @Test
     public void distributedQueryTraceTest() throws Exception {
-        final QueryResult result = query("sum(10ms) by shared", MetricType.POINT);
+        final QueryResult result = query("sum(10ms) by shared");
 
         // Verify that the top level QueryTrace is for CoreQueryManager
         assertThat(result.getTrace(), hasIdentifier(equalTo(CoreQueryManager.QUERY)));
@@ -296,7 +349,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
 
     @Test
     public void distributedDifferentQueryTest() throws Exception {
-        final QueryResult result = query("sum(10ms) by diff", MetricType.POINT);
+        final QueryResult result = query("sum(10ms) by diff");
 
         // check the number of ShardedResultGroup
         assertEquals(2,result.getGroups().size());
@@ -316,7 +369,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
 
     @Test
     public void distributedFilterQueryTest() throws Exception {
-        final QueryResult result = query("average(10ms) by * | topk(2) | bottomk(1) | sum(10ms)", MetricType.POINT);
+        final QueryResult result = query("average(10ms) by * | topk(2) | bottomk(1) | sum(10ms)");
 
         final Set<MetricCollection> m = getResults(result);
         final List<Long> cadences = getCadences(result);
@@ -330,7 +383,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
         final QueryResult result =
             query("average(10ms) by * | topk(2) | bottomk(1) | sum(10ms)", builder -> {
                 builder.features(Optional.empty());
-            }, MetricType.POINT);
+            });
 
         final Set<MetricCollection> m = getResults(result);
         final List<Long> cadences = getCadences(result);
@@ -344,7 +397,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
     public void pointsAboveTest() throws Exception {
         final QueryResult result = query("pointsabove(2) by *", builder -> {
             builder.features(Optional.empty());
-        }, MetricType.POINT);
+        });
 
         final Set<MetricCollection> m = getResults(result);
         final List<Long> cadences = getCadences(result);
@@ -357,7 +410,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
     public void pointsBelowTest() throws Exception {
         final QueryResult result = query("pointsbelow(3) by *", builder -> {
             builder.features(Optional.empty());
-        }, MetricType.POINT);
+        });
 
         final Set<MetricCollection> m = getResults(result);
         final List<Long> cadences = getCadences(result);
@@ -371,7 +424,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
     public void deltaQueryTest() throws Exception {
         final QueryResult result = query("delta", builder -> {
             builder.features(Optional.empty());
-        }, MetricType.POINT);
+        });
 
         final Set<MetricCollection> m = getResults(result);
         final List<Long> cadences = getCadences(result);
@@ -382,7 +435,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
 
     @Test
     public void distributedDeltaQueryTest() throws Exception {
-        final QueryResult result = query("max | delta", MetricType.POINT);
+        final QueryResult result = query("max | delta");
 
         final Set<MetricCollection> m = getResults(result);
         final List<Long> cadences = getCadences(result);
@@ -395,7 +448,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
     public void deltaPerSecondQueryTest() throws Exception {
         final QueryResult result = query("deltaPerSecond", builder -> {
             builder.features(Optional.empty());
-        }, MetricType.POINT);
+        });
 
         final Set<MetricCollection> m = getResults(result);
         final List<Long> cadences = getCadences(result);
@@ -406,7 +459,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
 
     @Test
     public void distributedDeltaPerSecondQueryTest() throws Exception {
-        final QueryResult result = query("max | deltaPerSecond", MetricType.POINT);
+        final QueryResult result = query("max | deltaPerSecond");
 
         final Set<MetricCollection> m = getResults(result);
         final List<Long> cadences = getCadences(result);
@@ -417,7 +470,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
 
     @Test
     public void distributedDeltaPerSecondWithNoNegativeQueryTest() throws Exception {
-        final QueryResult result = query("max | deltaPerSecond | notNegative ", MetricType.POINT);
+        final QueryResult result = query("max | deltaPerSecond | notNegative ");
 
         final Set<MetricCollection> m = getResults(result);
         final List<Long> cadences = getCadences(result);
@@ -429,7 +482,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
 
     @Test
     public void filterLastQueryTest() throws Exception {
-        final QueryResult result = query("average(10ms) by * | topk(2) | bottomk(1)", MetricType.POINT);
+        final QueryResult result = query("average(10ms) by * | topk(2) | bottomk(1)");
 
         final Set<MetricCollection> m = getResults(result);
         final List<Long> cadences = getCadences(result);
@@ -442,7 +495,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
     public void cardinalityTest() throws Exception {
         assumeTrue(cardinalitySupport);
 
-        final QueryResult result = query("cardinality(10ms)", MetricType.POINT);
+        final QueryResult result = query("cardinality(10ms)");
 
         final Set<MetricCollection> m = getResults(result);
         final List<Long> cadences = getCadences(result);
@@ -456,7 +509,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
         assumeTrue(cardinalitySupport);
 
         // TODO: support native booleans in expressions
-        final QueryResult result = query("cardinality(10ms, method=hllp(includeKey=\"true\"))", MetricType.POINT);
+        final QueryResult result = query("cardinality(10ms, method=hllp(includeKey=\"true\"))");
 
         final Set<MetricCollection> m = getResults(result);
         final List<Long> cadences = getCadences(result);
@@ -475,7 +528,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
     public  void testGroupLimit() throws Exception {
         final QueryResult result = query("*", builder -> {
             builder.options(Optional.of(QueryOptions.builder().groupLimit(1L).build()));
-        }, MetricType.POINT);
+        });
 
         assertEquals(0, result.getErrors().size());
         assertEquals(ResultLimits.of(ResultLimit.GROUP), result.getLimits());
@@ -499,7 +552,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
     private void testDataLimit(final MetricType metricType) throws Exception {
         final QueryResult result = query("*", builder -> {
             builder.options(Optional.of(QueryOptions.builder().dataLimit(1L).build()));
-        }, metricType);
+        });
 
         // quota limits are always errors
         assertEquals(2, result.getErrors().size());
@@ -518,7 +571,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
         final QueryResult result = query("*", builder -> {
             builder.options(
                 Optional.of(QueryOptions.builder().seriesLimit(0L).failOnLimits(true).build()));
-        }, metricType);
+        });
 
         assertEquals(2, result.getErrors().size());
 
@@ -536,7 +589,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
         final QueryResult result = query("*", builder -> {
             builder.options(
                 Optional.of(QueryOptions.builder().groupLimit(0L).failOnLimits(true).build()));
-        }, metricType);
+        });
 
         assertEquals(2, result.getErrors().size());
 
@@ -554,7 +607,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
     private void testAggregationLimit(final MetricType metricType, final String query) throws Exception {
         final QueryResult result = query(query, builder -> {
             builder.options(Optional.of(QueryOptions.builder().aggregationLimit(1L).build()));
-        }, metricType);
+        });
 
         // quota limits are always errors
         assertEquals(2, result.getErrors().size());
@@ -599,7 +652,7 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
 
 
     private void validateStatAccuracy(final Map<Long,Double> resMap){
-        // validate that error rate is less than 2/100 for each datapoint.
+
         double expected = randDataset1.getDataStat().get(99);
         double actual = resMap.get(10L);
         assertTrue( errorRate(expected, actual) <= EXPECTED_ERROR_RATE);

--- a/heroic-dist/src/test/java/com/spotify/heroic/HeroicDistributionGenerator.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/HeroicDistributionGenerator.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import org.apache.commons.math3.distribution.ParetoDistribution;
 
 
@@ -63,15 +64,23 @@ public class HeroicDistributionGenerator {
 
 
     public static class Data {
-        static List<Double> getRandomData(int count) {
+        static List<Long> getParetoData(int count) {
             ParetoDistribution pareto = new ParetoDistribution(5, 1);
-            List<Double> list = new ArrayList<>();
+            List<Long> list = new ArrayList<>();
             while (count-- > 0) {
-                list.add(pareto.sample());
+                list.add((long)pareto.sample());
             }
             return list;
         }
+
+       static List<Double> getRandomData( int size){
+            final Random rand = new Random();
+            List<Double> list = new ArrayList<>();
+            while (size-- > 0) {
+                double val = rand.nextDouble() ;
+                list.add(Math.abs(val));
+            }
+            return  list;
+        }
     }
-
-
 }

--- a/heroic-dist/src/test/java/com/spotify/heroic/RandomData.kt
+++ b/heroic-dist/src/test/java/com/spotify/heroic/RandomData.kt
@@ -2,6 +2,6 @@ package com.spotify.heroic
 
 internal data class RandomData(
         val randomData: List<Double>?,
-        val dataStat : Map<Integer, Double>?
+        val dataStat : Map<Int, Double>?
 )
 


### PR DESCRIPTION
1. Add a new group combiner to handle simple tdigest query
  This combiner handles query that doesn't include aggregation clause.
  Query will return the record count in each distributionPoint instead of a binary data.

2. Refactor DistributedCombiner. 

3. Add integration test to validate TdigestBucket thread safety

4. Add addition integration test  for tdigest

6. Remove lock free implementation of TdigestBucket .


**Sample Query** : 
1. curl --location --request POST ''http://localhost:8081/query/metrics'' --header 'Content-Type: application/json' --data-raw '{
 "source":"distributionPoints", "range": {"type": "relative", "unit": "DAYS", "value": 30},
  "filter": ["and", ["=", "run", "17716d49eab"], ["=", "metric_type", "distribution"]]
}'
return datapoint count in each distributionPoint and -1 if batch is empty.


2. 
curl --location --request POST 'http://localhost:8081/query/metrics' --header 'Content-Type: application/json' --data-raw '{
  "source":"distributionPoints","features":["com.spotify.heroic.distributed_aggregations"], "range": {"type": "relative", "unit": "DAYS", "value": 30},
  "filter": ["and", ["=", "run", "17716d49eab"], ["=", "metric_type", "distribution"]], "aggregation": { "type": "group", "of": ["site"], "each": { "type": "tdigest" }}
}'
merge and compute default percentile ( P99, p50 and p75)



  