### PR TITLE
Remove legacy source input, optional metricType query input for testing

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/Query.kt
+++ b/heroic-component/src/main/java/com/spotify/heroic/Query.kt
@@ -29,10 +29,9 @@ import java.util.*
 
 data class Query(
     val aggregation: Optional<Aggregation>,
-    val source: Optional<MetricType>,
+    val metricType: Optional<MetricType>, // points or distribution points for testing
     val range: Optional<QueryDateRange>,
     val filter: Optional<Filter>,
     val options: Optional<QueryOptions>,
-    // set of experimental features to enable
-    val features: Optional<FeatureSet>
+    val features: Optional<FeatureSet> // set of experimental features to enable
 )

--- a/heroic-component/src/main/java/com/spotify/heroic/QueryBuilder.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/QueryBuilder.java
@@ -40,11 +40,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class QueryBuilder {
-    private Optional<MetricType> source = Optional.empty();
     private Optional<Map<String, String>> tags = Optional.empty();
     private Optional<String> key = Optional.empty();
     private Optional<Filter> filter = Optional.empty();
     private Optional<QueryDateRange> range = Optional.empty();
+    private Optional<MetricType> metricType = Optional.empty();
     private Optional<Aggregation> aggregation = Optional.empty();
     private Optional<QueryOptions> options = Optional.empty();
     private Optional<JsonNode> clientContext = Optional.empty();
@@ -98,16 +98,20 @@ public class QueryBuilder {
     }
 
     /**
+     * Specify a metricType to use, if none are specified it will be determined in CoreQueryManager.
+     */
+    public QueryBuilder metricType(final Optional<MetricType> metricType) {
+        checkNotNull(metricType, "metricType must not be null");
+        this.metricType = pickOptional(this.metricType, metricType);
+        return this;
+    }
+
+    /**
      * Specify an aggregation to use.
      */
     public QueryBuilder aggregation(final Optional<Aggregation> aggregation) {
         checkNotNull(aggregation, "aggregation must not be null");
         this.aggregation = pickOptional(this.aggregation, aggregation);
-        return this;
-    }
-
-    public QueryBuilder source(Optional<MetricType> source) {
-        this.source = source;
         return this;
     }
 
@@ -146,7 +150,7 @@ public class QueryBuilder {
     }
 
     public Query build() {
-        return new Query(aggregation, source, range, legacyFilter(), options, features);
+        return new Query(aggregation, metricType, range, legacyFilter(), options, features);
     }
 
 

--- a/heroic-component/src/main/java/com/spotify/heroic/grammar/QueryExpression.kt
+++ b/heroic-component/src/main/java/com/spotify/heroic/grammar/QueryExpression.kt
@@ -29,7 +29,7 @@ import java.util.*
 data class QueryExpression(
     @JvmField val context: Context,
     val select: Optional<Expression>,
-    val source: Optional<MetricType>,
+    val metricType: Optional<MetricType>,
     val range: Optional<RangeExpression>,
     val filter: Optional<Filter>,
     val with: Map<String, Expression>,
@@ -41,7 +41,7 @@ data class QueryExpression(
         QueryExpression(
             context,
             select.map { it.eval(scope) },
-            source,
+            metricType,
             range.map { it.eval(scope) },
             filter,
             Expression.evalMap(with, scope),
@@ -52,6 +52,6 @@ data class QueryExpression(
         return visitor.visitQuery(this)
     }
 
-    override fun toRepr() = """{select: $select source: $source, 
+    override fun toRepr() = """{select: $select metricType: $metricType, 
         range: $range, filter: $filter, with: $with, as: $asExpression}""".trimIndent()
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/FetchData.kt
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/FetchData.kt
@@ -47,7 +47,7 @@ data class FetchData(
     }
 
     data class Request(
-        val type: MetricType,
+        val metricType: MetricType,
         val series: Series,
         val range: DateRange,
         val options: QueryOptions

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/FullQuery.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/FullQuery.java
@@ -158,26 +158,27 @@ public abstract class FullQuery {
     public abstract static class Request {
         @JsonCreator
         public static Request create(
-            @JsonProperty("source") MetricType source,
             @JsonProperty("filter") Filter filter,
             @JsonProperty("range") DateRange range,
             @JsonProperty("aggregation") AggregationInstance aggregation,
+            @JsonProperty("metricType") MetricType metricType,
             @JsonProperty("options") QueryOptions options,
             @JsonProperty("context") QueryContext context,
             @JsonProperty("features") Features features
         ) {
             return new AutoValue_FullQuery_Request(
-                source, filter, range, aggregation, options, context, features);
+              filter, range, aggregation, metricType, options, context, features);
         }
 
-        @JsonProperty
-        public abstract MetricType source();
+
         @JsonProperty
         public abstract Filter filter();
         @JsonProperty
         public abstract DateRange range();
         @JsonProperty
         public abstract AggregationInstance aggregation();
+        @JsonProperty
+        public abstract MetricType metricType();
         @JsonProperty
         public abstract QueryOptions options();
         @JsonProperty
@@ -186,16 +187,16 @@ public abstract class FullQuery {
         public abstract Features features();
 
         public Summary summarize() {
-            return Summary.create(source(), filter(), range(), aggregation(), options());
+            return Summary.create(filter(), range(), aggregation(), metricType(), options());
         }
 
         public void hashTo(final ObjectHasher hasher) {
             hasher.putObject(getClass(), () -> {
-                hasher.putField("source", source(), hasher.enumValue());
                 hasher.putField("filter", filter(), hasher.with(Filter::hashTo));
                 hasher.putField("range", range(), hasher.with(DateRange::hashTo));
                 hasher.putField("aggregation", aggregation(),
                     hasher.with(AggregationInstance::hashTo));
+                hasher.putField("metricType", metricType(), hasher.enumValue());
                 hasher.putField("options", options(), hasher.with(QueryOptions::hashTo));
                 hasher.putField("features", features(), hasher.with(Features::hashTo));
             });
@@ -205,24 +206,24 @@ public abstract class FullQuery {
         public abstract static class Summary {
             @JsonCreator
             public static Summary create(
-                @JsonProperty("source") MetricType source,
                 @JsonProperty("filter") Filter filter,
                 @JsonProperty("range") DateRange range,
                 @JsonProperty("aggregation") AggregationInstance aggregation,
+                @JsonProperty("metricType") MetricType metricType,
                 @JsonProperty("options") QueryOptions options
             ) {
                 return new AutoValue_FullQuery_Request_Summary(
-                    source, filter, range, aggregation, options);
+                    filter, range, aggregation, metricType, options);
             }
 
-            @JsonProperty
-            abstract MetricType source();
             @JsonProperty
             abstract Filter filter();
             @JsonProperty
             abstract DateRange range();
             @JsonProperty
             abstract AggregationInstance aggregation();
+            @JsonProperty
+            abstract MetricType metricType();
             @JsonProperty
             abstract QueryOptions options();
         }

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetrics.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryMetrics.java
@@ -45,13 +45,13 @@ public abstract class QueryMetrics {
     public static QueryMetrics create(
         Optional<String> query,
         Optional<Aggregation> aggregation,
-        Optional<String> source,
+        Optional<MetricType> metricType,
         Optional<QueryDateRange> range,
         Optional<Filter> filter,
         Optional<QueryOptions> options,
         Optional<JsonNode> clientContext
     ) {
-        return legacyCreate(query, aggregation, source, range, filter, options, clientContext,
+        return legacyCreate(query, aggregation, metricType, range, filter, options, clientContext,
              Optional.empty(), Optional.empty(), Optional.empty(),
             Optional.empty(), false);
     }
@@ -60,7 +60,7 @@ public abstract class QueryMetrics {
     public static QueryMetrics legacyCreate(
         @JsonProperty("query") Optional<String> query,
         @JsonProperty("aggregation") Optional<Aggregation> aggregation,
-        @JsonProperty("source") Optional<String> source,
+        @JsonProperty("metricType") Optional<MetricType> metricType,
         @JsonProperty("range") Optional<QueryDateRange> range,
         @JsonProperty("filter") Optional<Filter> filter,
         @JsonProperty("options") Optional<QueryOptions> options,
@@ -75,9 +75,8 @@ public abstract class QueryMetrics {
 
         final Optional<Aggregation> legitAggregation = firstPresent(aggregation,
             aggregators.filter(c -> !c.isEmpty()).map(Chain::fromList));
-        final Optional<MetricType> sourceMetric = source.flatMap(MetricType::fromIdentifier);
 
-        return new AutoValue_QueryMetrics(query, legitAggregation, sourceMetric, range, filter,
+        return new AutoValue_QueryMetrics(query, legitAggregation, metricType, range, filter,
             options, clientContext, key, tags, features);
     }
 
@@ -85,8 +84,8 @@ public abstract class QueryMetrics {
     public abstract Optional<String> query();
     @JsonProperty("aggregation")
     public abstract Optional<Aggregation> aggregation();
-    @JsonProperty("source")
-    public abstract Optional<MetricType> source();
+    @JsonProperty("metricType")
+    public abstract Optional<MetricType> metricType();
     @JsonProperty("range")
     public abstract Optional<QueryDateRange> range();
     @JsonProperty("filter")
@@ -111,7 +110,7 @@ public abstract class QueryMetrics {
             .filter(filter())
             .range(range())
             .aggregation(aggregation())
-            .source(source())
+            .metricType(metricType())
             .options(options())
             .clientContext(clientContext());
 

--- a/heroic-component/src/test/java/com/spotify/heroic/grammar/QueryExpressionTest.java
+++ b/heroic-component/src/test/java/com/spotify/heroic/grammar/QueryExpressionTest.java
@@ -36,7 +36,7 @@ public class QueryExpressionTest extends AbstractExpressionTest<QueryExpression>
         final QueryExpression e = build();
 
         assertEquals(select, e.getSelect());
-        assertEquals(source, e.getSource());
+        assertEquals(source, e.getMetricType());
         assertEquals(range, e.getRange());
         assertEquals(filter, e.getFilter());
         assertEquals(with, e.getWith());

--- a/heroic-core/build.gradle
+++ b/heroic-core/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     // Default usage tracking module. Normally different module dependencies are handled in
     // heroic-dist, but defaults need to be accessible in heroic-core.
     implementation project(':heroic-usage-tracking-google-analytics')
+    implementation project(':heroic-aggregation-simple')
     
     testImplementation project(':heroic-test')
     testImplementation project(path: ':heroic-component', configuration: 'testRuntime')

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -191,6 +191,7 @@ public class LocalMetricManager implements MetricManager {
         private class Transform implements LazyTransform<FindSeries, FullQuery> {
 
             private final AggregationInstance aggregation;
+            private final MetricType metricType;
             private final boolean failOnLimits;
             private final OptionalLimit seriesLimit;
             private final OptionalLimit groupLimit;
@@ -201,7 +202,6 @@ public class LocalMetricManager implements MetricManager {
             private final QueryOptions options;
             private final DataInMemoryReporter dataInMemoryReporter;
             private final Span parentSpan;
-            private final MetricType source;
 
             private Transform(
                 final FullQuery.Request request,
@@ -213,9 +213,9 @@ public class LocalMetricManager implements MetricManager {
                 final Span parentSpan
             ) {
                 this.aggregation = request.aggregation();
+                this.metricType = request.metricType();
                 this.range = request.range();
                 this.options = request.options();
-                this.source = request.source();
 
                 this.failOnLimits = failOnLimits;
                 this.seriesLimit = seriesLimit;
@@ -322,7 +322,7 @@ public class LocalMetricManager implements MetricManager {
 
                         fetchSeries.addAnnotation(series.toString());
                         fetches.add(() -> metricBackend.fetch(
-                            new FetchData.Request(source, series, range, options),
+                            new FetchData.Request(metricType, series, range, options),
                             quotaWatcher,
                             mcr -> collector.acceptMetricsCollection(series, mcr),
                             fetchSeries

--- a/heroic-core/src/main/java/com/spotify/heroic/shell/task/Fetch.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/shell/task/Fetch.java
@@ -100,7 +100,8 @@ public class Fetch implements ShellTask {
         final DateFormat point = new SimpleDateFormat("HH:mm:ss.SSS");
 
         final MetricBackendGroup readGroup = metrics.useOptionalGroup(params.group);
-        final MetricType source = MetricType.fromIdentifier(params.source).orElse(MetricType.POINT);
+
+        final MetricType metricType = params.metricType.orElse(MetricType.POINT);
 
         final QueryOptions.Builder optionsBuilder =
             QueryOptions.builder().tracing(Tracing.fromBoolean(params.tracing));
@@ -135,7 +136,7 @@ public class Fetch implements ShellTask {
         };
 
         return readGroup
-            .fetch(new FetchData.Request(source, series, range, options),
+            .fetch(new FetchData.Request(metricType, series, range, options),
                 FetchQuotaWatcher.NO_QUOTA, printMetricsCollection, BlankSpan.INSTANCE)
             .lazyTransform(handleResult);
     }
@@ -172,9 +173,9 @@ public class Fetch implements ShellTask {
         @Option(name = "-s", aliases = {"--series"}, usage = "Series to fetch", metaVar = "<json>")
         private Optional<String> series = Optional.empty();
 
-        @Option(name = "--source", aliases = {"--source"}, usage = "Source to fetch",
-            metaVar = "<events|points>")
-        private String source = MetricType.POINT.identifier();
+        @Option(name = "--metricType", aliases = {"--metricType"}, usage = "MetricType to fetch",
+            metaVar = "<MetricType.POINT|MetricType.DISTRIBUTION_POINTS>")
+        private Optional<MetricType> metricType = Optional.empty();
 
         @Option(name = "--start", usage = "Start date", metaVar = "<datetime>")
         private Optional<String> start = Optional.empty();

--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractClusterQueryIT.java
@@ -1,7 +1,5 @@
 package com.spotify.heroic;
 
-
-
 import static com.spotify.heroic.test.Matchers.containsChild;
 import static com.spotify.heroic.test.Matchers.hasIdentifier;
 import static com.spotify.heroic.test.Matchers.identifierContains;
@@ -164,7 +162,9 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
 
     public QueryResult query(final String queryString) throws Exception {
         return query(query.newQueryFromString(queryString), builder -> {
-        }, MetricType.POINT, true);
+        },
+        MetricType.POINT,
+        true);
     }
 
     public QueryResult query(final String queryString,
@@ -184,10 +184,10 @@ public abstract class AbstractClusterQueryIT extends AbstractLocalClusterIT {
         queryCount += 1;
 
         builder
-            .source(Optional.of(metricType))
+            .metricType(Optional.of(metricType))
             .rangeIfAbsent(Optional.of(new QueryDateRange.Absolute(0, 40)));
 
-        if ( isDistributed) {
+        if (isDistributed) {
             builder
                 .features(Optional.of(FeatureSet.of(Feature.DISTRIBUTED_AGGREGATIONS)));
         }

--- a/heroic-dist/src/test/java/com/spotify/heroic/AbstractConsumerIT.java
+++ b/heroic-dist/src/test/java/com/spotify/heroic/AbstractConsumerIT.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.protobuf.ByteString;
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Series;
 import com.spotify.heroic.consumer.schemas.spotify100.Version;
@@ -70,7 +69,8 @@ public abstract class AbstractConsumerIT extends AbstractSingleNodeIT {
 
             instance.inject(coreComponent -> {
                 FetchData.Request fetchDataRequest =
-                    new FetchData.Request(MetricType.DISTRIBUTION_POINTS, s1, new DateRange(0, 100),
+                    new FetchData.Request(MetricType.DISTRIBUTION_POINTS, s1, new DateRange(0,
+                     100),
                         QueryOptions.defaults());
                 return coreComponent
                     .metricManager()

--- a/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
+++ b/metric/bigtable/src/main/java/com/spotify/heroic/metric/bigtable/BigtableBackend.java
@@ -271,7 +271,7 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
         final Span parentSpan
     ) {
         return connection.doto(c -> {
-            final MetricType type = request.getType();
+            final MetricType type = request.getMetricType();
 
             if (!watcher.mayReadData()) {
                 throw new IllegalArgumentException("query violated data limit");
@@ -286,7 +286,7 @@ public class BigtableBackend extends AbstractMetricBackend implements LifeCycles
                         consumer, parentSpan);
                 default:
                     return async.resolved(new FetchData.Result(QueryTrace.of(FETCH),
-                        new QueryError("unsupported source: " + request.getType())));
+                        new QueryError("unsupported source: " + request.getMetricType())));
             }
         });
     }

--- a/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxBackend.java
+++ b/metric/datastax/src/main/java/com/spotify/heroic/metric/datastax/DatastaxBackend.java
@@ -151,7 +151,7 @@ public class DatastaxBackend extends AbstractMetricBackend implements LifeCycles
             final List<PreparedFetch> prepared =
                 c.schema.ranges(request.getSeries(), request.getRange());
 
-            if (request.getType() == MetricType.POINT) {
+            if (request.getMetricType() == MetricType.POINT) {
                 final List<AsyncFuture<FetchData>> fetches =
                     fetchDataPoints(w, limit, request.getOptions(), prepared, c);
 
@@ -166,7 +166,7 @@ public class DatastaxBackend extends AbstractMetricBackend implements LifeCycles
             }
 
             return async.resolved(new FetchData.Result(w.end(FETCH),
-                new QueryError("unsupported source: " + request.getType())));
+                new QueryError("unsupported source: " + request.getMetricType())));
         });
     }
 

--- a/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryBackend.java
+++ b/metric/memory/src/main/java/com/spotify/heroic/metric/memory/MemoryBackend.java
@@ -137,7 +137,7 @@ public class MemoryBackend extends AbstractMetricBackend {
         Span parentSpan
     ) {
         final QueryTrace.NamedWatch w = QueryTrace.watch(FETCH);
-        final MemoryKey key = new MemoryKey(request.getType(), request.getSeries().getTags());
+        final MemoryKey key = new MemoryKey(request.getMetricType(), request.getSeries().getTags());
         doFetch(key, request.getRange(), watcher, metricsConsumer);
         return async.resolved(new FetchData.Result(w.end()));
     }


### PR DESCRIPTION
`source` was a legacy query option left over from when `events` were partially supported: 
https://github.com/spotify/heroic/commit/bc533078fad161efa76001cdc4f2a6e22dcb88d5#diff-0e5dda61cc1e44c094fed3ce698715de1d3b11747d9f312df0fbf6a52f70f1fcR222

This PR gets rid of source as an input and essentially re-names it to metricType with a few updates.

Since end users don't care about what `metricType` is being used, Distributions can instead set `metricType` based on what aggregation (tdigest) is being used. 

