### PR TITLE
adds x-client-id header to example curl in docco

### DIFF
--- a/docs/_layouts/api-endpoint.html
+++ b/docs/_layouts/api-endpoint.html
@@ -48,7 +48,7 @@ layout: sidebar
         {%
         endunless %}
           {%- endcapture %}
-          $ curl -X{{ page.method }} {{ headers -}}
+          $ curl {{ page.x-client-id-header }} -X{{ page.method }} {{ headers -}}
           http://localhost:8080{{ page.endpoint }}
           {%- unless page.empty %} \
           -d '{{ request | normalize_whitespace }}'

--- a/docs/content/_endpoints/post-query-batch.md
+++ b/docs/content/_endpoints/post-query-batch.md
@@ -1,6 +1,7 @@
 ---
 method: POST
 endpoint: /query/batch
+x-client-id-header: "-H 'x-client-id: my-app'"
 help: Perform a batch query
 description: Run multiple metrics query in a batch.
 fields:
@@ -14,6 +15,5 @@ response_fields:
   purpose: Responses to each query run.
 ---
 This accepts a JSON document where all keys are expected to map up to a Query.
-<p></p>
-<em>Note that the <code>x-client-id: my_app_name</code> 
-header must be supplied since anonymous requests are not permitted.</em>
+
+*Note that the `x-client-id: my_app_name` header must be supplied since anonymous requests are not permitted.*

--- a/docs/content/_endpoints/post-query-metrics.md
+++ b/docs/content/_endpoints/post-query-metrics.md
@@ -1,6 +1,7 @@
 ---
 method: POST
 endpoint: /query/metrics
+x-client-id-header: "-H 'x-client-id: my-app'"
 help: Query for metrics
 description: Query and aggregate metrics.
 fields:
@@ -33,5 +34,4 @@ response_fields:
   type_name: 'Statistics'
   purpose: 'Statistics about the current query. This field should be inspected for errors which will have caused the result to be inconsistent.'
 ---
-<em>Note that the <code>x-client-id: my_app_name</code> 
-header must be supplied since anonymous requests are not permitted.</em>
+*Note that the `x-client-id: my_app_name` header must be supplied since anonymous requests are not permitted.*


### PR DESCRIPTION
addresses [add x-client-id to markdown documentation examples for /query/...](https://github.com/spotify/heroic/issues/754)