### PR TITLE
Implement metric and log lines when a Bigtable request times out, per x-client-id

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/common/FailureType.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/common/FailureType.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2019 Spotify AB.
+ * Copyright (c) 2015 Spotify AB.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
- * "License"): you may not use this file except in compliance
+ * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
@@ -19,12 +19,19 @@
  * under the License.
  */
 
-package com.spotify.heroic.metric
+package com.spotify.heroic.common;
 
-data class QueryError(private val error: String): RequestError {
-    constructor(e: Throwable): this(e.message ?: "unknown")
+public enum FailureType {
+    TIMEOUT("timeout"),
+    QUOTA_EXCEEDED("quota-exceeded");
 
-    override fun getError(): String {
-        return error;
+    public final String label;
+
+    private FailureType(String timeout) {
+        label = timeout;
+    }
+    @Override
+    public String toString() {
+        return this.label;
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/NodeError.kt
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/NodeError.kt
@@ -33,7 +33,7 @@ data class NodeError(
     val nodeId: UUID,
     @JsonProperty("nodeUri") val node: String,
     val tags: Map<String, String>,
-    val error: String,
+    private val error: String,
     val internal: Boolean
 ): RequestError {
     companion object {
@@ -48,5 +48,9 @@ data class NodeError(
         fun internalError(error: String): NodeError {
             return NodeError(UUID.randomUUID(), "", mapOf(), error, true)
         }
+    }
+
+    override fun getError(): String {
+        return error;
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/RequestError.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/RequestError.java
@@ -31,4 +31,5 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(value = QueryError.class, name = "query")
 })
 public interface RequestError {
+    String getError();
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/metric/ShardError.kt
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/ShardError.kt
@@ -26,7 +26,7 @@ import com.spotify.heroic.cluster.ClusterShard
 data class ShardError(
     val nodes: List<String>,
     val shard: Map<String, String>,
-    val error: String
+    private val error: String
 ): RequestError {
     companion object {
         @JvmStatic
@@ -41,5 +41,9 @@ data class ShardError(
 
             return "$message, caused by ${errorMessage(cause)}"
         }
+    }
+
+    override fun getError(): String {
+        return error;
     }
 }

--- a/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryLogger.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryLogger.java
@@ -42,10 +42,6 @@ public interface QueryLogger {
             QueryContext context, FullQuery.Request request
     );
 
-    void logBigtableQuerySuccess(
-            QueryContext context, FullQuery.Request request
-    );
-
     void logOutgoingResponseAtNode(QueryContext context, FullQuery response);
 
     void logIncomingResponseFromShard(QueryContext context, FullQuery response);

--- a/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryLogger.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/querylogging/QueryLogger.java
@@ -38,6 +38,14 @@ public interface QueryLogger {
 
     void logIncomingRequestAtNode(QueryContext context, FullQuery.Request request);
 
+    void logBigtableQueryTimeout(
+            QueryContext context, FullQuery.Request request
+    );
+
+    void logBigtableQuerySuccess(
+            QueryContext context, FullQuery.Request request
+    );
+
     void logOutgoingResponseAtNode(QueryContext context, FullQuery response);
 
     void logIncomingResponseFromShard(QueryContext context, FullQuery response);

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/MetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/MetricBackendReporter.java
@@ -25,8 +25,6 @@ import com.spotify.heroic.common.FailureType;
 import com.spotify.heroic.metric.MetricBackend;
 
 public interface MetricBackendReporter {
-    void reportClientIdSuccessCount(String clientId);
-
     void reportClientIdFailure(String clientId, FailureType failureType);
 
     MetricBackend decorate(MetricBackend backend);

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/MetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/MetricBackendReporter.java
@@ -21,9 +21,14 @@
 
 package com.spotify.heroic.statistics;
 
+import com.spotify.heroic.common.FailureType;
 import com.spotify.heroic.metric.MetricBackend;
 
 public interface MetricBackendReporter {
+    void reportClientIdSuccessCount(String clientId);
+
+    void reportClientIdFailure(String clientId, FailureType failureType);
+
     MetricBackend decorate(MetricBackend backend);
 
     DataInMemoryReporter newDataInMemoryReporter();

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
@@ -59,14 +59,11 @@ public class NoopMetricBackendReporter implements MetricBackendReporter {
     }
 
     @Override
-    public void reportClientIdSuccessCount(String clientId) {
-
-    }
+    public void reportClientIdSuccessCount(String clientId) { /* intentionally blank */ }
 
     @Override
     public void reportClientIdFailure(String clientId, FailureType failureType) {
-
-    }
+        /* intentionally blank */ }
 
     @Override
     public MetricBackend decorate(final MetricBackend backend) {

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
@@ -21,6 +21,7 @@
 
 package com.spotify.heroic.statistics.noop;
 
+import com.spotify.heroic.common.FailureType;
 import com.spotify.heroic.metric.MetricBackend;
 import com.spotify.heroic.statistics.DataInMemoryReporter;
 import com.spotify.heroic.statistics.FutureReporter;
@@ -55,6 +56,16 @@ public class NoopMetricBackendReporter implements MetricBackendReporter {
     };
 
     private NoopMetricBackendReporter() {
+    }
+
+    @Override
+    public void reportClientIdSuccessCount(String clientId) {
+
+    }
+
+    @Override
+    public void reportClientIdFailure(String clientId, FailureType failureType) {
+
     }
 
     @Override

--- a/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/statistics/noop/NoopMetricBackendReporter.java
@@ -59,9 +59,6 @@ public class NoopMetricBackendReporter implements MetricBackendReporter {
     }
 
     @Override
-    public void reportClientIdSuccessCount(String clientId) { /* intentionally blank */ }
-
-    @Override
     public void reportClientIdFailure(String clientId, FailureType failureType) {
         /* intentionally blank */ }
 

--- a/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java
@@ -38,6 +38,7 @@ import com.spotify.heroic.aggregation.BucketStrategy;
 import com.spotify.heroic.aggregation.RetainQuotaWatcher;
 import com.spotify.heroic.async.AsyncObservable;
 import com.spotify.heroic.common.DateRange;
+import com.spotify.heroic.common.FailureType;
 import com.spotify.heroic.common.Feature;
 import com.spotify.heroic.common.Features;
 import com.spotify.heroic.common.GoAwayException;
@@ -52,9 +53,12 @@ import com.spotify.heroic.common.Statistics;
 import com.spotify.heroic.metadata.FindSeries;
 import com.spotify.heroic.metadata.MetadataBackend;
 import com.spotify.heroic.metadata.MetadataManager;
+import com.spotify.heroic.metric.FetchData.Result;
+import com.spotify.heroic.metric.FullQuery.Request;
 import com.spotify.heroic.querylogging.QueryContext;
 import com.spotify.heroic.querylogging.QueryLogger;
 import com.spotify.heroic.querylogging.QueryLoggerFactory;
+import com.spotify.heroic.servlet.MandatoryClientIdFilter;
 import com.spotify.heroic.statistics.DataInMemoryReporter;
 import com.spotify.heroic.statistics.MetricBackendReporter;
 import com.spotify.heroic.tracing.EndSpanFutureReporter;
@@ -82,10 +86,19 @@ import java.util.function.Function;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.commons.lang3.NotImplementedException;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
 @MetricScope
 public class LocalMetricManager implements MetricManager {
+    // This is a constant (as opposed to inline as one might expect) in order to draw attention
+    // to the fact that this string is matched upon in other parts of the code.
+    private static final String SOME_FETCHES_FAILED_MESSAGE = "Some fetches failed (";
+
+    public static boolean matchesTimeoutMessage(String errorMessage) {
+        return errorMessage.toLowerCase().contains(SOME_FETCHES_FAILED_MESSAGE.toLowerCase());
+    }
+
     private static final Tracer tracer = io.opencensus.trace.Tracing.getTracer();
     private static final QueryTrace.Identifier QUERY =
         QueryTrace.identifier(LocalMetricManager.class, "query");
@@ -155,7 +168,7 @@ public class LocalMetricManager implements MetricManager {
 
     @Override
     public MetricBackendGroup useOptionalGroup(final Optional<String> group) {
-        return new Group(groupSet.useOptionalGroup(group), metadata.useDefaultGroup());
+        return new Group(groupSet.useOptionalGroup(group), metadata.useDefaultGroup(), reporter);
     }
 
     public String toString() {
@@ -165,11 +178,14 @@ public class LocalMetricManager implements MetricManager {
     private class Group extends AbstractMetricBackend implements MetricBackendGroup {
         private final SelectedGroup<MetricBackend> backends;
         private final MetadataBackend metadata;
+        private final MetricBackendReporter reporter;
 
-        public Group(final SelectedGroup<MetricBackend> backends, final MetadataBackend metadata) {
+        public Group(final SelectedGroup<MetricBackend> backends, final MetadataBackend metadata,
+                     MetricBackendReporter reporter) {
             super(async);
             this.backends = backends;
             this.metadata = metadata;
+            this.reporter = reporter;
         }
 
         @Override
@@ -202,6 +218,9 @@ public class LocalMetricManager implements MetricManager {
             private final QueryOptions options;
             private final DataInMemoryReporter dataInMemoryReporter;
             private final Span parentSpan;
+            private final MetricBackendReporter reporter;
+            private final String clientId;
+            private final Request request;
 
             private Transform(
                 final FullQuery.Request request,
@@ -210,12 +229,23 @@ public class LocalMetricManager implements MetricManager {
                 final OptionalLimit groupLimit,
                 final QuotaWatcher quotaWatcher,
                 final DataInMemoryReporter dataInMemoryReporter,
-                final Span parentSpan
+                final Span parentSpan,
+                final MetricBackendReporter reporter
             ) {
+                this.request = request;
                 this.aggregation = request.aggregation();
                 this.range = request.range();
                 this.options = request.options();
                 this.source = request.source();
+
+                var httpContext = request.context().httpContext();
+
+                this.clientId = httpContext.isPresent()
+                        ? httpContext
+                            .get()
+                            .getClientId()
+                            .orElse(MandatoryClientIdFilter.MISSING_X_CLIENT_ID)
+                        : MandatoryClientIdFilter.MISSING_X_CLIENT_ID;
 
                 this.failOnLimits = failOnLimits;
                 this.seriesLimit = seriesLimit;
@@ -226,6 +256,8 @@ public class LocalMetricManager implements MetricManager {
 
                 this.dataInMemoryReporter = dataInMemoryReporter;
                 this.parentSpan = parentSpan;
+
+                this.reporter = reporter;
 
                 final Features features = request.features();
                 this.bucketStrategy = options
@@ -243,16 +275,7 @@ public class LocalMetricManager implements MetricManager {
 
                 if (result.getLimited()) {
                     if (failOnLimits) {
-                        final RequestError error = new QueryError(
-                            "The number of series requested is more than the allowed limit of " +
-                                seriesLimit);
-
-                        fetchSpan.addAnnotation(error.toString());
-                        fetchSpan.putAttribute("quotaViolation", booleanAttributeValue(true));
-                        fetchSpan.end();
-
-                        return async.resolved(FullQuery.limitsError(namedWatch.end(), error,
-                            ResultLimits.of(ResultLimit.SERIES)));
+                        return buildFullQueryError(fetchSpan);
                     }
 
                     limits = ResultLimits.of(ResultLimit.SERIES);
@@ -269,17 +292,52 @@ public class LocalMetricManager implements MetricManager {
                 try {
                     session = aggregation.session(range, quotaWatcher, bucketStrategy);
                 } catch (QuotaViolationException e) {
-                    String error = format(
-                        "aggregation needs to retain more data then what is allowed: %d",
-                        aggregationLimit.asLong().get());
-                    fetchSpan.addAnnotation(error);
-                    fetchSpan.putAttribute("quotaViolation", booleanAttributeValue(true));
-                    fetchSpan.end();
-                    return async.resolved(FullQuery.limitsError(namedWatch.end(),
-                        new QueryError(error),
-                        ResultLimits.of(ResultLimit.AGGREGATION)));
+                    return createQuotaViolationQueryFuture(fetchSpan);
                 }
 
+                var collector = createResultCollector(session, limits);
+
+                final List<Callable<AsyncFuture<Result>>>
+                        fetches = buildMetricsBackendFetches(result, fetchSpan, collector);
+
+                return async
+                    .eventuallyCollect(fetches, collector, fetchParallelism)
+                    .onDone(new EndSpanFutureReporter(fetchSpan))
+                    .onDone(new FutureDone<FullQuery>() {
+                        @Override
+                        public void failed(Throwable cause) throws Exception {
+                            if (matchesTimeoutMessage(cause.getMessage())) {
+                                reporter.reportClientIdFailure(clientId, FailureType.TIMEOUT);
+                            }
+                            queryLogger.logBigtableQueryTimeout(request.context(), request);
+                        }
+
+                        @Override
+                        public void resolved(FullQuery result) throws Exception {
+                            /* no-op */
+                        }
+
+                        @Override
+                        public void cancelled() throws Exception {
+                            /* no-op */
+                        }
+                    });
+            }
+
+            private AsyncFuture<FullQuery> createQuotaViolationQueryFuture(Span fetchSpan) {
+                String error = format(
+                    "aggregation needs to retain more data then what is allowed: %d",
+                    aggregationLimit.asLong().get());
+                fetchSpan.addAnnotation(error);
+                fetchSpan.putAttribute("quotaViolation", booleanAttributeValue(true));
+                fetchSpan.end();
+                return async.resolved(FullQuery.limitsError(namedWatch.end(),
+                    new QueryError(error),
+                    ResultLimits.of(ResultLimit.AGGREGATION)));
+            }
+
+            private ResultCollector createResultCollector(
+                    AggregationSession session, ResultLimits limits) {
                 /* setup collector */
                 final ResultCollector collector;
 
@@ -312,26 +370,48 @@ public class LocalMetricManager implements MetricManager {
                     };
                 }
 
-                final List<Callable<AsyncFuture<FetchData.Result>>> fetches = new ArrayList<>();
-                accept(metricBackend -> {
+                return collector;
+            }
+
+            private AsyncFuture<FullQuery> buildFullQueryError(Span fetchSpan) {
+                final RequestError error = new QueryError(
+                    "The number of series requested is more than the allowed limit of " +
+                        seriesLimit);
+
+                fetchSpan.addAnnotation(error.toString());
+                fetchSpan.putAttribute("quotaViolation", booleanAttributeValue(true));
+                fetchSpan.end();
+
+                return async.resolved(FullQuery.limitsError(namedWatch.end(), error,
+                    ResultLimits.of(ResultLimit.SERIES)));
+            }
+
+            @NotNull
+            private List<Callable<AsyncFuture<Result>>> buildMetricsBackendFetches(
+                                                                     FindSeries result,
+                                                                     Span fetchSpan,
+                                                                     ResultCollector collector) {
+                final List<Callable<AsyncFuture<Result>>> fetches = new ArrayList<>();
+
+                // Requires the squashing exporter otherwise too many spans are produced.
+                backends.stream().forEach(((Consumer<MetricBackend>) metricBackend -> {
                     for (final Series series : result.getSeries()) {
                         // Requires the squashing exporter otherwise too many spans are produced.
                         final Span fetchSeries =
-                            tracer.spanBuilderWithExplicitParent(
-                                "localMetricsManager.fetchSeries", fetchSpan).startSpan();
+                                tracer.spanBuilderWithExplicitParent(
+                                        "localMetricsManager.fetchSeries", fetchSpan).startSpan();
 
                         fetchSeries.addAnnotation(series.toString());
                         fetches.add(() -> metricBackend.fetch(
                             new FetchData.Request(source, series, range, options),
-                            quotaWatcher,
-                            mcr -> collector.acceptMetricsCollection(series, mcr),
-                            fetchSeries
+                                quotaWatcher,
+                                mcr -> collector.acceptMetricsCollection(series, mcr),
+                                fetchSeries
                         ).onDone(new EndSpanFutureReporter(fetchSeries)));
                     }
-                });
-                return async
-                    .eventuallyCollect(fetches, collector, fetchParallelism)
-                    .onDone(new EndSpanFutureReporter(fetchSpan));
+                })::accept);
+
+                return fetches;
             }
         }
 
@@ -393,13 +473,14 @@ public class LocalMetricManager implements MetricManager {
 
                 // Transform that takes the result from ES metadata lookup to fetch from backend
                 final LazyTransform<FindSeries, FullQuery> transform =
-                    new Transform(request,
-                        failOnLimits,
-                        seriesLimit,
-                        groupLimit,
-                        quotaWatcher,
-                        dataInMemoryReporter,
-                        findSeriesSpan);
+                        new Transform(request,
+                                failOnLimits,
+                                seriesLimit,
+                                groupLimit,
+                                quotaWatcher,
+                                dataInMemoryReporter,
+                                findSeriesSpan,
+                                reporter);
 
                 // Add watcher to set to compute stats across all queries
                 quotaWatchers.put(quotaWatcher, quotaWatcher);
@@ -562,15 +643,18 @@ public class LocalMetricManager implements MetricManager {
             return AsyncObservable.chain(map(b -> b.streamRow(key)));
         }
 
-        private void accept(final Consumer<MetricBackend> op) {
-            backends.stream().forEach(op::accept);
-        }
-
         private <T> List<T> map(final Function<MetricBackend, T> op) {
             return ImmutableList.copyOf(backends.stream().map(op).iterator());
         }
     }
 
+    /**
+     * From https://docs.oracle.com/javase/tutorial/java/javaOO/nested.html:
+     * Note: A static nested class interacts with the instance members of its outer class (and other
+     * classes) just like any other top-level class. In effect, a static nested class is
+     * behaviorally a top-level class that has been nested in another top-level class for packaging
+     * convenience.
+     */
     private abstract static class ResultCollector
         implements StreamCollector<FetchData.Result, FullQuery> {
         private static final String ROWS_ACCESSED = "rowsAccessed";
@@ -627,8 +711,8 @@ public class LocalMetricManager implements MetricManager {
             });
         }
 
-        private Map<String, String> buildAggregationKey(
-            final Series series, final MetricReadResult readResult
+        private static Map<String, String> buildAggregationKey(
+                final Series series, final MetricReadResult readResult
         ) {
             if (readResult.getResource().isEmpty()) {
                 return series.getTags();
@@ -722,10 +806,10 @@ public class LocalMetricManager implements MetricManager {
                 new ResultLimits(limitsBuilder.build()), dataDensity);
         }
 
-        private Optional<String> checkIssues(final int failed, final int cancelled) {
+        private static Optional<String> checkIssues(final int failed, final int cancelled) {
             if (failed > 0 || cancelled > 0) {
-                return Optional.of(
-                    "Some fetches failed (" + failed + ") or were cancelled (" + cancelled + ")");
+                return Optional.of(SOME_FETCHES_FAILED_MESSAGE + failed + ") or were cancelled ("
+                        + cancelled + ")");
             }
 
             return Optional.empty();

--- a/heroic-core/src/main/java/com/spotify/heroic/querylogging/Slf4jQueryLogger.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/querylogging/Slf4jQueryLogger.java
@@ -145,17 +145,11 @@ public class Slf4jQueryLogger implements QueryLogger {
     }
 
     /**
-     * PSK: I have serious reservations about this approach. It _appears_ to try to
-     * spin up a new thread per log message, which in theory could prevent the calling thread
-     * from blocking and speed processing up overall. However it would create and destroy
-     * a *lot* of Thread objects and hardware/OS-level threads and potentially slow processing
-     * down overall.
-     *
-     * However these thoughts are moot - notice that no Thread object is created and no
-     * `start()` method is called, which means that all callers of performAndCatch write the log
-     * message _in the calling thread_, thus defeating the whole point of performAndCatch it would
-     * seem - to me at least.
-     *
+     * Notice that no Thread object is created and no `start()` method is called, which means
+     * that all callers of performAndCatch write to the log files in the same thread. Hence the
+     * sole purpose of this idiom is to avoid writing the try...catch statements several times.
+     * Personally I find that this benefit does not outweigh the confusion it can (and has!) cause
+     * (PSK).
      * @param toRun Runnable to run in the calling thread
      */
     private static void performAndCatch(Runnable toRun) {

--- a/heroic-core/src/main/java/com/spotify/heroic/querylogging/noop/NoopQueryLogger.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/querylogging/noop/NoopQueryLogger.java
@@ -23,6 +23,7 @@ package com.spotify.heroic.querylogging.noop;
 
 import com.spotify.heroic.Query;
 import com.spotify.heroic.metric.FullQuery;
+import com.spotify.heroic.metric.FullQuery.Request;
 import com.spotify.heroic.metric.QueryMetrics;
 import com.spotify.heroic.metric.QueryMetricsResponse;
 import com.spotify.heroic.querylogging.HttpContext;
@@ -67,6 +68,16 @@ public class NoopQueryLogger implements QueryLogger {
     public void logIncomingRequestAtNode(
         final QueryContext context, final FullQuery.Request request
     ) {
+    }
+
+    @Override
+    public void logBigtableQueryTimeout(QueryContext context, Request request) {
+
+    }
+
+    @Override
+    public void logBigtableQuerySuccess(QueryContext context, Request request) {
+
     }
 
     @Override

--- a/heroic-core/src/main/java/com/spotify/heroic/querylogging/noop/NoopQueryLogger.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/querylogging/noop/NoopQueryLogger.java
@@ -76,11 +76,6 @@ public class NoopQueryLogger implements QueryLogger {
     }
 
     @Override
-    public void logBigtableQuerySuccess(QueryContext context, Request request) {
-
-    }
-
-    @Override
     public void logOutgoingResponseAtNode(final QueryContext context, final FullQuery response) {
     }
 

--- a/heroic-core/src/main/java/com/spotify/heroic/servlet/MandatoryClientIdFilter.java
+++ b/heroic-core/src/main/java/com/spotify/heroic/servlet/MandatoryClientIdFilter.java
@@ -43,6 +43,8 @@ import javax.ws.rs.core.Response.Status;
 public class MandatoryClientIdFilter extends SimpleFilter {
 
     public static final String X_CLIENT_ID_HEADER_NAME = "X-Client-Id";
+    public static final String MISSING_X_CLIENT_ID = "missing-client-id";
+
     public static final String ERROR_MESSAGE_TEXT =
             "This anonymous request has been rejected. Please add a 'x-client-id' " +
                     "HTTP header to your request.";

--- a/heroic-test/src/main/java/com/spotify/heroic/test/AbstractMetadataBackendIT.java
+++ b/heroic-test/src/main/java/com/spotify/heroic/test/AbstractMetadataBackendIT.java
@@ -378,7 +378,7 @@ public abstract class AbstractMetadataBackendIT {
     private void retrySome(final ThrowingRunnable action) throws Exception {
         AssertionError error = null;
 
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 50; i++) {
             try {
                 action.run();
             } catch (final AssertionError e) {

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
@@ -244,11 +244,6 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
         return "SemanticMetricBackendReporter()";
     }
 
-    private Counter getClientCounter(String what, String clientId) {
-        return registry.counter(
-            base.tagged("what", what, "x-client-id", clientId,  "unit", Units.QUERY));
-    }
-
     private Counter getClientCounter(String what, String clientId, FailureType failureType) {
         return registry.counter(
                 base.tagged("what", what, "x-client-id", clientId, "failure-type",

--- a/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
+++ b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java
@@ -84,8 +84,7 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
     private final Histogram queryRowDensity;
     // Counter of dropped writes due to row key size
     private final Counter writesDroppedBySize;
-    // Gauge
-    // of all read data points currently in memory across all queries
+    // Gauge of all read data points currently in memory across all queries
     private final Gauge<Long> globalDataPointsGauge;
     final AtomicLong globalReadDataPoints = new AtomicLong();
     // Gauge of all retained data points currently in memory across all queries
@@ -143,11 +142,6 @@ public class SemanticMetricBackendReporter implements MetricBackendReporter {
         globalRetainedDataPointsGauge = registry.register(
             base.tagged("what", "retained-data-points"),
             (Gauge<Long>) () -> (long) globalRetainedDataPoints.get());
-    }
-
-    @Override
-    public void reportClientIdSuccessCount(String clientId) {
-        getClientCounter("query-metrics-client-id-count-no-timeout", clientId).inc();
     }
 
     @Override


### PR DESCRIPTION
#### We need to know how many requests are hitting Bigtable timeouts per x-client-id

- I am a prism engineer
- Who wants to know the impact of his/her changes on our user base
- So that I can put out any fires efficiently, inform the user base if necessary, and protect heroic

#### Proposed Solution

- decorate the exception-handling at the API request level: add a check for the Bigtable timeout exception string
- if found, increment the according counter for the request's x-client-id
- if found, emit a log message that details the x-client-id (and the other usual exception info)

#### Design & Implementation Notes

nothing unusual. Just added : 
1. [detection logic](https://github.com/spotify/heroic/blob/8f1b4492f56110693e99ddc39d0cb64dde3ed7d9/heroic-core/src/main/java/com/spotify/heroic/metric/LocalMetricManager.java#L96), 
2. [a new metric e.g. `query-metrics-client-id-count-playerapp-timeout`](https://github.com/spotify/heroic/blob/33bf38ffa1a7778cfb2af279348c5253a78a671b/statistics/semantic/src/main/java/com/spotify/heroic/statistics/semantic/SemanticMetricBackendReporter.java#L155)
3. [logging e.g. `"bigtable-query-timeout...`](https://github.com/spotify/heroic/blob/8f1b4492f56110693e99ddc39d0cb64dde3ed7d9/heroic-core/src/main/java/com/spotify/heroic/querylogging/Slf4jQueryLogger.java#L89)