### PR TITLE
Dynamic Metadata Read Indices 

### DIFF
--- a/docs/content/_docs/config.md
+++ b/docs/content/_docs/config.md
@@ -655,6 +655,9 @@ maxReadIndices: <int> default = 2
 # Maximum indices to write to at a time. Minumum of 1.
 maxWriteIndices: <int> default = 1
 
+# Support dynamically determining number of indices to read based upon the range of a query
+supportDynamicMaxReadIndices: <boolean> default = false
+
 # Pattern to use when creating an index. The pattern must contain a single '%s' that will be
 # replaced with the base time stamp of the index.
 pattern: <string> default = heroic-%s

--- a/heroic-dist/src/main/java/com/spotify/heroic/profile/ElasticsearchMetadataProfile.java
+++ b/heroic-dist/src/main/java/com/spotify/heroic/profile/ElasticsearchMetadataProfile.java
@@ -48,6 +48,8 @@ public class ElasticsearchMetadataProfile extends HeroicProfileBase {
             .map(index::pattern);
         params.getDuration("interval")
             .map(index::interval);
+        params.getBoolean("supportDynamicReadIndices")
+            .map(index::dynamicMaxReadIndices);
 
         final ConnectionModule.Builder connection = ConnectionModule.builder().index(index.build());
 

--- a/heroic-dist/src/main/java/com/spotify/heroic/profile/ElasticsearchMetadataProfile.java
+++ b/heroic-dist/src/main/java/com/spotify/heroic/profile/ElasticsearchMetadataProfile.java
@@ -48,8 +48,10 @@ public class ElasticsearchMetadataProfile extends HeroicProfileBase {
             .map(index::pattern);
         params.getDuration("interval")
             .map(index::interval);
-        params.getBoolean("supportDynamicReadIndices")
+        params.getBoolean("supportDynamicMaxReadIndices")
             .map(index::dynamicMaxReadIndices);
+        params.getInteger("maxReadIndices")
+            .map(index::maxReadIndices);
 
         final ConnectionModule.Builder connection = ConnectionModule.builder().index(index.build());
 

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/IndexMapping.kt
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/IndexMapping.kt
@@ -34,7 +34,6 @@ import org.elasticsearch.action.search.SearchRequest
 interface IndexMapping {
     val settings: Map<String, Any>
     val template: String
-    val dynamicMaxReadIndices: Boolean
 
     @Throws(NoIndexSelectedException::class)
     fun readIndices(type: String): Array<String>

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/IndexMapping.kt
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/IndexMapping.kt
@@ -34,12 +34,10 @@ import org.elasticsearch.action.search.SearchRequest
 interface IndexMapping {
     val settings: Map<String, Any>
     val template: String
+    val dynamicMaxReadIndices: Boolean
 
     @Throws(NoIndexSelectedException::class)
     fun readIndices(type: String): Array<String>
-
-    @Throws(NoIndexSelectedException::class)
-    fun readIndicesInRange(type: String, endRange: Long): Array<String>
 
     @Throws(NoIndexSelectedException::class)
     fun writeIndices(type: String): Array<String>
@@ -48,13 +46,7 @@ interface IndexMapping {
     fun search(type: String): SearchRequest
 
     @Throws(NoIndexSelectedException::class)
-    fun searchInRange(type: String, endRange: Long): SearchRequest
-
-    @Throws(NoIndexSelectedException::class)
     fun count(type: String): SearchRequest
-
-    @Throws(NoIndexSelectedException::class)
-    fun countInRange(type:String, endRange: Long): SearchRequest
 
     /**
      * Create a delete request.

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/IndexMapping.kt
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/IndexMapping.kt
@@ -39,13 +39,22 @@ interface IndexMapping {
     fun readIndices(type: String): Array<String>
 
     @Throws(NoIndexSelectedException::class)
+    fun readIndicesInRange(type: String, endRange: Long): Array<String>
+
+    @Throws(NoIndexSelectedException::class)
     fun writeIndices(type: String): Array<String>
 
     @Throws(NoIndexSelectedException::class)
     fun search(type: String): SearchRequest
 
     @Throws(NoIndexSelectedException::class)
+    fun searchInRange(type: String, endRange: Long): SearchRequest
+
+    @Throws(NoIndexSelectedException::class)
     fun count(type: String): SearchRequest
+
+    @Throws(NoIndexSelectedException::class)
+    fun countInRange(type:String, endRange: Long): SearchRequest
 
     /**
      * Create a delete request.

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/RotatingIndexMapping.kt
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/RotatingIndexMapping.kt
@@ -40,15 +40,15 @@ private val OPTIONS = IndicesOptions.fromOptions(
 
 data class RotatingIndexMapping(
     @JsonProperty("interval") private val intervalDuration: Duration = DEFAULT_INTERVAL,
-    @JsonProperty("supportDynamicReadIndices") private val supportDynamicReadIndices: Boolean = DEFAULT_DYNAMIC_MAX_READ_INDICES,
-    private val maxReadIndices: Int = DEFAULT_MAX_READ_INDICES,
+    @JsonProperty("supportDynamicMaxReadIndices") private val supportDynamicMaxReadIndices: Boolean = DEFAULT_DYNAMIC_MAX_READ_INDICES,
+    @JsonProperty("maxReadIndices") private val maxReadIndices: Int = DEFAULT_MAX_READ_INDICES,
     private val maxWriteIndices: Int = DEFAULT_MAX_WRITE_INDICES,
     private val pattern: String = DEFAULT_PATTERN,
     override val settings: Map<String, Any> = emptyMap()
 ): IndexMapping {
     private val interval = intervalDuration.convert(TimeUnit.MILLISECONDS)
     override val template = pattern.format("*")
-    override val dynamicMaxReadIndices = supportDynamicReadIndices
+    val dynamicMaxReadIndicesSupport = supportDynamicMaxReadIndices
 
     private fun indices(maxIndices: Int, now: Long, type: String): Array<String> {
         val curr = now - (now % interval)

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/SingleIndexMapping.kt
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/SingleIndexMapping.kt
@@ -42,12 +42,24 @@ data class SingleIndexMapping(
         return arrayOf(getFullIndexName(type))
     }
 
+    override fun readIndicesInRange(type: String, endRange: Long): Array<String> {
+        TODO("Not yet implemented")
+    }
+
+    override fun searchInRange(type: String, endRange: Long): SearchRequest {
+        TODO("Not yet implemented")
+    }
+
     override fun search(type: String): SearchRequest {
         return SearchRequest(getFullIndexName(type))
     }
 
     override fun count(type: String): SearchRequest {
         return search(type).source(SearchSourceBuilder().size(0))
+    }
+
+    override fun countInRange(type: String, endRange: Long): SearchRequest {
+        TODO("Not yet implemented")
     }
 
     override fun delete(type: String, id: String): List<DeleteRequest> {

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/SingleIndexMapping.kt
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/SingleIndexMapping.kt
@@ -42,24 +42,12 @@ data class SingleIndexMapping(
         return arrayOf(getFullIndexName(type))
     }
 
-    override fun readIndicesInRange(type: String, endRange: Long): Array<String> {
-        TODO("Not yet implemented")
-    }
-
-    override fun searchInRange(type: String, endRange: Long): SearchRequest {
-        TODO("Not yet implemented")
-    }
-
     override fun search(type: String): SearchRequest {
         return SearchRequest(getFullIndexName(type))
     }
 
     override fun count(type: String): SearchRequest {
         return search(type).source(SearchSourceBuilder().size(0))
-    }
-
-    override fun countInRange(type: String, endRange: Long): SearchRequest {
-        TODO("Not yet implemented")
     }
 
     override fun delete(type: String, id: String): List<DeleteRequest> {

--- a/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/index/RotatingIndexMappingTest.java
+++ b/heroic-elasticsearch-utils/src/test/java/com/spotify/heroic/elasticsearch/index/RotatingIndexMappingTest.java
@@ -18,7 +18,7 @@ public class RotatingIndexMappingTest {
 
     @Before
     public void setup() {
-        rotating = new RotatingIndexMapping(interval, maxReadIndices, maxWriteIndices, pattern,
+        rotating = new RotatingIndexMapping(interval, true, maxReadIndices, maxWriteIndices, pattern,
             new HashMap<>());
     }
 
@@ -26,6 +26,12 @@ public class RotatingIndexMappingTest {
     public void testReadIndex() throws NoIndexSelectedException {
         final String[] indices = rotating.readIndices(8000, "typeA");
         assertArrayEquals(new String[]{"index-typeA-8000", "index-typeA-7000"}, indices);
+    }
+
+    @Test
+    public void testReadIndexInRange() throws NoIndexSelectedException {
+        final String[] indices = rotating.readIndicesInRange(5000, "typeA", 1000);
+        assertArrayEquals(new String[]{"index-typeA-5000", "index-typeA-4000", "index-typeA-3000", "index-typeA-2000", "index-typeA-1000"}, indices);
     }
 
     @Test

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/ElasticsearchMetadataModule.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/ElasticsearchMetadataModule.java
@@ -99,7 +99,6 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
     private final boolean configure;
     private final int scrollSize;
     private final boolean indexResourceIdentifiers;
-    private final boolean dynamicMaxReadIndices;
 
     private static Supplier<BackendType> defaultSetup = MetadataBackendKV::backendType;
 
@@ -132,12 +131,12 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
         @JsonProperty("backendType") Optional<String> backendType,
         @JsonProperty("configure") Optional<Boolean> configure,
         @JsonProperty("scrollSize") Optional<Integer> scrollSize,
-        @JsonProperty("indexResourceIdentifiers") Optional<Boolean> indexResourceIdentifiers,
-        @JsonProperty("dynamicMaxReadIndices") Optional<Boolean> dynamicMaxReadIndices
+        @JsonProperty("indexResourceIdentifiers") Optional<Boolean> indexResourceIdentifiers
     ) {
         this.id = id;
         this.groups = groups.orElseGet(Groups::empty).or(DEFAULT_GROUP);
         this.connection = connection.orElseGet(ConnectionModule::buildDefault);
+
         this.writesPerSecond = writesPerSecond.orElse(DEFAULT_WRITES_PER_SECOND);
         this.rateLimitSlowStartSeconds =
             rateLimitSlowStartSeconds.orElse(DEFAULT_RATE_LIMIT_SLOW_START_SECONDS);
@@ -157,7 +156,6 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
             backendType.flatMap(bt -> ofNullable(backendTypes.get(bt))).orElse(defaultSetup);
         this.configure = configure.orElse(false);
         this.indexResourceIdentifiers = indexResourceIdentifiers.orElse(false);
-        this.dynamicMaxReadIndices = dynamicMaxReadIndices.orElse(false);
     }
 
     @Override
@@ -259,13 +257,6 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
 
         @Provides
         @ElasticsearchScope
-        @Named("dynamicMaxReadIndices")
-        public boolean dynamicMaxReadIndices() {
-            return dynamicMaxReadIndices;
-        }
-
-        @Provides
-        @ElasticsearchScope
         public RateLimitedCache<Pair<String, HashCode>> writeCache(HeroicReporter reporter) {
             final Cache<Pair<String, HashCode>, Boolean> cache = CacheBuilder
                 .newBuilder()
@@ -327,7 +318,6 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
         private Optional<Boolean> configure = empty();
         private Optional<Integer> scrollSize = empty();
         private Optional<Boolean> indexResourceIdentifiers = empty();
-        private Optional<Boolean> dynamicMaxReadIndices = empty();
 
         public Builder id(final String id) {
             checkNotNull(id, "id");
@@ -411,11 +401,6 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
             return this;
         }
 
-        public Builder dynamicMaxReadIndices(final boolean dynamicMaxReadIndices) {
-            this.dynamicMaxReadIndices = of(dynamicMaxReadIndices);
-            return this;
-        }
-
         public ElasticsearchMetadataModule build() {
             return new ElasticsearchMetadataModule(
                 id,
@@ -432,8 +417,7 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
                 backendType,
                 configure,
                 scrollSize,
-                indexResourceIdentifiers,
-                dynamicMaxReadIndices
+                indexResourceIdentifiers
             );
         }
     }

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/ElasticsearchMetadataModule.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/ElasticsearchMetadataModule.java
@@ -136,7 +136,6 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
         this.id = id;
         this.groups = groups.orElseGet(Groups::empty).or(DEFAULT_GROUP);
         this.connection = connection.orElseGet(ConnectionModule::buildDefault);
-
         this.writesPerSecond = writesPerSecond.orElse(DEFAULT_WRITES_PER_SECOND);
         this.rateLimitSlowStartSeconds =
             rateLimitSlowStartSeconds.orElse(DEFAULT_RATE_LIMIT_SLOW_START_SECONDS);

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/ElasticsearchMetadataModule.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/ElasticsearchMetadataModule.java
@@ -99,6 +99,7 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
     private final boolean configure;
     private final int scrollSize;
     private final boolean indexResourceIdentifiers;
+    private final boolean dynamicMaxReadIndices;
 
     private static Supplier<BackendType> defaultSetup = MetadataBackendKV::backendType;
 
@@ -131,7 +132,8 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
         @JsonProperty("backendType") Optional<String> backendType,
         @JsonProperty("configure") Optional<Boolean> configure,
         @JsonProperty("scrollSize") Optional<Integer> scrollSize,
-        @JsonProperty("indexResourceIdentifiers") Optional<Boolean> indexResourceIdentifiers
+        @JsonProperty("indexResourceIdentifiers") Optional<Boolean> indexResourceIdentifiers,
+        @JsonProperty("dynamicMaxReadIndices") Optional<Boolean> dynamicMaxReadIndices
     ) {
         this.id = id;
         this.groups = groups.orElseGet(Groups::empty).or(DEFAULT_GROUP);
@@ -155,6 +157,7 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
             backendType.flatMap(bt -> ofNullable(backendTypes.get(bt))).orElse(defaultSetup);
         this.configure = configure.orElse(false);
         this.indexResourceIdentifiers = indexResourceIdentifiers.orElse(false);
+        this.dynamicMaxReadIndices = dynamicMaxReadIndices.orElse(false);
     }
 
     @Override
@@ -256,6 +259,13 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
 
         @Provides
         @ElasticsearchScope
+        @Named("dynamicMaxReadIndices")
+        public boolean dynamicMaxReadIndices() {
+            return dynamicMaxReadIndices;
+        }
+
+        @Provides
+        @ElasticsearchScope
         public RateLimitedCache<Pair<String, HashCode>> writeCache(HeroicReporter reporter) {
             final Cache<Pair<String, HashCode>, Boolean> cache = CacheBuilder
                 .newBuilder()
@@ -317,6 +327,7 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
         private Optional<Boolean> configure = empty();
         private Optional<Integer> scrollSize = empty();
         private Optional<Boolean> indexResourceIdentifiers = empty();
+        private Optional<Boolean> dynamicMaxReadIndices = empty();
 
         public Builder id(final String id) {
             checkNotNull(id, "id");
@@ -400,6 +411,11 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
             return this;
         }
 
+        public Builder dynamicMaxReadIndices(final boolean dynamicMaxReadIndices) {
+            this.dynamicMaxReadIndices = of(dynamicMaxReadIndices);
+            return this;
+        }
+
         public ElasticsearchMetadataModule build() {
             return new ElasticsearchMetadataModule(
                 id,
@@ -416,7 +432,8 @@ public final class ElasticsearchMetadataModule implements MetadataModule, Dynami
                 backendType,
                 configure,
                 scrollSize,
-                indexResourceIdentifiers
+                indexResourceIdentifiers,
+                dynamicMaxReadIndices
             );
         }
     }

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
@@ -330,10 +330,11 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
 
             SearchRequest request;
 
-            if(c.getIndex() instanceof RotatingIndexMapping && c.getIndex().getDynamicMaxReadIndices()) {
-                final long start = filter.getRange().getStart();
-                RotatingIndexMapping i = (RotatingIndexMapping) c.getIndex();
-                request = i.countInRange(METADATA_TYPE, start);
+            if (c.getIndex() instanceof RotatingIndexMapping &&
+                ((RotatingIndexMapping) c.getIndex()).getDynamicMaxReadIndicesSupport()) {
+                    final long start = filter.getRange().getStart();
+                    RotatingIndexMapping i = (RotatingIndexMapping) c.getIndex();
+                    request = i.countInRange(METADATA_TYPE, start);
             } else {
                 request = c.getIndex().count(METADATA_TYPE);
             }
@@ -430,10 +431,11 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
           final QueryBuilder f = filter(request.getFilter());
 
           SearchRequest searchRequest;
-          if(c.getIndex() instanceof RotatingIndexMapping && c.getIndex().getDynamicMaxReadIndices()) {
-              final long start = request.getRange().getStart();
-              RotatingIndexMapping ri = (RotatingIndexMapping) c.getIndex();
-              searchRequest = ri.searchInRange(METADATA_TYPE, start);
+          if (c.getIndex() instanceof RotatingIndexMapping &&
+              ((RotatingIndexMapping) c.getIndex()).getDynamicMaxReadIndicesSupport()) {
+                final long start = request.getRange().getStart();
+                RotatingIndexMapping ri = (RotatingIndexMapping) c.getIndex();
+                searchRequest = ri.searchInRange(METADATA_TYPE, start);
           } else {
               searchRequest = c.getIndex().search(METADATA_TYPE);
           }
@@ -504,10 +506,11 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
 
         return doto(c -> {
             SearchRequest request;
-            if(c.getIndex() instanceof RotatingIndexMapping && c.getIndex().getDynamicMaxReadIndices()) {
-                final long start = seriesRequest.getRange().getStart();
-                RotatingIndexMapping ri = (RotatingIndexMapping) c.getIndex();
-                request = ri.searchInRange(METADATA_TYPE, start);
+            if (c.getIndex() instanceof RotatingIndexMapping &&
+                ((RotatingIndexMapping) c.getIndex()).getDynamicMaxReadIndicesSupport()) {
+                    final long start = seriesRequest.getRange().getStart();
+                    RotatingIndexMapping ri = (RotatingIndexMapping) c.getIndex();
+                    request = ri.searchInRange(METADATA_TYPE, start);
             } else {
                 request =
                     c.getIndex().search(METADATA_TYPE).allowPartialSearchResults(false);
@@ -581,10 +584,11 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
 
         return observer -> connection.doto(c -> {
             SearchRequest request;
-            if(c.getIndex() instanceof RotatingIndexMapping && c.getIndex().getDynamicMaxReadIndices()) {
-                final long start = findRequest.getRange().getStart();
-                RotatingIndexMapping ri = (RotatingIndexMapping) c.getIndex();
-                request = ri.searchInRange(METADATA_TYPE, start);
+            if (c.getIndex() instanceof RotatingIndexMapping &&
+                ((RotatingIndexMapping) c.getIndex()).getDynamicMaxReadIndicesSupport()) {
+                    final long start = findRequest.getRange().getStart();
+                    RotatingIndexMapping ri = (RotatingIndexMapping) c.getIndex();
+                    request = ri.searchInRange(METADATA_TYPE, start);
             } else {
                 request = c.getIndex().search(METADATA_TYPE).scroll(SCROLL_TIME);
             }


### PR DESCRIPTION
Introduce support for RotatingIndexMapping to limit the number of elasticsearch metadata indices read based upon the range of a heroic query. If the newly introduced config flag is set to `true`, the number of read indices is dynamically determined based upon the rotation interval and the range of the query.

This PR also makes the non-dynamic `maxReadIndices` configurable so as to properly support `delete`. This variable should be set to the maximum number of queryable indices that could possibly exist in Elasticsearch based upon the rotation interval and ILM policy. 

Closes #745. 